### PR TITLE
Add readonly default policy and enforce least-privilege defaults

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -14,6 +14,7 @@
 - Added policy loader for CLI workflows and documented policy usage in README.
 - Added toolpack tests covering base directory enforcement and shell allowlist outputs.
 - Restored verification coverage for toolpack tests and made tests importable as a package.
+- Added readonly default policy auto-loading with enforcement tests for denied tools.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -27,6 +28,7 @@
 - `python -m unittest -v`
 - `python -m unittest discover -s tests -p "test*.py" -v`
 - `python -m unittest -v tests.test_toolpacks`
+- `python -m unittest -v tests.test_policy_defaults`
 - Optional: `make test`
 - Optional: `make demo`
 - Optional: `make demo-graph`

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Run the demo workflow:
 python -m gismo.cli.main demo
 ```
 
+If `policy/readonly.json` exists and `--policy` is not provided, the CLI defaults to that readonly policy.
+
 Run the demo workflow with a policy:
 
 ```bash
@@ -221,6 +223,7 @@ GISMO supports deterministic operator-like commands that map to tasks and tools.
 ## Toolpack Policy & Safety
 
 GISMO ships with a minimal local toolpack (filesystem + restricted shell) that is deny-by-default and policy-gated. Policies are JSON files that explicitly allow tools and define safety boundaries.
+If `policy/readonly.json` exists, the CLI will auto-load it unless you pass `--policy` explicitly. Use `--policy policy/dev.json` to opt into the development policy.
 
 Example policy (`policy/dev.json`):
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from gismo.cli.operator import (
@@ -22,6 +23,9 @@ from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
 def run_demo(db_path: str, policy_path: str | None) -> None:
     repo_root = Path(__file__).resolve().parents[2]
     state_store = StateStore(db_path)
+    policy_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
     policy = load_policy(policy_path, repo_root=repo_root, default_allowed_tools={"echo"})
     registry = _build_registry(state_store, policy)
 
@@ -79,6 +83,9 @@ def run_demo(db_path: str, policy_path: str | None) -> None:
 def run_demo_graph(db_path: str, policy_path: str | None) -> None:
     repo_root = Path(__file__).resolve().parents[2]
     state_store = StateStore(db_path)
+    policy_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
     policy = load_policy(
         policy_path,
         repo_root=repo_root,
@@ -141,6 +148,9 @@ def run_operator(db_path: str, command_parts: list[str], policy_path: str | None
     plan = parse_command(command_text)
     normalized = normalize_command(command_text)
     default_tools = required_tools(plan) if policy_path is None else ()
+    policy_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
     policy = load_policy(policy_path, repo_root=repo_root, default_allowed_tools=default_tools)
     registry = _build_registry(state_store, policy)
     agent = SimpleAgent(registry=registry)
@@ -192,6 +202,23 @@ def _print_operator_summary(state_store: StateStore, run_id: str) -> None:
             f"- {task.id} {task.title} [{task.status.value}] "
             f"failure_type={failure_type} tool_calls={len(tool_calls)} skipped={skipped}"
         )
+
+
+def _resolve_default_policy_path(policy_path: str | None, repo_root: Path) -> tuple[str | None, bool]:
+    if policy_path:
+        return policy_path, False
+    readonly_path = repo_root / "policy" / "readonly.json"
+    if readonly_path.exists():
+        return str(readonly_path), False
+    return None, True
+
+
+def _warn_missing_default_policy() -> None:
+    print(
+        "Warning: no policy provided and no policy/readonly.json found; "
+        "continuing with existing default tool allowances.",
+        file=sys.stderr,
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/policy/readonly.json
+++ b/policy/readonly.json
@@ -1,0 +1,4 @@
+{
+  "allowed_tools": ["echo", "read_file", "list_dir"],
+  "fs": { "base_dir": "." }
+}

--- a/tests/test_policy_defaults.py
+++ b/tests/test_policy_defaults.py
@@ -1,0 +1,91 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.agent import SimpleAgent
+from gismo.core.models import FailureType
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy, load_policy
+from gismo.core.state import StateStore
+from gismo.core.toolpacks.fs_tools import FileSystemConfig, WriteFileTool
+from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
+from gismo.core.tools import ToolRegistry
+
+
+class PolicyDefaultTest(unittest.TestCase):
+    def _load_readonly_policy(self) -> tuple[Path, PermissionPolicy]:
+        repo_root = Path(__file__).resolve().parents[1]
+        policy_path = repo_root / "policy" / "readonly.json"
+        policy = load_policy(str(policy_path), repo_root=repo_root)
+        return repo_root, policy
+
+    def _build_orchestrator(
+        self, db_path: str, policy: PermissionPolicy
+    ) -> tuple[StateStore, Orchestrator]:
+        state_store = StateStore(db_path)
+        registry = ToolRegistry()
+        fs_config = FileSystemConfig(base_dir=policy.fs.base_dir)
+        registry.register(WriteFileTool(fs_config))
+        shell_config = ShellConfig(
+            base_dir=policy.shell.base_dir,
+            allowlist=policy.shell.allowlist,
+            timeout_seconds=policy.shell.timeout_seconds,
+        )
+        registry.register(ShellTool(shell_config))
+        agent = SimpleAgent(registry=registry)
+        orchestrator = Orchestrator(
+            state_store=state_store,
+            registry=registry,
+            policy=policy,
+            agent=agent,
+        )
+        return state_store, orchestrator
+
+    def test_readonly_policy_denies_run_shell(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, policy = self._load_readonly_policy()
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store, orchestrator = self._build_orchestrator(db_path, policy)
+
+            run = state_store.create_run(label="readonly", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Shell",
+                description="Attempt shell",
+                input_json={"tool": "run_shell", "payload": {"command": ["echo", "nope"]}},
+            )
+            result = orchestrator.run_tool(run.id, task, "run_shell", {"command": ["echo", "nope"]})
+
+            self.assertEqual(result.failure_type, FailureType.PERMISSION_DENIED)
+            self.assertIn("not allowed", result.error or "")
+            tool_calls = list(state_store.list_tool_calls_for_task(task.id))
+            self.assertEqual(tool_calls[0].failure_type, FailureType.PERMISSION_DENIED)
+
+    def test_readonly_policy_denies_write_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, policy = self._load_readonly_policy()
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store, orchestrator = self._build_orchestrator(db_path, policy)
+
+            run = state_store.create_run(label="readonly", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Write file",
+                description="Attempt write",
+                input_json={"tool": "write_file", "payload": {"path": "x.txt", "content": "nope"}},
+            )
+            result = orchestrator.run_tool(
+                run.id,
+                task,
+                "write_file",
+                {"path": "x.txt", "content": "nope"},
+            )
+
+            self.assertEqual(result.failure_type, FailureType.PERMISSION_DENIED)
+            self.assertIn("not allowed", result.error or "")
+            tool_calls = list(state_store.list_tool_calls_for_task(task.id))
+            self.assertEqual(tool_calls[0].failure_type, FailureType.PERMISSION_DENIED)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Establish a safe, least-privilege default policy so the CLI does not implicitly grant write or shell privileges when `--policy` is omitted.
- Ensure permission denials are enforced and auditable by recording `PERMISSION_DENIED` failure types for denied tool calls.
- Make CLI behavior conservative by auto-loading a repo-scoped readonly policy if present and warning when it is absent.
- Risk: workflows that relied on previous implicit allowances may fail unless an explicit `--policy` is provided.  

### Description
- Add `policy/readonly.json` permitting only `"echo"`, `"read_file"`, and `"list_dir"` with `fs.base_dir` set to `"."`.
- Update the CLI to auto-load `policy/readonly.json` when `--policy` is not provided and to print a warning to stderr if no default policy file exists.  
- Add `tests/test_policy_defaults.py` to assert that `run_shell` and `write_file` are denied and recorded with `FailureType.PERMISSION_DENIED`.  
- Update `README.md` and `Handoff.md` to document the readonly default and how to opt into the dev policy with `--policy policy/dev.json`.  

### Testing
- Ran `python scripts/verify.py`, which runs the full verification suite, and it completed successfully (all tests OK).  
- Ran `python -m unittest -v tests.test_policy_defaults` and the new policy default tests passed (OK).  
- Ran `python -m unittest -v` and `python -m unittest discover -s tests -p "test*.py" -v` and all existing unit tests passed (OK).  
- No automated test failures observed during verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c14ce01f88330ab848c8dc279fe8e)