### PR TITLE
Scaffold GISMO core abstractions with CLI demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+# Placeholder for environment variables

--- a/Handoff.md
+++ b/Handoff.md
@@ -1,0 +1,14 @@
+# Handoff
+
+## Status
+- Implemented GISMO core scaffolding (models, state store, permissions, tools, agent, orchestrator).
+- Added CLI demo and smoke test.
+- Added minimal packaging config and environment placeholder.
+
+## Next Steps
+- Expand tool catalog and add richer permission policies.
+- Add query/reporting helpers for audit trails.
+- Harden error handling and add more unit coverage per module.
+
+## Tests
+- Not run (not requested).

--- a/README.md
+++ b/README.md
@@ -124,3 +124,26 @@ Expect breaking changes until core abstractions stabilize.
 
 Most AI systems **talk**.
 GISMO is built to **operate**.
+
+---
+
+## Quickstart
+
+**Python:** 3.11+
+
+Run the demo workflow:
+
+```bash
+python -m gismo.cli.main demo
+```
+
+Expected behavior:
+* Creates a run and two tasks (echo, write_note)
+* Echo succeeds immediately
+* write_note fails on first attempt due to permissions, then succeeds after being allowed
+* Outputs a summary of tasks and tool calls
+
+## Decisions (v0 scope)
+
+* Core state, task lifecycle, agent execution, and permission gating are implemented with standard library tools.
+* Persistence uses SQLite via the `sqlite3` module for auditability and portability.

--- a/gismo/__init__.py
+++ b/gismo/__init__.py
@@ -1,0 +1,1 @@
+"""GISMO package."""

--- a/gismo/cli/__init__.py
+++ b/gismo/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI package."""

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -1,0 +1,92 @@
+"""CLI entrypoint for GISMO."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from gismo.core.agent import SimpleAgent
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy
+from gismo.core.state import StateStore
+from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
+
+
+def run_demo(db_path: str) -> None:
+    state_store = StateStore(db_path)
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    registry.register(WriteNoteTool(state_store))
+
+    policy = PermissionPolicy(allowed_tools={"echo"})
+    agent = SimpleAgent(registry=registry)
+    orchestrator = Orchestrator(
+        state_store=state_store,
+        registry=registry,
+        policy=policy,
+        agent=agent,
+    )
+
+    run = state_store.create_run(label="demo", metadata={"purpose": "quickstart"})
+
+    echo_task = state_store.create_task(
+        run_id=run.id,
+        title="Echo input",
+        description="Echo the provided payload",
+        input_json={"tool": "echo", "payload": {"message": "hello"}},
+    )
+    orchestrator.run_tool(run.id, echo_task, "echo", {"message": "hello"})
+
+    note_task = state_store.create_task(
+        run_id=run.id,
+        title="Write note",
+        description="Attempt to write a note",
+        input_json={"tool": "write_note", "payload": {"note": "Hello, GISMO."}},
+    )
+    orchestrator.run_tool(run.id, note_task, "write_note", {"note": "Hello, GISMO."})
+
+    policy.allow("write_note")
+    orchestrator.run_tool(run.id, note_task, "write_note", {"note": "Hello, GISMO."})
+
+    print("=== GISMO Demo Summary ===")
+    print(f"Run: {run.id} ({run.label})")
+    print("Tasks:")
+    for task in state_store.list_tasks(run.id):
+        print(f"- {task.id} {task.title} [{task.status}]")
+        if task.error:
+            print(f"  error: {task.error}")
+        if task.output_json:
+            print(f"  output: {task.output_json}")
+
+    print("Tool Calls:")
+    for call in state_store.list_tool_calls(run.id):
+        print(
+            f"- {call.id} tool={call.tool_name} status={call.status} "
+            f"started={call.started_at.isoformat()}"
+        )
+        if call.error:
+            print(f"  error: {call.error}")
+        if call.output_json:
+            print(f"  output: {call.output_json}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="GISMO CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    demo_parser = subparsers.add_parser("demo", help="Run the demo workflow")
+    demo_parser.add_argument(
+        "--db-path",
+        default=str(Path(".gismo") / "state.db"),
+        help="Path to SQLite state database",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "demo":
+        run_demo(args.db_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/gismo/core/__init__.py
+++ b/gismo/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core abstractions for GISMO."""

--- a/gismo/core/agent.py
+++ b/gismo/core/agent.py
@@ -1,0 +1,22 @@
+"""Agent abstractions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from gismo.core.models import Task
+from gismo.core.tools import ToolRegistry
+
+
+@dataclass
+class Agent:
+    registry: ToolRegistry
+
+    def execute(self, task: Task, tool_name: str, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class SimpleAgent(Agent):
+    def execute(self, task: Task, tool_name: str, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        tool = self.registry.get(tool_name)
+        return tool.run(tool_input)

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -1,0 +1,87 @@
+"""Data models for GISMO."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class TaskStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+class ToolCallStatus(str, Enum):
+    STARTED = "STARTED"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
+@dataclass
+class Run:
+    id: str = field(default_factory=lambda: str(uuid4()))
+    created_at: datetime = field(default_factory=_utc_now)
+    label: str = ""
+    metadata_json: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Task:
+    run_id: str
+    title: str
+    description: str
+    input_json: Dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid4()))
+    status: TaskStatus = TaskStatus.PENDING
+    created_at: datetime = field(default_factory=_utc_now)
+    updated_at: datetime = field(default_factory=_utc_now)
+    output_json: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+
+    def mark_running(self) -> None:
+        self.status = TaskStatus.RUNNING
+        self.updated_at = _utc_now()
+
+    def mark_succeeded(self, output: Dict[str, Any]) -> None:
+        self.status = TaskStatus.SUCCEEDED
+        self.output_json = output
+        self.error = None
+        self.updated_at = _utc_now()
+
+    def mark_failed(self, error: str) -> None:
+        self.status = TaskStatus.FAILED
+        self.error = error
+        self.updated_at = _utc_now()
+
+
+@dataclass
+class ToolCall:
+    run_id: str
+    task_id: str
+    tool_name: str
+    input_json: Dict[str, Any]
+    id: str = field(default_factory=lambda: str(uuid4()))
+    started_at: datetime = field(default_factory=_utc_now)
+    finished_at: Optional[datetime] = None
+    output_json: Optional[Dict[str, Any]] = None
+    status: ToolCallStatus = ToolCallStatus.STARTED
+    error: Optional[str] = None
+
+    def mark_succeeded(self, output: Dict[str, Any]) -> None:
+        self.status = ToolCallStatus.SUCCEEDED
+        self.output_json = output
+        self.error = None
+        self.finished_at = _utc_now()
+
+    def mark_failed(self, error: str) -> None:
+        self.status = ToolCallStatus.FAILED
+        self.error = error
+        self.finished_at = _utc_now()

--- a/gismo/core/orchestrator.py
+++ b/gismo/core/orchestrator.py
@@ -1,0 +1,56 @@
+"""Orchestrator tying state, tools, and agents together."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from gismo.core.agent import Agent
+from gismo.core.models import Task, ToolCall
+from gismo.core.permissions import PermissionPolicy
+from gismo.core.state import StateStore
+from gismo.core.tools import ToolRegistry
+
+
+@dataclass
+class Orchestrator:
+    state_store: StateStore
+    registry: ToolRegistry
+    policy: PermissionPolicy
+    agent: Agent
+
+    def run_tool(self, run_id: str, task: Task, tool_name: str, tool_input: Dict[str, Any]) -> Task:
+        task.mark_running()
+        self.state_store.update_task(task)
+
+        tool_call = ToolCall(
+            run_id=run_id,
+            task_id=task.id,
+            tool_name=tool_name,
+            input_json=tool_input,
+        )
+
+        try:
+            self.policy.check_tool_allowed(tool_name)
+        except PermissionError as exc:
+            tool_call.mark_failed(str(exc))
+            self.state_store.record_tool_call(tool_call)
+            task.mark_failed(str(exc))
+            self.state_store.update_task(task)
+            return task
+
+        self.state_store.record_tool_call(tool_call)
+
+        try:
+            output = self.agent.execute(task, tool_name, tool_input)
+        except Exception as exc:  # noqa: BLE001 - fail fast with explicit exception
+            tool_call.mark_failed(str(exc))
+            self.state_store.update_tool_call(tool_call)
+            task.mark_failed(str(exc))
+            self.state_store.update_task(task)
+            return task
+
+        tool_call.mark_succeeded(output)
+        self.state_store.update_tool_call(tool_call)
+        task.mark_succeeded(output)
+        self.state_store.update_task(task)
+        return task

--- a/gismo/core/permissions.py
+++ b/gismo/core/permissions.py
@@ -1,0 +1,20 @@
+"""Permission gating for tools."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Set
+
+
+@dataclass
+class PermissionPolicy:
+    allowed_tools: Set[str] = field(default_factory=set)
+
+    def allow(self, tool_name: str) -> None:
+        self.allowed_tools.add(tool_name)
+
+    def revoke(self, tool_name: str) -> None:
+        self.allowed_tools.discard(tool_name)
+
+    def check_tool_allowed(self, tool_name: str) -> None:
+        if tool_name not in self.allowed_tools:
+            raise PermissionError(f"Tool '{tool_name}' is not allowed")

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -1,0 +1,245 @@
+"""SQLite-backed persistent state store."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from gismo.core.models import Run, Task, TaskStatus, ToolCall, ToolCallStatus
+
+
+class StateStore:
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _init_db(self) -> None:
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        with self._connect() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    metadata_json TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    description TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    input_json TEXT NOT NULL,
+                    output_json TEXT,
+                    error TEXT,
+                    FOREIGN KEY (run_id) REFERENCES runs(id)
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tool_calls (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    task_id TEXT NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    finished_at TEXT,
+                    input_json TEXT NOT NULL,
+                    output_json TEXT,
+                    status TEXT NOT NULL,
+                    error TEXT,
+                    FOREIGN KEY (run_id) REFERENCES runs(id),
+                    FOREIGN KEY (task_id) REFERENCES tasks(id)
+                )
+                """
+            )
+            connection.commit()
+
+    def create_run(self, label: str, metadata: Optional[Dict[str, Any]] = None) -> Run:
+        run = Run(label=label, metadata_json=metadata or {})
+        with self._connect() as connection:
+            connection.execute(
+                "INSERT INTO runs (id, created_at, label, metadata_json) VALUES (?, ?, ?, ?)",
+                (
+                    run.id,
+                    run.created_at.isoformat(),
+                    run.label,
+                    json.dumps(run.metadata_json),
+                ),
+            )
+            connection.commit()
+        return run
+
+    def create_task(
+        self,
+        run_id: str,
+        title: str,
+        description: str,
+        input_json: Dict[str, Any],
+    ) -> Task:
+        task = Task(
+            run_id=run_id,
+            title=title,
+            description=description,
+            input_json=input_json,
+        )
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO tasks (
+                    id, run_id, title, description, status,
+                    created_at, updated_at, input_json, output_json, error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    task.id,
+                    task.run_id,
+                    task.title,
+                    task.description,
+                    task.status.value,
+                    task.created_at.isoformat(),
+                    task.updated_at.isoformat(),
+                    json.dumps(task.input_json),
+                    json.dumps(task.output_json) if task.output_json is not None else None,
+                    task.error,
+                ),
+            )
+            connection.commit()
+        return task
+
+    def update_task(self, task: Task) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE tasks
+                SET status = ?, updated_at = ?, output_json = ?, error = ?
+                WHERE id = ?
+                """,
+                (
+                    task.status.value,
+                    task.updated_at.isoformat(),
+                    json.dumps(task.output_json) if task.output_json is not None else None,
+                    task.error,
+                    task.id,
+                ),
+            )
+            connection.commit()
+
+    def record_tool_call(self, tool_call: ToolCall) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO tool_calls (
+                    id, run_id, task_id, tool_name, started_at, finished_at,
+                    input_json, output_json, status, error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    tool_call.id,
+                    tool_call.run_id,
+                    tool_call.task_id,
+                    tool_call.tool_name,
+                    tool_call.started_at.isoformat(),
+                    tool_call.finished_at.isoformat() if tool_call.finished_at else None,
+                    json.dumps(tool_call.input_json),
+                    json.dumps(tool_call.output_json) if tool_call.output_json is not None else None,
+                    tool_call.status.value,
+                    tool_call.error,
+                ),
+            )
+            connection.commit()
+
+    def update_tool_call(self, tool_call: ToolCall) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE tool_calls
+                SET finished_at = ?, output_json = ?, status = ?, error = ?
+                WHERE id = ?
+                """,
+                (
+                    tool_call.finished_at.isoformat() if tool_call.finished_at else None,
+                    json.dumps(tool_call.output_json) if tool_call.output_json is not None else None,
+                    tool_call.status.value,
+                    tool_call.error,
+                    tool_call.id,
+                ),
+            )
+            connection.commit()
+
+    def list_tasks(self, run_id: str) -> Iterable[Task]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM tasks WHERE run_id = ? ORDER BY created_at",
+                (run_id,),
+            ).fetchall()
+        return [self._row_to_task(row) for row in rows]
+
+    def list_tool_calls(self, run_id: str) -> Iterable[ToolCall]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT * FROM tool_calls WHERE run_id = ? ORDER BY started_at",
+                (run_id,),
+            ).fetchall()
+        return [self._row_to_tool_call(row) for row in rows]
+
+    def get_task(self, task_id: str) -> Optional[Task]:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM tasks WHERE id = ?",
+                (task_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_task(row)
+
+    def _row_to_task(self, row: sqlite3.Row) -> Task:
+        task = Task(
+            id=row["id"],
+            run_id=row["run_id"],
+            title=row["title"],
+            description=row["description"],
+            status=TaskStatus(row["status"]),
+            created_at=_parse_dt(row["created_at"]),
+            updated_at=_parse_dt(row["updated_at"]),
+            input_json=json.loads(row["input_json"]),
+            output_json=json.loads(row["output_json"]) if row["output_json"] else None,
+            error=row["error"],
+        )
+        return task
+
+    def _row_to_tool_call(self, row: sqlite3.Row) -> ToolCall:
+        tool_call = ToolCall(
+            id=row["id"],
+            run_id=row["run_id"],
+            task_id=row["task_id"],
+            tool_name=row["tool_name"],
+            started_at=_parse_dt(row["started_at"]),
+            finished_at=_parse_dt(row["finished_at"]) if row["finished_at"] else None,
+            input_json=json.loads(row["input_json"]),
+            output_json=json.loads(row["output_json"]) if row["output_json"] else None,
+            status=ToolCallStatus(row["status"]),
+            error=row["error"],
+        )
+        return tool_call
+
+
+def _parse_dt(value: str) -> datetime:
+    return datetime.fromisoformat(value)

--- a/gismo/core/tools.py
+++ b/gismo/core/tools.py
@@ -1,0 +1,61 @@
+"""Tool abstractions and registry."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from gismo.core.state import StateStore
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    schema: Optional[Dict[str, Any]] = None
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class ToolRegistry:
+    def __init__(self) -> None:
+        self._tools: Dict[str, Tool] = {}
+
+    def register(self, tool: Tool) -> None:
+        if tool.name in self._tools:
+            raise ValueError(f"Tool '{tool.name}' is already registered")
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool:
+        try:
+            return self._tools[name]
+        except KeyError as exc:
+            raise KeyError(f"Tool '{name}' is not registered") from exc
+
+
+class EchoTool(Tool):
+    def __init__(self) -> None:
+        super().__init__(
+            name="echo",
+            description="Echo back the provided input",
+            schema={"type": "object"},
+        )
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        return {"echo": tool_input}
+
+
+class WriteNoteTool(Tool):
+    def __init__(self, state_store: StateStore) -> None:
+        super().__init__(
+            name="write_note",
+            description="Write a note to the state store as a task output",
+            schema={"type": "object", "properties": {"note": {"type": "string"}}},
+        )
+        self._state_store = state_store
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        note = tool_input.get("note")
+        if not isinstance(note, str) or not note.strip():
+            raise ValueError("'note' must be a non-empty string")
+        return {"note": note}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gismo"
+version = "0.1.0"
+description = "GISMO persistent orchestration core"
+readme = "README.md"
+requires-python = ">=3.11"
+license = {text = "UNLICENSED"}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["gismo*"]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,63 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.agent import SimpleAgent
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy
+from gismo.core.state import StateStore
+from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
+
+
+class SmokeTest(unittest.TestCase):
+    def test_demo_workflow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            registry.register(EchoTool())
+            registry.register(WriteNoteTool(state_store))
+            policy = PermissionPolicy(allowed_tools={"echo"})
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            run = state_store.create_run(label="smoke", metadata={})
+
+            echo_task = state_store.create_task(
+                run_id=run.id,
+                title="Echo",
+                description="Echo payload",
+                input_json={"tool": "echo", "payload": {"message": "ping"}},
+            )
+            orchestrator.run_tool(run.id, echo_task, "echo", {"message": "ping"})
+
+            note_task = state_store.create_task(
+                run_id=run.id,
+                title="Write note",
+                description="Write a note",
+                input_json={"tool": "write_note", "payload": {"note": "hello"}},
+            )
+            orchestrator.run_tool(run.id, note_task, "write_note", {"note": "hello"})
+            policy.allow("write_note")
+            orchestrator.run_tool(run.id, note_task, "write_note", {"note": "hello"})
+
+            tasks = list(state_store.list_tasks(run.id))
+            self.assertEqual(len(tasks), 2)
+            task_statuses = {task.title: task.status for task in tasks}
+            self.assertEqual(task_statuses["Echo"].value, "SUCCEEDED")
+            self.assertEqual(task_statuses["Write note"].value, "SUCCEEDED")
+
+            tool_calls = list(state_store.list_tool_calls(run.id))
+            self.assertEqual(len(tool_calls), 3)
+            statuses = [call.status.value for call in tool_calls]
+            self.assertIn("FAILED", statuses)
+            self.assertIn("SUCCEEDED", statuses)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide the v0 scaffolding for a persistent orchestration core implementing state, task lifecycle, agent execution, and permission-gated tools.
- Ensure auditability and deny-by-default tool permissioning so every tool call is recorded with timestamps, inputs, outputs, and status.
- Offer a minimal CLI demo and an automated smoke test to validate the core proof-of-life workflow.

### Description

- Added dataclass models in `gismo/core/models.py` for `Run`, `Task`, and `ToolCall` with lifecycle helpers (`mark_running`, `mark_succeeded`, `mark_failed`).
- Implemented `StateStore` in `gismo/core/state.py` using SQLite with methods `create_run`, `create_task`, `update_task`, `record_tool_call`, `update_tool_call`, `list_tasks`, `list_tool_calls`, and `get_task` and JSON-serialized fields for portability.
- Added `PermissionPolicy` (`gismo/core/permissions.py`), tool abstractions and registry plus `EchoTool` and `WriteNoteTool` (`gismo/core/tools.py`), a `SimpleAgent` (`gismo/core/agent.py`), and an `Orchestrator` (`gismo/core/orchestrator.py`) that ties state, policy, tools, and agents together.
- Added CLI entrypoint `gismo/cli/main.py` (`python -m gismo.cli.main demo`), a smoke test `tests/test_smoke.py`, README Quickstart update, `.env.example`, `pyproject.toml`, and `Handoff.md`, and documented limitations (local SQLite file, simple in-memory policy, no concurrency handling yet).

### Testing

- Added a unittest smoke test `tests/test_smoke.py` that exercises the demo workflow end-to-end via `StateStore`, `Orchestrator`, and `SimpleAgent`.
- To run the smoke test locally execute `python -m unittest tests/test_smoke.py`.
- To run the demo CLI manually execute `python -m gismo.cli.main demo` which creates a run, executes `echo` (allowed) and `write_note` (denied then allowed) and prints a summary.
- No automated tests or CI were executed as part of this PR; the smoke test was added but not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c03c889d8833081ab89af0f8c59d8)