### PR TITLE
Add operator CLI `run` command with deterministic parsing and idempotency

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -8,14 +8,20 @@
 - Added task dependency persistence and scheduler-driven task graph execution.
 - Extended CLI demo and smoke tests for dependency graphs and deadlock handling.
 - Added repository hygiene files, developer tooling, and architecture/decision docs.
+- Added operator command parsing and CLI run flow with deterministic idempotency keys and summaries.
+- Expanded smoke tests to cover operator run commands, permissions, graph dependencies, and idempotency skips.
+- Updated README with operator command usage.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.
+- Consider richer operator command validation and error messaging.
 
 ## Tests
 - `python scripts/verify.py`
+- `python -m gismo.cli.main run "echo: hello"`
+- `python -m gismo.cli.main run "graph: echo A -> note B -> echo C"`
 - `python -m unittest -v`
 - `python -m unittest discover -s tests -p "test*.py" -v`
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ Run the dependency graph demo:
 python -m gismo.cli.main demo-graph
 ```
 
+Run operator commands:
+
+```bash
+python -m gismo.cli.main run "echo: hello"
+python -m gismo.cli.main run "note: remember this"
+python -m gismo.cli.main run "graph: echo A -> note B -> echo C"
+```
+
 Expected behavior:
 * Creates a run and two tasks (echo, write_note)
 * Echo succeeds immediately
@@ -159,6 +167,28 @@ make demo
 make demo-graph
 make test
 ```
+
+## Operator Commands
+
+GISMO supports deterministic operator-like commands that map to tasks and tools. The CLI only allows the tools needed for each command.
+
+* Echo (routes to `echo` tool)
+
+  ```bash
+  python -m gismo.cli.main run "echo: status check"
+  ```
+
+* Note (routes to `write_note` tool)
+
+  ```bash
+  python -m gismo.cli.main run "note: rotating credentials on Friday"
+  ```
+
+* Graph (one-line chain with dependencies)
+
+  ```bash
+  python -m gismo.cli.main run "graph: echo A -> note B -> echo C"
+  ```
 
 ## Decisions (v0 scope)
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from gismo.cli.operator import (
+    make_idempotency_key,
+    normalize_command,
+    parse_command,
+    required_tools,
+)
 from gismo.core.agent import SimpleAgent
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy
@@ -121,6 +127,70 @@ def run_demo_graph(db_path: str) -> None:
             print(f"  output: {task.output_json}")
 
 
+def run_operator(db_path: str, command_parts: list[str]) -> None:
+    command_text = " ".join(command_parts).strip()
+    if not command_text:
+        raise ValueError("Operator run requires a command string.")
+
+    state_store = StateStore(db_path)
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    registry.register(WriteNoteTool(state_store))
+
+    plan = parse_command(command_text)
+    normalized = normalize_command(command_text)
+    policy = PermissionPolicy(allowed_tools=required_tools(plan))
+    agent = SimpleAgent(registry=registry)
+    orchestrator = Orchestrator(
+        state_store=state_store,
+        registry=registry,
+        policy=policy,
+        agent=agent,
+    )
+
+    run = state_store.create_run(label="operator-run", metadata={"command": normalized})
+
+    created_tasks = []
+    previous_task_id = None
+    for index, step in enumerate(plan["steps"]):
+        tool_name = step["tool_name"]
+        tool_input = step["input_json"]
+        idempotency_key = make_idempotency_key(step, normalized, index)
+        depends_on = [previous_task_id] if plan["mode"] == "graph" and previous_task_id else None
+        task = state_store.create_task(
+            run_id=run.id,
+            title=step["title"],
+            description="Operator command step",
+            input_json={"tool": tool_name, "payload": tool_input},
+            depends_on=depends_on,
+            idempotency_key=idempotency_key,
+        )
+        created_tasks.append(task)
+        previous_task_id = task.id
+
+    if plan["mode"] == "single":
+        task = created_tasks[0]
+        orchestrator.run_tool(run.id, task, task.input_json["tool"], task.input_json["payload"])
+    else:
+        orchestrator.run_task_graph(run.id)
+
+    _print_operator_summary(state_store, run.id)
+
+
+def _print_operator_summary(state_store: StateStore, run_id: str) -> None:
+    print("=== GISMO Operator Summary ===")
+    print(f"Run: {run_id}")
+    print("Tasks:")
+    for task in state_store.list_tasks(run_id):
+        tool_calls = list(state_store.list_tool_calls_for_task(task.id))
+        skipped = sum(1 for call in tool_calls if call.status.value == "SKIPPED")
+        failure_type = task.failure_type.value if task.failure_type else "NONE"
+        print(
+            f"- {task.id} {task.title} [{task.status.value}] "
+            f"failure_type={failure_type} tool_calls={len(tool_calls)} skipped={skipped}"
+        )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="GISMO CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -136,6 +206,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=str(Path(".gismo") / "state.db"),
         help="Path to SQLite state database",
     )
+    run_parser = subparsers.add_parser("run", help="Run an operator command")
+    run_parser.add_argument(
+        "--db-path",
+        default=str(Path(".gismo") / "state.db"),
+        help="Path to SQLite state database",
+    )
+    run_parser.add_argument(
+        "operator_command",
+        nargs=argparse.REMAINDER,
+        help="Operator command string (echo:, note:, or graph:)",
+    )
     return parser
 
 
@@ -146,6 +227,8 @@ def main() -> None:
         run_demo(args.db_path)
     elif args.command == "demo-graph":
         run_demo_graph(args.db_path)
+    elif args.command == "run":
+        run_operator(args.db_path, args.operator_command)
 
 
 if __name__ == "__main__":

--- a/gismo/cli/operator.py
+++ b/gismo/cli/operator.py
@@ -1,0 +1,111 @@
+"""Operator command parsing for GISMO."""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Set
+
+
+@dataclass(frozen=True)
+class OperatorStep:
+    tool_name: str
+    input_json: Dict[str, Any]
+    title: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "input_json": self.input_json,
+            "title": self.title,
+        }
+
+
+def normalize_command(command: str) -> str:
+    return " ".join(command.strip().split())
+
+
+def parse_command(command: str) -> Dict[str, Any]:
+    if not isinstance(command, str) or not command.strip():
+        raise ValueError("Command must be a non-empty string.")
+
+    trimmed = command.strip()
+
+    single_match = re.match(r"(?i)^(echo|note)\s*:\s*(.+)$", trimmed)
+    if single_match:
+        verb = single_match.group(1).lower()
+        payload = single_match.group(2).strip()
+        if not payload:
+            raise ValueError(f"{verb} command requires text after ':'")
+        step = _build_step(verb, payload)
+        return {"mode": "single", "steps": [step.to_dict()]}
+
+    graph_match = re.match(r"(?i)^graph\s*:\s*(.+)$", trimmed)
+    if graph_match:
+        remainder = graph_match.group(1).strip()
+        if not remainder:
+            raise ValueError("graph command requires at least one step")
+        raw_steps = [part.strip() for part in remainder.split("->")]
+        if any(not part for part in raw_steps):
+            raise ValueError("graph command contains an empty step")
+        steps: List[OperatorStep] = []
+        for raw_step in raw_steps:
+            step_match = re.match(r"(?i)^(echo|note)\s+(.+)$", raw_step)
+            if not step_match:
+                raise ValueError(
+                    f"Invalid graph step '{raw_step}'. Expected 'echo <text>' or 'note <text>'."
+                )
+            verb = step_match.group(1).lower()
+            payload = step_match.group(2).strip()
+            if not payload:
+                raise ValueError(f"{verb} step requires text after the verb")
+            steps.append(_build_step(verb, payload))
+        return {"mode": "graph", "steps": [step.to_dict() for step in steps]}
+
+    raise ValueError("Unsupported command. Use echo:, note:, or graph:.")
+
+
+def required_tools(plan: Dict[str, Any]) -> Set[str]:
+    tools: Set[str] = set()
+    for step in plan.get("steps", []):
+        tool_name = step.get("tool_name")
+        if tool_name:
+            tools.add(tool_name)
+    return tools
+
+
+def make_idempotency_key(step: Dict[str, Any], normalized_command: str, index: int) -> str:
+    normalized_input = _normalize_payload(step.get("input_json", {}))
+    payload = json.dumps(
+        {
+            "command": normalized_command,
+            "tool": step.get("tool_name"),
+            "input": normalized_input,
+            "index": index,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _normalize_payload(payload: Dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _build_step(verb: str, payload: str) -> OperatorStep:
+    if verb == "echo":
+        return OperatorStep(
+            tool_name="echo",
+            input_json={"message": payload},
+            title=f"Echo: {payload}",
+        )
+    if verb == "note":
+        return OperatorStep(
+            tool_name="write_note",
+            input_json={"note": payload},
+            title=f"Note: {payload}",
+        )
+    raise ValueError(f"Unsupported verb '{verb}'")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -2,6 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from gismo.cli.operator import make_idempotency_key, normalize_command, parse_command, required_tools
 from gismo.core.agent import SimpleAgent
 from gismo.core.models import FailureType, TaskStatus, ToolCallStatus
 from gismo.core.orchestrator import Orchestrator
@@ -38,6 +39,41 @@ class AlwaysFailTool(Tool):
 
     def run(self, tool_input: dict) -> dict:
         raise ValueError("planned failure")
+
+
+def run_operator_plan(
+    state_store: StateStore,
+    orchestrator: Orchestrator,
+    plan: dict,
+    normalized_command: str,
+) -> tuple[str, list[str]]:
+    run = state_store.create_run(label="operator-test", metadata={"command": normalized_command})
+    created_task_ids = []
+    previous_task_id = None
+    for index, step in enumerate(plan["steps"]):
+        tool_name = step["tool_name"]
+        tool_input = step["input_json"]
+        idempotency_key = make_idempotency_key(step, normalized_command, index)
+        depends_on = [previous_task_id] if plan["mode"] == "graph" and previous_task_id else None
+        task = state_store.create_task(
+            run_id=run.id,
+            title=step["title"],
+            description="Operator test step",
+            input_json={"tool": tool_name, "payload": tool_input},
+            depends_on=depends_on,
+            idempotency_key=idempotency_key,
+        )
+        created_task_ids.append(task.id)
+        previous_task_id = task.id
+
+    if plan["mode"] == "single":
+        task = state_store.get_task(created_task_ids[0])
+        assert task is not None
+        orchestrator.run_tool(run.id, task, task.input_json["tool"], task.input_json["payload"])
+    else:
+        orchestrator.run_task_graph(run.id)
+
+    return run.id, created_task_ids
 
 
 class SmokeTest(unittest.TestCase):
@@ -344,6 +380,131 @@ class SmokeTest(unittest.TestCase):
             self.assertEqual(updated_b.status, TaskStatus.FAILED)
             self.assertIn("Deadlock/cycle detected", updated_a.error or "")
             self.assertIn("Deadlock/cycle detected", updated_b.error or "")
+
+    def test_operator_run_echo(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            registry.register(EchoTool())
+            policy = PermissionPolicy(allowed_tools=set())
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            command = "echo: hello operator"
+            plan = parse_command(command)
+            normalized = normalize_command(command)
+            policy.allowed_tools = required_tools(plan)
+            run_id, task_ids = run_operator_plan(state_store, orchestrator, plan, normalized)
+
+            tasks = {task.id: task for task in state_store.list_tasks(run_id)}
+            self.assertEqual(len(tasks), 1)
+            self.assertEqual(tasks[task_ids[0]].status, TaskStatus.SUCCEEDED)
+            tool_calls = list(state_store.list_tool_calls(run_id))
+            self.assertEqual(len(tool_calls), 1)
+            self.assertEqual(tool_calls[0].status, ToolCallStatus.SUCCEEDED)
+
+    def test_operator_run_note_permissions(self) -> None:
+        plan = parse_command("note: keep this")
+        tools = required_tools(plan)
+        self.assertEqual(tools, {"write_note"})
+        policy = PermissionPolicy(allowed_tools=tools)
+        policy.check_tool_allowed("write_note")
+        with self.assertRaises(PermissionError):
+            policy.check_tool_allowed("echo")
+
+    def test_operator_run_graph_creates_dependencies(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            registry.register(EchoTool())
+            registry.register(WriteNoteTool(state_store))
+            policy = PermissionPolicy(allowed_tools=set())
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            command = "graph: echo A -> note B -> echo C"
+            plan = parse_command(command)
+            normalized = normalize_command(command)
+            policy.allowed_tools = required_tools(plan)
+            run_id, task_ids = run_operator_plan(state_store, orchestrator, plan, normalized)
+
+            tasks = {task.id: task for task in state_store.list_tasks(run_id)}
+            self.assertEqual(len(tasks), 3)
+            self.assertEqual(tasks[task_ids[0]].depends_on, [])
+            self.assertEqual(tasks[task_ids[1]].depends_on, [task_ids[0]])
+            self.assertEqual(tasks[task_ids[2]].depends_on, [task_ids[1]])
+            self.assertEqual(tasks[task_ids[0]].status, TaskStatus.SUCCEEDED)
+            self.assertEqual(tasks[task_ids[1]].status, TaskStatus.SUCCEEDED)
+            self.assertEqual(tasks[task_ids[2]].status, TaskStatus.SUCCEEDED)
+
+    def test_operator_idempotency_repeat(self) -> None:
+        class CountingEchoTool(Tool):
+            def __init__(self) -> None:
+                super().__init__(name="echo", description="Counts echo invocations")
+                self.calls = 0
+
+            def run(self, tool_input: dict) -> dict:
+                self.calls += 1
+                return {"count": self.calls}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            registry = ToolRegistry()
+            counting = CountingEchoTool()
+            registry.register(counting)
+            policy = PermissionPolicy(allowed_tools=set())
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+
+            command = "echo: repeat"
+            plan = parse_command(command)
+            normalized = normalize_command(command)
+            policy.allowed_tools = required_tools(plan)
+
+            run = state_store.create_run(label="operator-idempotency", metadata={})
+            step = plan["steps"][0]
+            idempotency_key = make_idempotency_key(step, normalized, 0)
+            first_task = state_store.create_task(
+                run_id=run.id,
+                title=step["title"],
+                description="First operator run",
+                input_json={"tool": "echo", "payload": step["input_json"]},
+                idempotency_key=idempotency_key,
+            )
+            orchestrator.run_tool(run.id, first_task, "echo", step["input_json"])
+
+            second_task = state_store.create_task(
+                run_id=run.id,
+                title=step["title"],
+                description="Second operator run",
+                input_json={"tool": "echo", "payload": step["input_json"]},
+                idempotency_key=idempotency_key,
+            )
+            result = orchestrator.run_tool(run.id, second_task, "echo", step["input_json"])
+
+            self.assertEqual(counting.calls, 1)
+            self.assertEqual(result.status, TaskStatus.SUCCEEDED)
+            tool_calls = list(state_store.list_tool_calls_for_task(second_task.id))
+            self.assertEqual(len(tool_calls), 1)
+            self.assertEqual(tool_calls[0].status, ToolCallStatus.SKIPPED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide a deterministic operator CLI entrypoint that routes simple human command strings into Tasks and executes them through the existing Orchestrator/Agent/Tools while preserving audit, permissions, idempotency, and retries.
- Support a small, explicit operator grammar (`echo:`, `note:`, `graph:`) so operators can create single or dependent task graphs from one-line commands.
- Enforce least-privilege permission allowlists per command and deterministic idempotency so repeated operator invocations are safe and auditable.

### Description
- Added `gismo/cli/operator.py` implementing `parse_command`, `required_tools`, `make_idempotency_key`, and helpers to normalize commands and build operator steps for `echo` and `write_note` tools.
- Wired a new `run` subcommand in `gismo/cli/main.py` that builds a run, creates Tasks (with `idempotency_key`), sets a least-privilege `PermissionPolicy`, and executes via `Orchestrator.run_tool` or `Orchestrator.run_task_graph` as appropriate.
- Stored tool selection in tasks as `{"tool": "...", "payload": {...}}` to match existing orchestrator conventions and print a concise operator summary including run id, each task id/title/status/failure_type, and per-task tool call counts and SKIPPED counts.
- Updated tests (`tests/test_smoke.py`) to add operator-focused smoke tests and updated `README.md` and `Handoff.md` with usage and status notes.

### Testing
- Automated tests: ran `python scripts/verify.py` (which runs the test suite) and `python -m unittest -v`, and the test suite passed (all smoke/unit tests OK).
- Manual CLI verification commands that were exercised during development: `python -m gismo.cli.main run "echo: hello"` and `python -m gismo.cli.main run "graph: echo A -> note B -> echo C"`, which produced concise operator summaries.
- Repository-level non-Python CI checks were attempted but are not applicable: `cargo fmt`, `cargo clippy -D warnings`, `cargo test`, and `npm ci && npm run build` failed because this repository is Python-only (no Cargo.toml or package lockfile).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c0dbf94bc833093bdabaf00422243)