### PR TITLE
Add task graph scheduler with dependencies and demo-graph

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -5,6 +5,8 @@
 - Added CLI demo and smoke test.
 - Added minimal packaging config and environment placeholder.
 - Hardened orchestration with idempotency keys, retry tracking, failure taxonomy, and transactional state updates.
+- Added task dependency persistence and scheduler-driven task graph execution.
+- Extended CLI demo and smoke tests for dependency graphs and deadlock handling.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -13,3 +15,4 @@
 
 ## Tests
 - `python -m unittest -v`
+- `python -m unittest discover -s tests -p "test*.py" -v`

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Run the demo workflow:
 python -m gismo.cli.main demo
 ```
 
+Run the dependency graph demo:
+
+```bash
+python -m gismo.cli.main demo-graph
+```
+
 Expected behavior:
 * Creates a run and two tasks (echo, write_note)
 * Echo succeeds immediately
@@ -149,3 +155,4 @@ Expected behavior:
 * Core state, task lifecycle, agent execution, and permission gating are implemented with standard library tools.
 * Persistence uses SQLite via the `sqlite3` module for auditability and portability.
 * Tool calls are idempotent by key + normalized input hash, with retry semantics and a failure taxonomy stored in state.
+* Task dependency graphs are persisted on tasks and executed via a scheduler that respects dependency ordering.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -69,11 +69,69 @@ def run_demo(db_path: str) -> None:
             print(f"  output: {call.output_json}")
 
 
+def run_demo_graph(db_path: str) -> None:
+    state_store = StateStore(db_path)
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    registry.register(WriteNoteTool(state_store))
+
+    policy = PermissionPolicy(allowed_tools={"echo", "write_note"})
+    agent = SimpleAgent(registry=registry)
+    orchestrator = Orchestrator(
+        state_store=state_store,
+        registry=registry,
+        policy=policy,
+        agent=agent,
+    )
+
+    run = state_store.create_run(label="demo-graph", metadata={"purpose": "dag-demo"})
+
+    task_a = state_store.create_task(
+        run_id=run.id,
+        title="Echo A",
+        description="Echo A",
+        input_json={"tool": "echo", "payload": {"message": "A"}},
+    )
+    task_b = state_store.create_task(
+        run_id=run.id,
+        title="Note B",
+        description="Write note B",
+        input_json={"tool": "write_note", "payload": {"note": "B"}},
+        depends_on=[task_a.id],
+    )
+    task_c = state_store.create_task(
+        run_id=run.id,
+        title="Echo C",
+        description="Echo C",
+        input_json={"tool": "echo", "payload": {"message": "C"}},
+        depends_on=[task_b.id],
+    )
+
+    orchestrator.run_task_graph(run.id)
+
+    print("=== GISMO Demo Graph Summary ===")
+    print(f"Run: {run.id} ({run.label})")
+    print("Tasks:")
+    for task in state_store.list_tasks(run.id):
+        deps = ", ".join(task.depends_on) if task.depends_on else "none"
+        print(f"- {task.id} {task.title} [{task.status}] depends_on={deps}")
+        if task.error:
+            print(f"  error: {task.error}")
+        if task.output_json:
+            print(f"  output: {task.output_json}")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="GISMO CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
     demo_parser = subparsers.add_parser("demo", help="Run the demo workflow")
     demo_parser.add_argument(
+        "--db-path",
+        default=str(Path(".gismo") / "state.db"),
+        help="Path to SQLite state database",
+    )
+    demo_graph_parser = subparsers.add_parser("demo-graph", help="Run the task graph demo")
+    demo_graph_parser.add_argument(
         "--db-path",
         default=str(Path(".gismo") / "state.db"),
         help="Path to SQLite state database",
@@ -86,6 +144,8 @@ def main() -> None:
     args = parser.parse_args()
     if args.command == "demo":
         run_demo(args.db_path)
+    elif args.command == "demo-graph":
+        run_demo_graph(args.db_path)
 
 
 if __name__ == "__main__":

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -50,6 +50,7 @@ class Task:
     input_json: Dict[str, Any]
     id: str = field(default_factory=lambda: str(uuid4()))
     status: TaskStatus = TaskStatus.PENDING
+    depends_on: list[str] = field(default_factory=list)
     idempotency_key: str = ""
     input_hash: str = ""
     created_at: datetime = field(default_factory=_utc_now)
@@ -57,10 +58,12 @@ class Task:
     output_json: Optional[Dict[str, Any]] = None
     error: Optional[str] = None
     failure_type: FailureType = FailureType.NONE
+    status_reason: Optional[str] = None
 
     def mark_running(self) -> None:
         self.status = TaskStatus.RUNNING
         self.failure_type = FailureType.NONE
+        self.status_reason = None
         self.updated_at = _utc_now()
 
     def mark_succeeded(self, output: Dict[str, Any]) -> None:
@@ -68,12 +71,19 @@ class Task:
         self.output_json = output
         self.error = None
         self.failure_type = FailureType.NONE
+        self.status_reason = None
         self.updated_at = _utc_now()
 
-    def mark_failed(self, error: str, failure_type: FailureType = FailureType.SYSTEM_ERROR) -> None:
+    def mark_failed(
+        self,
+        error: str,
+        failure_type: FailureType = FailureType.SYSTEM_ERROR,
+        status_reason: Optional[str] = None,
+    ) -> None:
         self.status = TaskStatus.FAILED
         self.error = error
         self.failure_type = failure_type
+        self.status_reason = status_reason
         self.updated_at = _utc_now()
 
 

--- a/gismo/core/orchestrator.py
+++ b/gismo/core/orchestrator.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Tuple, Type
 
 from gismo.core.agent import Agent
-from gismo.core.models import FailureType, Task, ToolCall, ToolCallStatus
+from gismo.core.models import FailureType, Task, TaskStatus, ToolCall, ToolCallStatus
 from gismo.core.permissions import PermissionPolicy
 from gismo.core.state import StateStore
 from gismo.core.tools import ToolRegistry
@@ -115,6 +115,72 @@ class Orchestrator:
 
         return task
 
+    def run_task_graph(self, run_id: str) -> Dict[str, Task]:
+        tasks = {task.id: task for task in self.state_store.list_tasks(run_id)}
+        if not tasks:
+            return {}
+
+        while True:
+            runnable: list[Task] = []
+            pending = [task for task in tasks.values() if task.status == TaskStatus.PENDING]
+
+            for task in pending:
+                if not task.depends_on:
+                    runnable.append(task)
+                    continue
+
+                missing = [dep for dep in task.depends_on if dep not in tasks]
+                if missing:
+                    error = f"Dependency missing: {', '.join(missing)}"
+                    task.mark_failed(error, FailureType.SYSTEM_ERROR, status_reason=error)
+                    with self.state_store.transaction() as connection:
+                        self.state_store.update_task(task, connection=connection)
+                    continue
+
+                failed_deps = [
+                    dep_id
+                    for dep_id in task.depends_on
+                    if tasks[dep_id].status == TaskStatus.FAILED
+                ]
+                if failed_deps:
+                    error = f"Dependency failed: {failed_deps[0]}"
+                    task.mark_failed(error, FailureType.SYSTEM_ERROR, status_reason=error)
+                    with self.state_store.transaction() as connection:
+                        self.state_store.update_task(task, connection=connection)
+                    continue
+
+                if all(tasks[dep_id].status == TaskStatus.SUCCEEDED for dep_id in task.depends_on):
+                    runnable.append(task)
+
+            if runnable:
+                for task in runnable:
+                    tool_name, tool_input = _task_tool_spec(task)
+                    if tool_name is None:
+                        error = "Invalid task input: missing tool or payload"
+                        task.mark_failed(error, FailureType.INVALID_INPUT, status_reason=error)
+                        with self.state_store.transaction() as connection:
+                            self.state_store.update_task(task, connection=connection)
+                        continue
+                    updated = self.run_tool(run_id, task, tool_name, tool_input)
+                    tasks[task.id] = updated
+                continue
+
+            pending = [task for task in tasks.values() if task.status == TaskStatus.PENDING]
+            if not pending:
+                break
+
+            diagnostics = "; ".join(
+                f"{task.id} depends_on={task.depends_on}" for task in pending
+            )
+            error = f"Deadlock/cycle detected: {diagnostics}"
+            for task in pending:
+                task.mark_failed(error, FailureType.SYSTEM_ERROR, status_reason=error)
+                with self.state_store.transaction() as connection:
+                    self.state_store.update_task(task, connection=connection)
+            break
+
+        return tasks
+
 
 def _normalize_input(payload: Dict[str, Any]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
@@ -144,3 +210,13 @@ def _safe_error_message(exc: BaseException) -> str:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _task_tool_spec(task: Task) -> Tuple[Optional[str], Dict[str, Any]]:
+    if not isinstance(task.input_json, dict):
+        return None, {}
+    tool_name = task.input_json.get("tool")
+    payload = task.input_json.get("payload")
+    if not tool_name or not isinstance(payload, dict):
+        return None, {}
+    return tool_name, payload

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -43,6 +43,7 @@ class StateStore:
                     title TEXT NOT NULL,
                     description TEXT NOT NULL,
                     status TEXT NOT NULL,
+                    depends_on_json TEXT NOT NULL DEFAULT '[]',
                     idempotency_key TEXT NOT NULL DEFAULT '',
                     input_hash TEXT NOT NULL DEFAULT '',
                     created_at TEXT NOT NULL,
@@ -51,6 +52,7 @@ class StateStore:
                     output_json TEXT,
                     error TEXT,
                     failure_type TEXT,
+                    status_reason TEXT,
                     FOREIGN KEY (run_id) REFERENCES runs(id)
                 )
                 """
@@ -91,7 +93,14 @@ class StateStore:
             "input_hash",
             "TEXT NOT NULL DEFAULT ''",
         )
+        self._ensure_column(
+            connection,
+            "tasks",
+            "depends_on_json",
+            "TEXT NOT NULL DEFAULT '[]'",
+        )
         self._ensure_column(connection, "tasks", "failure_type", "TEXT")
+        self._ensure_column(connection, "tasks", "status_reason", "TEXT")
         self._ensure_column(
             connection,
             "tool_calls",
@@ -148,6 +157,7 @@ class StateStore:
         title: str,
         description: str,
         input_json: Dict[str, Any],
+        depends_on: Optional[list[str]] = None,
         idempotency_key: str = "",
         input_hash: str = "",
     ) -> Task:
@@ -156,6 +166,7 @@ class StateStore:
             title=title,
             description=description,
             input_json=input_json,
+            depends_on=list(depends_on or []),
             idempotency_key=idempotency_key,
             input_hash=input_hash,
         )
@@ -164,9 +175,10 @@ class StateStore:
                 """
                 INSERT INTO tasks (
                     id, run_id, title, description, status,
-                    idempotency_key, input_hash, created_at, updated_at,
-                    input_json, output_json, error, failure_type
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    depends_on_json, idempotency_key, input_hash,
+                    created_at, updated_at, input_json, output_json,
+                    error, failure_type, status_reason
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     task.id,
@@ -174,6 +186,7 @@ class StateStore:
                     task.title,
                     task.description,
                     task.status.value,
+                    json.dumps(task.depends_on),
                     task.idempotency_key,
                     task.input_hash,
                     task.created_at.isoformat(),
@@ -182,6 +195,7 @@ class StateStore:
                     json.dumps(task.output_json) if task.output_json is not None else None,
                     task.error,
                     task.failure_type.value if task.failure_type else None,
+                    task.status_reason,
                 ),
             )
             connection.commit()
@@ -197,7 +211,8 @@ class StateStore:
             """
             UPDATE tasks
             SET status = ?, updated_at = ?, output_json = ?, error = ?,
-                idempotency_key = ?, input_hash = ?, failure_type = ?
+                idempotency_key = ?, input_hash = ?, failure_type = ?,
+                depends_on_json = ?, status_reason = ?
             WHERE id = ?
             """,
             (
@@ -208,6 +223,8 @@ class StateStore:
                 task.idempotency_key,
                 task.input_hash,
                 task.failure_type.value if task.failure_type else None,
+                json.dumps(task.depends_on),
+                task.status_reason,
                 task.id,
             ),
         )
@@ -279,6 +296,17 @@ class StateStore:
             ).fetchall()
         return [self._row_to_task(row) for row in rows]
 
+    def get_tasks_by_ids(self, task_ids: list[str]) -> Iterable[Task]:
+        if not task_ids:
+            return []
+        placeholders = ",".join("?" for _ in task_ids)
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"SELECT * FROM tasks WHERE id IN ({placeholders})",
+                tuple(task_ids),
+            ).fetchall()
+        return [self._row_to_task(row) for row in rows]
+
     def list_tool_calls(self, run_id: str) -> Iterable[ToolCall]:
         with self._connect() as connection:
             rows = connection.execute(
@@ -333,6 +361,9 @@ class StateStore:
             title=row["title"],
             description=row["description"],
             status=TaskStatus(row["status"]),
+            depends_on=json.loads(row["depends_on_json"])
+            if row["depends_on_json"]
+            else [],
             idempotency_key=row["idempotency_key"],
             input_hash=row["input_hash"],
             created_at=_parse_dt(row["created_at"]),
@@ -343,6 +374,7 @@ class StateStore:
             failure_type=FailureType(row["failure_type"])
             if row["failure_type"]
             else FailureType.NONE,
+            status_reason=row["status_reason"],
         )
         return task
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,7 +3,7 @@ import unittest
 from pathlib import Path
 
 from gismo.core.agent import SimpleAgent
-from gismo.core.models import FailureType, ToolCallStatus
+from gismo.core.models import FailureType, TaskStatus, ToolCallStatus
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy
 from gismo.core.state import StateStore
@@ -30,6 +30,14 @@ class CountingTool(Tool):
     def run(self, tool_input: dict) -> dict:
         self.calls += 1
         return {"count": self.calls}
+
+
+class AlwaysFailTool(Tool):
+    def __init__(self) -> None:
+        super().__init__(name="always_fail", description="Always fails")
+
+    def run(self, tool_input: dict) -> dict:
+        raise ValueError("planned failure")
 
 
 class SmokeTest(unittest.TestCase):
@@ -201,6 +209,141 @@ class SmokeTest(unittest.TestCase):
             self.assertEqual(len(tool_calls), 1)
             self.assertEqual(tool_calls[0].status, ToolCallStatus.SKIPPED)
             self.assertEqual(tool_calls[0].failure_type, FailureType.NONE)
+
+    def test_task_graph_happy_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            registry.register(EchoTool())
+            registry.register(WriteNoteTool(state_store))
+            policy = PermissionPolicy(allowed_tools={"echo", "write_note"})
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            run = state_store.create_run(label="graph", metadata={})
+            task_a = state_store.create_task(
+                run_id=run.id,
+                title="A",
+                description="Echo A",
+                input_json={"tool": "echo", "payload": {"message": "A"}},
+            )
+            task_b = state_store.create_task(
+                run_id=run.id,
+                title="B",
+                description="Note B",
+                input_json={"tool": "write_note", "payload": {"note": "B"}},
+                depends_on=[task_a.id],
+            )
+            task_c = state_store.create_task(
+                run_id=run.id,
+                title="C",
+                description="Echo C",
+                input_json={"tool": "echo", "payload": {"message": "C"}},
+                depends_on=[task_b.id],
+            )
+
+            orchestrator.run_task_graph(run.id)
+
+            tasks = {task.id: task for task in state_store.list_tasks(run.id)}
+            self.assertEqual(tasks[task_a.id].status, TaskStatus.SUCCEEDED)
+            self.assertEqual(tasks[task_b.id].status, TaskStatus.SUCCEEDED)
+            self.assertEqual(tasks[task_c.id].status, TaskStatus.SUCCEEDED)
+
+            tool_calls = list(state_store.list_tool_calls(run.id))
+            self.assertEqual([call.task_id for call in tool_calls], [task_a.id, task_b.id, task_c.id])
+
+    def test_task_graph_dependency_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            registry.register(AlwaysFailTool())
+            policy = PermissionPolicy(allowed_tools={"always_fail"})
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            run = state_store.create_run(label="dep-fail", metadata={})
+            task_a = state_store.create_task(
+                run_id=run.id,
+                title="A",
+                description="Failing A",
+                input_json={"tool": "always_fail", "payload": {}},
+            )
+            task_b = state_store.create_task(
+                run_id=run.id,
+                title="B",
+                description="Blocked B",
+                input_json={"tool": "always_fail", "payload": {}},
+                depends_on=[task_a.id],
+            )
+
+            orchestrator.run_task_graph(run.id)
+
+            updated_a = state_store.get_task(task_a.id)
+            updated_b = state_store.get_task(task_b.id)
+            assert updated_a is not None
+            assert updated_b is not None
+            self.assertEqual(updated_a.status, TaskStatus.FAILED)
+            self.assertEqual(updated_a.failure_type, FailureType.INVALID_INPUT)
+            self.assertEqual(updated_b.status, TaskStatus.FAILED)
+            self.assertEqual(updated_b.failure_type, FailureType.SYSTEM_ERROR)
+            self.assertIn(task_a.id, updated_b.error or "")
+            tool_calls_b = list(state_store.list_tool_calls_for_task(task_b.id))
+            self.assertEqual(tool_calls_b, [])
+
+    def test_task_graph_deadlock_detection(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            registry.register(EchoTool())
+            policy = PermissionPolicy(allowed_tools={"echo"})
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            run = state_store.create_run(label="deadlock", metadata={})
+            task_a = state_store.create_task(
+                run_id=run.id,
+                title="A",
+                description="A",
+                input_json={"tool": "echo", "payload": {"message": "A"}},
+            )
+            task_b = state_store.create_task(
+                run_id=run.id,
+                title="B",
+                description="B",
+                input_json={"tool": "echo", "payload": {"message": "B"}},
+                depends_on=[task_a.id],
+            )
+            task_a.depends_on = [task_b.id]
+            state_store.update_task(task_a)
+
+            orchestrator.run_task_graph(run.id)
+
+            updated_a = state_store.get_task(task_a.id)
+            updated_b = state_store.get_task(task_b.id)
+            assert updated_a is not None
+            assert updated_b is not None
+            self.assertEqual(updated_a.status, TaskStatus.FAILED)
+            self.assertEqual(updated_b.status, TaskStatus.FAILED)
+            self.assertIn("Deadlock/cycle detected", updated_a.error or "")
+            self.assertIn("Deadlock/cycle detected", updated_b.error or "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Add first-class task dependency support so runs can express DAGs of tasks to execute in-order.
- Provide a scheduler/orchestrator that enforces dependency ordering, propagates dependency failures, and detects deadlocks.
- Preserve GISMO non-negotiables: deny-by-default permissions, full auditability of tool calls and task state, and minimal, deterministic behavior.

### Description

- Models: added `depends_on: list[str]` and `status_reason: Optional[str]` to `Task` in `gismo/core/models.py` and wired them into lifecycle methods like `mark_failed` and `mark_succeeded`.
- Persistence: added `depends_on_json` and `status_reason` columns and migration logic in `gismo/core/state.py`, persisted on create/update, implemented `get_tasks_by_ids` and ensured `_row_to_task` populates `depends_on`.
- Orchestrator: implemented `Orchestrator.run_task_graph(run_id)` in `gismo/core/orchestrator.py` to repeatedly find runnable tasks (PENDING with all deps SUCCEEDED), execute them via existing `run_tool`, mark tasks FAILED when dependencies fail or are missing, and mark remaining pending tasks FAILED with a `Deadlock/cycle detected` error when no progress is possible.
- CLI & tests: added `demo-graph` CLI command in `gismo/cli/main.py` which builds a 3-task A->B->C demo and runs `run_task_graph`, and extended `tests/test_smoke.py` with deterministic `unittest` cases for happy path ordering, dependency failure propagation, and deadlock detection.

### Testing

- Ran the unit test suite with `python -m unittest -v` which passed locally for the updated tests.
- Ran discovery `python -m unittest discover -s tests -p "test*.py" -v` and all new and existing smoke tests passed.
- The new smoke tests exercise the DAG scheduler for successful ordering, dependency-failure propagation, and cycle/deadlock detection.
- Note: platform/tooling commands unrelated to this Python change (e.g. `cargo`/`npm`) were not required for the Python tests and are not applicable to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0b381ed0833092a1133d3cfef148)