### PR TITLE
Add safe filesystem and shell tools with policy loading

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -10,16 +10,20 @@
 - Added repository hygiene files, developer tooling, and architecture/decision docs.
 - Added operator command parsing and CLI run flow with deterministic idempotency keys and summaries.
 - Expanded smoke tests to cover operator run commands, permissions, graph dependencies, and idempotency skips.
-- Updated README with operator command usage.
+- Added policy-driven filesystem and shell toolpack with strict base directory and allowlist enforcement.
+- Added policy loader for CLI workflows and documented policy usage in README.
+- Added toolpack tests covering base directory enforcement and shell allowlist outputs.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.
 - Consider richer operator command validation and error messaging.
+- Add policy-driven examples for operator tasks using the new toolpack.
 
 ## Tests
 - `python scripts/verify.py`
+- `python -m unittest -v`
 - Optional: `make test`
 - Optional: `make demo`
 - Optional: `make demo-graph`

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Run the demo workflow:
 python -m gismo.cli.main demo
 ```
 
+Run the demo workflow with a policy:
+
+```bash
+python -m gismo.cli.main demo --policy policy/dev.json
+```
+
 Run the dependency graph demo:
 
 ```bash
@@ -149,6 +155,12 @@ Run operator commands:
 python -m gismo.cli.main run "echo: hello"
 python -m gismo.cli.main run "note: remember this"
 python -m gismo.cli.main run "graph: echo A -> note B -> echo C"
+```
+
+Run operator commands with a policy:
+
+```bash
+python -m gismo.cli.main run --policy policy/dev.json "echo: hello"
 ```
 
 Expected behavior:
@@ -205,6 +217,28 @@ GISMO supports deterministic operator-like commands that map to tasks and tools.
   ```bash
   python -m gismo.cli.main run "graph: echo A -> note B -> echo C"
   ```
+
+## Toolpack Policy & Safety
+
+GISMO ships with a minimal local toolpack (filesystem + restricted shell) that is deny-by-default and policy-gated. Policies are JSON files that explicitly allow tools and define safety boundaries.
+
+Example policy (`policy/dev.json`):
+
+```json
+{
+  "allowed_tools": ["echo", "write_note", "read_file", "write_file", "list_dir", "run_shell"],
+  "fs": { "base_dir": "." },
+  "shell": {
+    "base_dir": ".",
+    "allowlist": [["git", "status"], ["python", "-m", "unittest", "-v"], ["make", "test"]]
+  }
+}
+```
+
+Safety notes:
+* Filesystem tools are restricted to the configured base directory (default is the repo root).
+* Shell commands must be exact allowlist matches and are executed without a shell, with a default timeout.
+* No network calls are added by the built-in toolpack.
 
 ## Decisions (v0 scope)
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -12,18 +12,19 @@ from gismo.cli.operator import (
 )
 from gismo.core.agent import SimpleAgent
 from gismo.core.orchestrator import Orchestrator
-from gismo.core.permissions import PermissionPolicy
+from gismo.core.permissions import PermissionPolicy, load_policy
 from gismo.core.state import StateStore
 from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
+from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFileTool, WriteFileTool
+from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
 
 
-def run_demo(db_path: str) -> None:
+def run_demo(db_path: str, policy_path: str | None) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
     state_store = StateStore(db_path)
-    registry = ToolRegistry()
-    registry.register(EchoTool())
-    registry.register(WriteNoteTool(state_store))
+    policy = load_policy(policy_path, repo_root=repo_root, default_allowed_tools={"echo"})
+    registry = _build_registry(state_store, policy)
 
-    policy = PermissionPolicy(allowed_tools={"echo"})
     agent = SimpleAgent(registry=registry)
     orchestrator = Orchestrator(
         state_store=state_store,
@@ -75,13 +76,16 @@ def run_demo(db_path: str) -> None:
             print(f"  output: {call.output_json}")
 
 
-def run_demo_graph(db_path: str) -> None:
+def run_demo_graph(db_path: str, policy_path: str | None) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
     state_store = StateStore(db_path)
-    registry = ToolRegistry()
-    registry.register(EchoTool())
-    registry.register(WriteNoteTool(state_store))
+    policy = load_policy(
+        policy_path,
+        repo_root=repo_root,
+        default_allowed_tools={"echo", "write_note"},
+    )
+    registry = _build_registry(state_store, policy)
 
-    policy = PermissionPolicy(allowed_tools={"echo", "write_note"})
     agent = SimpleAgent(registry=registry)
     orchestrator = Orchestrator(
         state_store=state_store,
@@ -127,19 +131,18 @@ def run_demo_graph(db_path: str) -> None:
             print(f"  output: {task.output_json}")
 
 
-def run_operator(db_path: str, command_parts: list[str]) -> None:
+def run_operator(db_path: str, command_parts: list[str], policy_path: str | None) -> None:
     command_text = " ".join(command_parts).strip()
     if not command_text:
         raise ValueError("Operator run requires a command string.")
 
+    repo_root = Path(__file__).resolve().parents[2]
     state_store = StateStore(db_path)
-    registry = ToolRegistry()
-    registry.register(EchoTool())
-    registry.register(WriteNoteTool(state_store))
-
     plan = parse_command(command_text)
     normalized = normalize_command(command_text)
-    policy = PermissionPolicy(allowed_tools=required_tools(plan))
+    default_tools = required_tools(plan) if policy_path is None else ()
+    policy = load_policy(policy_path, repo_root=repo_root, default_allowed_tools=default_tools)
+    registry = _build_registry(state_store, policy)
     agent = SimpleAgent(registry=registry)
     orchestrator = Orchestrator(
         state_store=state_store,
@@ -200,17 +203,32 @@ def build_parser() -> argparse.ArgumentParser:
         default=str(Path(".gismo") / "state.db"),
         help="Path to SQLite state database",
     )
+    demo_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
     demo_graph_parser = subparsers.add_parser("demo-graph", help="Run the task graph demo")
     demo_graph_parser.add_argument(
         "--db-path",
         default=str(Path(".gismo") / "state.db"),
         help="Path to SQLite state database",
     )
+    demo_graph_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
     run_parser = subparsers.add_parser("run", help="Run an operator command")
     run_parser.add_argument(
         "--db-path",
         default=str(Path(".gismo") / "state.db"),
         help="Path to SQLite state database",
+    )
+    run_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
     )
     run_parser.add_argument(
         "operator_command",
@@ -224,11 +242,28 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
     if args.command == "demo":
-        run_demo(args.db_path)
+        run_demo(args.db_path, args.policy)
     elif args.command == "demo-graph":
-        run_demo_graph(args.db_path)
+        run_demo_graph(args.db_path, args.policy)
     elif args.command == "run":
-        run_operator(args.db_path, args.operator_command)
+        run_operator(args.db_path, args.operator_command, args.policy)
+
+
+def _build_registry(state_store: StateStore, policy: PermissionPolicy) -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    registry.register(WriteNoteTool(state_store))
+    fs_config = FileSystemConfig(base_dir=policy.fs.base_dir)
+    registry.register(ReadFileTool(fs_config))
+    registry.register(WriteFileTool(fs_config))
+    registry.register(ListDirTool(fs_config))
+    shell_config = ShellConfig(
+        base_dir=policy.shell.base_dir,
+        allowlist=policy.shell.allowlist,
+        timeout_seconds=policy.shell.timeout_seconds,
+    )
+    registry.register(ShellTool(shell_config))
+    return registry
 
 
 if __name__ == "__main__":

--- a/gismo/core/permissions.py
+++ b/gismo/core/permissions.py
@@ -1,13 +1,29 @@
 """Permission gating for tools."""
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Iterable, Set
+
+
+@dataclass
+class FileSystemPolicy:
+    base_dir: Path
+
+
+@dataclass
+class ShellPolicy:
+    base_dir: Path
+    allowlist: list[list[str]] = field(default_factory=list)
+    timeout_seconds: float = 10.0
 
 
 @dataclass
 class PermissionPolicy:
     allowed_tools: Set[str] = field(default_factory=set)
+    fs: FileSystemPolicy = field(default_factory=lambda: FileSystemPolicy(Path(".")))
+    shell: ShellPolicy = field(default_factory=lambda: ShellPolicy(Path(".")))
 
     def allow(self, tool_name: str) -> None:
         self.allowed_tools.add(tool_name)
@@ -18,3 +34,77 @@ class PermissionPolicy:
     def check_tool_allowed(self, tool_name: str) -> None:
         if tool_name not in self.allowed_tools:
             raise PermissionError(f"Tool '{tool_name}' is not allowed")
+
+
+def load_policy(
+    policy_path: str | None,
+    *,
+    repo_root: Path,
+    default_allowed_tools: Iterable[str] = (),
+) -> PermissionPolicy:
+    repo_root = repo_root.resolve()
+    if policy_path is None:
+        return PermissionPolicy(
+            allowed_tools=set(default_allowed_tools),
+            fs=FileSystemPolicy(base_dir=repo_root),
+            shell=ShellPolicy(base_dir=repo_root),
+        )
+
+    data = json.loads(Path(policy_path).read_text(encoding="utf-8"))
+    allowed_tools = _ensure_string_list(data.get("allowed_tools", []), "allowed_tools")
+    fs_config = data.get("fs", {}) or {}
+    shell_config = data.get("shell", {}) or {}
+    fs_base_dir = _resolve_base_dir(repo_root, fs_config.get("base_dir", "."))
+    shell_base_dir = _resolve_base_dir(repo_root, shell_config.get("base_dir", "."))
+    allowlist = _ensure_command_allowlist(shell_config.get("allowlist", []))
+    timeout_seconds = _ensure_timeout(shell_config.get("timeout_seconds", 10))
+    return PermissionPolicy(
+        allowed_tools=set(allowed_tools),
+        fs=FileSystemPolicy(base_dir=fs_base_dir),
+        shell=ShellPolicy(
+            base_dir=shell_base_dir,
+            allowlist=allowlist,
+            timeout_seconds=timeout_seconds,
+        ),
+    )
+
+
+def _ensure_string_list(value: object, field_name: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{field_name} must be a list of strings")
+    return value
+
+
+def _ensure_command_allowlist(value: object) -> list[list[str]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError("shell.allowlist must be a list of command lists")
+    commands: list[list[str]] = []
+    for entry in value:
+        if not isinstance(entry, list) or not entry or not all(
+            isinstance(part, str) and part for part in entry
+        ):
+            raise ValueError("shell.allowlist entries must be non-empty string lists")
+        commands.append(entry)
+    return commands
+
+
+def _ensure_timeout(value: object) -> float:
+    if isinstance(value, int | float):
+        if value <= 0:
+            raise ValueError("shell.timeout_seconds must be positive")
+        return float(value)
+    raise ValueError("shell.timeout_seconds must be a number")
+
+
+def _resolve_base_dir(repo_root: Path, base_dir_value: object) -> Path:
+    if not isinstance(base_dir_value, str) or not base_dir_value.strip():
+        raise ValueError("base_dir must be a non-empty string")
+    base_path = Path(base_dir_value)
+    if not base_path.is_absolute():
+        base_path = repo_root / base_path
+    resolved = base_path.resolve()
+    if resolved != repo_root and repo_root not in resolved.parents:
+        raise PermissionError("base_dir must be within the repository root")
+    return resolved

--- a/gismo/core/toolpacks/__init__.py
+++ b/gismo/core/toolpacks/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in toolpacks for GISMO."""
+
+from gismo.core.toolpacks.fs_tools import ListDirTool, ReadFileTool, WriteFileTool
+from gismo.core.toolpacks.shell_tool import ShellTool
+
+__all__ = ["ListDirTool", "ReadFileTool", "ShellTool", "WriteFileTool"]

--- a/gismo/core/toolpacks/fs_tools.py
+++ b/gismo/core/toolpacks/fs_tools.py
@@ -1,0 +1,76 @@
+"""Filesystem toolpack with base directory restrictions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+from gismo.core.toolpacks.path_utils import resolve_within_base
+from gismo.core.tools import Tool
+
+
+@dataclass
+class FileSystemConfig:
+    base_dir: Path
+
+
+class ReadFileTool(Tool):
+    def __init__(self, config: FileSystemConfig) -> None:
+        super().__init__(
+            name="read_file",
+            description="Read a file from the allowed base directory",
+            schema={"type": "object", "properties": {"path": {"type": "string"}}},
+        )
+        self._config = config
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        path = tool_input.get("path")
+        resolved = resolve_within_base(self._config.base_dir, path)
+        if not resolved.exists() or not resolved.is_file():
+            raise FileNotFoundError(f"File not found: {resolved}")
+        content = resolved.read_text(encoding="utf-8")
+        return {"path": str(resolved), "content": content}
+
+
+class WriteFileTool(Tool):
+    def __init__(self, config: FileSystemConfig) -> None:
+        super().__init__(
+            name="write_file",
+            description="Write a file within the allowed base directory",
+            schema={
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "content": {"type": "string"},
+                },
+            },
+        )
+        self._config = config
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        path = tool_input.get("path")
+        content = tool_input.get("content")
+        if not isinstance(content, str):
+            raise ValueError("content must be a string")
+        resolved = resolve_within_base(self._config.base_dir, path)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        resolved.write_text(content, encoding="utf-8")
+        return {"path": str(resolved), "bytes_written": len(content.encode("utf-8"))}
+
+
+class ListDirTool(Tool):
+    def __init__(self, config: FileSystemConfig) -> None:
+        super().__init__(
+            name="list_dir",
+            description="List directory entries within the allowed base directory",
+            schema={"type": "object", "properties": {"path": {"type": "string"}}},
+        )
+        self._config = config
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        path = tool_input.get("path", ".")
+        resolved = resolve_within_base(self._config.base_dir, path)
+        if not resolved.exists() or not resolved.is_dir():
+            raise FileNotFoundError(f"Directory not found: {resolved}")
+        entries: List[str] = sorted(entry.name for entry in resolved.iterdir())
+        return {"path": str(resolved), "entries": entries}

--- a/gismo/core/toolpacks/path_utils.py
+++ b/gismo/core/toolpacks/path_utils.py
@@ -1,0 +1,14 @@
+"""Shared path safety helpers for toolpacks."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_within_base(base_dir: Path, target: str) -> Path:
+    if not isinstance(target, str) or not target.strip():
+        raise ValueError("path must be a non-empty string")
+    base_dir = base_dir.resolve()
+    candidate = (base_dir / target).resolve()
+    if candidate != base_dir and base_dir not in candidate.parents:
+        raise PermissionError("Path is outside the allowed base directory")
+    return candidate

--- a/gismo/core/toolpacks/shell_tool.py
+++ b/gismo/core/toolpacks/shell_tool.py
@@ -1,0 +1,63 @@
+"""Restricted shell tool for safe local execution."""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from gismo.core.toolpacks.path_utils import resolve_within_base
+from gismo.core.tools import Tool
+
+
+@dataclass
+class ShellConfig:
+    base_dir: Path
+    allowlist: List[List[str]] = field(default_factory=list)
+    timeout_seconds: float = 10.0
+
+
+class ShellTool(Tool):
+    def __init__(self, config: ShellConfig) -> None:
+        super().__init__(
+            name="run_shell",
+            description="Run an allowlisted shell command with restricted working directory",
+            schema={
+                "type": "object",
+                "properties": {
+                    "command": {"type": "array", "items": {"type": "string"}},
+                    "cwd": {"type": "string"},
+                },
+            },
+        )
+        self._config = config
+
+    def run(self, tool_input: Dict[str, Any]) -> Dict[str, Any]:
+        command = tool_input.get("command")
+        cwd_input = tool_input.get("cwd")
+        if not isinstance(command, list) or not command or not all(
+            isinstance(part, str) and part for part in command
+        ):
+            raise ValueError("command must be a non-empty list of strings")
+        if command not in self._config.allowlist:
+            raise PermissionError("Command is not in the allowlist")
+        if cwd_input is None:
+            cwd = self._config.base_dir.resolve()
+        else:
+            cwd = resolve_within_base(self._config.base_dir, cwd_input)
+
+        result = subprocess.run(
+            command,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=self._config.timeout_seconds,
+            check=False,
+        )
+        return {
+            "command": command,
+            "cwd": str(cwd),
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.returncode,
+        }

--- a/policy/dev.json
+++ b/policy/dev.json
@@ -1,0 +1,21 @@
+{
+  "allowed_tools": [
+    "echo",
+    "write_note",
+    "read_file",
+    "write_file",
+    "list_dir",
+    "run_shell"
+  ],
+  "fs": {
+    "base_dir": "."
+  },
+  "shell": {
+    "base_dir": ".",
+    "allowlist": [
+      ["git", "status"],
+      ["python", "-m", "unittest", "-v"],
+      ["make", "test"]
+    ]
+  }
+}

--- a/tests/test_toolpacks.py
+++ b/tests/test_toolpacks.py
@@ -1,0 +1,58 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFileTool, WriteFileTool
+from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
+
+
+class FileSystemToolTest(unittest.TestCase):
+    def test_fs_tools_respect_base_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir) / "base"
+            base_dir.mkdir()
+            config = FileSystemConfig(base_dir=base_dir)
+            read_tool = ReadFileTool(config)
+            write_tool = WriteFileTool(config)
+            list_tool = ListDirTool(config)
+
+            write_result = write_tool.run({"path": "notes/hello.txt", "content": "hello"})
+            self.assertTrue(write_result["bytes_written"] > 0)
+
+            read_result = read_tool.run({"path": "notes/hello.txt"})
+            self.assertEqual(read_result["content"], "hello")
+
+            list_result = list_tool.run({"path": "notes"})
+            self.assertIn("hello.txt", list_result["entries"])
+
+            with self.assertRaises(PermissionError):
+                read_tool.run({"path": "../outside.txt"})
+
+
+class ShellToolTest(unittest.TestCase):
+    def test_shell_tool_denies_non_allowlisted_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            config = ShellConfig(base_dir=base_dir, allowlist=[["echo", "ok"]], timeout_seconds=2)
+            tool = ShellTool(config)
+
+            with self.assertRaises(PermissionError):
+                tool.run({"command": ["ls"]})
+
+    def test_shell_tool_logs_output_and_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+            config = ShellConfig(base_dir=base_dir, allowlist=[["echo", "hello"]], timeout_seconds=2)
+            tool = ShellTool(config)
+
+            result = tool.run({"command": ["echo", "hello"]})
+            self.assertEqual(result["stdout"].strip(), "hello")
+            self.assertEqual(result["stderr"], "")
+            self.assertEqual(result["exit_code"], 0)
+
+            with self.assertRaises(PermissionError):
+                tool.run({"command": ["echo", "hello"], "cwd": "../outside"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide safe local system operations (filesystem + restricted shell) for GISMO while preserving deny-by-default permissions.
- Enforce auditable, policy-driven boundaries so tool usage is explicit and reviewable. 
- Integrate policy loading into the CLI so operator/demo runs can opt into an allowlist file. 
- Keep the implementation dependency-free and deterministic per repository safety requirements. 

### Description
- Add a minimal toolpack under `gismo/core/toolpacks/` with `fs_tools.py`, `shell_tool.py`, and `path_utils.py` that implement `read_file`, `write_file`, `list_dir`, and `run_shell` with base-dir and allowlist checks. 
- Extend `gismo/core/permissions.py` with `load_policy()` plus `FileSystemPolicy` and `ShellPolicy` types to parse JSON policies and expose `fs`/`shell` settings. 
- Wire policy loading and tool registration into the CLI by adding `--policy` support and `_build_registry()` in `gismo/cli/main.py`, and include a sample policy at `policy/dev.json`. 
- Add unit tests in `tests/test_toolpacks.py` and update `README.md` and `Handoff.md` with usage, examples, and safety notes. 

### Testing
- Ran `python scripts/verify.py`, which executed the test suite and completed successfully (`OK`, 14 tests ran including new toolpack tests). 
- Ran the unit test runner `python -m unittest -v` as an automated command (note: test discovery can vary by working directory but the full suite succeeds when invoked via `scripts/verify.py`). 
- Attempted repository checks `cargo fmt`, `cargo clippy`, and `npm ci && npm run build` and observed expected failures because this repo is Python-only and lacks Rust/Node manifests. 
- Risk/limitation: shell execution requires exact allowlist array matches and policy `base_dir` values must be within the repo root to avoid unsafe filesystem access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c11790da0833087e7fc11f9b30565)