### PR TITLE
Add JSONL audit export and dev-safe shell policy

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -15,6 +15,9 @@
 - Added toolpack tests covering base directory enforcement and shell allowlist outputs.
 - Restored verification coverage for toolpack tests and made tests importable as a package.
 - Added readonly default policy auto-loading with enforcement tests for denied tools.
+- Added JSONL audit export for runs, tasks, and tool calls with optional redaction.
+- Added dev-safe shell policy profile and tests for allowlisted shell execution.
+- Extended CLI and documentation with export and policy usage.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -25,13 +28,7 @@
 
 ## Tests
 - `python scripts/verify.py`
-- `python -m unittest -v`
 - `python -m unittest discover -s tests -p "test*.py" -v`
-- `python -m unittest -v tests.test_toolpacks`
-- `python -m unittest -v tests.test_policy_defaults`
-- Optional: `make test`
-- Optional: `make demo`
-- Optional: `make demo-graph`
 
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ Run operator commands with a policy:
 python -m gismo.cli.main run --policy policy/dev.json "echo: hello"
 ```
 
+Export a run audit trail as JSONL:
+
+```bash
+python -m gismo.cli.main export --run <RUN_ID> --format jsonl --out exports/<RUN_ID>.jsonl
+python -m gismo.cli.main export --latest --format jsonl
+```
+
 Expected behavior:
 * Creates a run and two tasks (echo, write_note)
 * Echo succeeds immediately
@@ -197,6 +204,11 @@ make test
 make demo
 make demo-graph
 ```
+
+## Policies
+
+* `policy/readonly.json`: default readonly policy if no `--policy` is provided.
+* `policy/dev-safe.json`: dev-safe policy allowing `run_shell` with a minimal allowlist.
 
 ## Operator Commands
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -12,6 +12,7 @@ from gismo.cli.operator import (
     required_tools,
 )
 from gismo.core.agent import SimpleAgent
+from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy, load_policy
 from gismo.core.state import StateStore
@@ -190,6 +191,48 @@ def run_operator(db_path: str, command_parts: list[str], policy_path: str | None
     _print_operator_summary(state_store, run.id)
 
 
+def run_export(
+    db_path: str,
+    *,
+    run_id: str | None,
+    use_latest: bool,
+    export_format: str,
+    out_path: str | None,
+    redact: bool,
+    policy_path: str | None,
+) -> None:
+    if export_format != "jsonl":
+        raise ValueError("Only jsonl export is supported")
+    if run_id and use_latest:
+        raise ValueError("Provide either --run or --latest, not both")
+    if not run_id and not use_latest:
+        raise ValueError("Export requires --run or --latest")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    state_store = StateStore(db_path)
+    policy_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
+    policy = load_policy(policy_path, repo_root=repo_root)
+    base_dir = policy.fs.base_dir
+    if use_latest:
+        export_path = export_latest_run_jsonl(
+            state_store,
+            out_path=out_path,
+            redact=redact,
+            base_dir=base_dir,
+        )
+    else:
+        export_path = export_run_jsonl(
+            state_store,
+            run_id,
+            out_path=out_path,
+            redact=redact,
+            base_dir=base_dir,
+        )
+    print(f"Exported run audit to {export_path}")
+
+
 def _print_operator_summary(state_store: StateStore, run_id: str) -> None:
     print("=== GISMO Operator Summary ===")
     print(f"Run: {run_id}")
@@ -262,6 +305,43 @@ def build_parser() -> argparse.ArgumentParser:
         nargs=argparse.REMAINDER,
         help="Operator command string (echo:, note:, or graph:)",
     )
+    export_parser = subparsers.add_parser("export", help="Export run audit trail")
+    export_parser.add_argument(
+        "--db-path",
+        default=str(Path(".gismo") / "state.db"),
+        help="Path to SQLite state database",
+    )
+    export_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
+    export_parser.add_argument(
+        "--run",
+        dest="run_id",
+        default=None,
+        help="Run ID to export",
+    )
+    export_parser.add_argument(
+        "--latest",
+        action="store_true",
+        help="Export the most recent run",
+    )
+    export_parser.add_argument(
+        "--format",
+        default="jsonl",
+        help="Export format (jsonl only)",
+    )
+    export_parser.add_argument(
+        "--out",
+        default=None,
+        help="Output file path (defaults to exports/<run_id>.jsonl)",
+    )
+    export_parser.add_argument(
+        "--redact",
+        action="store_true",
+        help="Redact file contents, shell output, and large tool outputs",
+    )
     return parser
 
 
@@ -274,6 +354,16 @@ def main() -> None:
         run_demo_graph(args.db_path, args.policy)
     elif args.command == "run":
         run_operator(args.db_path, args.operator_command, args.policy)
+    elif args.command == "export":
+        run_export(
+            args.db_path,
+            run_id=args.run_id,
+            use_latest=args.latest,
+            export_format=args.format,
+            out_path=args.out,
+            redact=args.redact,
+            policy_path=args.policy,
+        )
 
 
 def _build_registry(state_store: StateStore, policy: PermissionPolicy) -> ToolRegistry:

--- a/gismo/core/export.py
+++ b/gismo/core/export.py
@@ -1,0 +1,170 @@
+"""Audit export utilities for runs, tasks, and tool calls."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from gismo.core.models import Run, Task, ToolCall
+from gismo.core.state import StateStore
+
+
+def export_run_jsonl(
+    state_store: StateStore,
+    run_id: str,
+    *,
+    out_path: str | Path | None = None,
+    redact: bool = False,
+    base_dir: Path | None = None,
+) -> Path:
+    run = state_store.get_run(run_id)
+    if run is None:
+        raise ValueError(f"Run not found: {run_id}")
+    base_dir = base_dir or Path(".")
+    resolved_out = _resolve_output_path(run_id, out_path, base_dir)
+    tasks = list(state_store.list_tasks(run_id))
+    tool_calls = list(state_store.list_tool_calls(run_id))
+    records = _build_records(run, tasks, tool_calls, redact=redact)
+    _write_jsonl(resolved_out, records)
+    return resolved_out
+
+
+def export_latest_run_jsonl(
+    state_store: StateStore,
+    *,
+    out_path: str | Path | None = None,
+    redact: bool = False,
+    base_dir: Path | None = None,
+) -> Path:
+    run = state_store.get_latest_run()
+    if run is None:
+        raise ValueError("No runs found to export")
+    return export_run_jsonl(
+        state_store,
+        run.id,
+        out_path=out_path,
+        redact=redact,
+        base_dir=base_dir,
+    )
+
+
+def _resolve_output_path(run_id: str, out_path: str | Path | None, base_dir: Path) -> Path:
+    if out_path is None:
+        resolved = base_dir / "exports" / f"{run_id}.jsonl"
+    else:
+        resolved = Path(out_path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    return resolved
+
+
+def _write_jsonl(path: Path, records: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False))
+            handle.write("\n")
+
+
+def _build_records(
+    run: Run,
+    tasks: list[Task],
+    tool_calls: list[ToolCall],
+    *,
+    redact: bool,
+) -> list[dict[str, Any]]:
+    sorted_tasks = sorted(tasks, key=lambda task: task.created_at)
+    sorted_calls = sorted(tool_calls, key=lambda call: (call.started_at, call.attempt_number))
+    records = [_serialize_run(run)]
+    records.extend(_serialize_task(task, redact=redact) for task in sorted_tasks)
+    records.extend(_serialize_tool_call(call, redact=redact) for call in sorted_calls)
+    return records
+
+
+def _serialize_run(run: Run) -> dict[str, Any]:
+    payload = asdict(run)
+    payload["created_at"] = run.created_at.isoformat()
+    return {
+        "record_type": "run",
+        "id": run.id,
+        "created_at": payload["created_at"],
+        "label": run.label,
+        "metadata": run.metadata_json,
+        "status": "CREATED",
+        "failure_type": "NONE",
+    }
+
+
+def _serialize_task(task: Task, *, redact: bool) -> dict[str, Any]:
+    inputs = task.input_json
+    outputs = task.output_json
+    if redact:
+        inputs = _redact_payload(inputs)
+        outputs = _redact_outputs(outputs)
+    tool_name = None
+    if isinstance(task.input_json, dict):
+        tool_name = task.input_json.get("tool")
+    return {
+        "record_type": "task",
+        "id": task.id,
+        "run_id": task.run_id,
+        "title": task.title,
+        "description": task.description,
+        "tool_name": tool_name,
+        "inputs": inputs,
+        "outputs": outputs,
+        "status": task.status.value,
+        "failure_type": task.failure_type.value if task.failure_type else "NONE",
+        "error": task.error,
+        "status_reason": task.status_reason,
+        "created_at": task.created_at.isoformat(),
+        "updated_at": task.updated_at.isoformat(),
+    }
+
+
+def _serialize_tool_call(call: ToolCall, *, redact: bool) -> dict[str, Any]:
+    inputs = call.input_json
+    outputs = call.output_json
+    if redact:
+        inputs = _redact_payload(inputs)
+        outputs = _redact_outputs(outputs)
+    return {
+        "record_type": "tool_call",
+        "id": call.id,
+        "run_id": call.run_id,
+        "task_id": call.task_id,
+        "tool_name": call.tool_name,
+        "inputs": inputs,
+        "outputs": outputs,
+        "status": call.status.value,
+        "failure_type": call.failure_type.value if call.failure_type else "NONE",
+        "error": call.error,
+        "attempt_number": call.attempt_number,
+        "started_at": call.started_at.isoformat(),
+        "finished_at": call.finished_at.isoformat() if call.finished_at else None,
+    }
+
+
+def _redact_outputs(output: Any) -> Any:
+    if output is None:
+        return None
+    if _payload_size(output) > 1024:
+        return "[REDACTED]"
+    return _redact_payload(output)
+
+
+def _payload_size(payload: Any) -> int:
+    return len(json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8"))
+
+
+def _redact_payload(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        redacted: dict[str, Any] = {}
+        for key, value in payload.items():
+            if key in {"content", "stdout", "stderr"}:
+                redacted[key] = "[REDACTED]"
+            else:
+                redacted[key] = _redact_payload(value)
+        return redacted
+    if isinstance(payload, list):
+        return [_redact_payload(item) for item in payload]
+    return payload

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -323,6 +323,25 @@ class StateStore:
             ).fetchall()
         return [self._row_to_tool_call(row) for row in rows]
 
+    def get_run(self, run_id: str) -> Optional[Run]:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM runs WHERE id = ?",
+                (run_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_run(row)
+
+    def get_latest_run(self) -> Optional[Run]:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM runs ORDER BY created_at DESC LIMIT 1",
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_run(row)
+
     def find_succeeded_task_by_idempotency(
         self,
         idempotency_key: str,
@@ -377,6 +396,14 @@ class StateStore:
             status_reason=row["status_reason"],
         )
         return task
+
+    def _row_to_run(self, row: sqlite3.Row) -> Run:
+        return Run(
+            id=row["id"],
+            created_at=_parse_dt(row["created_at"]),
+            label=row["label"],
+            metadata_json=json.loads(row["metadata_json"]),
+        )
 
     def _row_to_tool_call(self, row: sqlite3.Row) -> ToolCall:
         tool_call = ToolCall(

--- a/policy/dev-safe.json
+++ b/policy/dev-safe.json
@@ -1,0 +1,12 @@
+{
+  "allowed_tools": ["echo", "read_file", "list_dir", "write_note", "run_shell"],
+  "fs": { "base_dir": "." },
+  "shell": {
+    "base_dir": ".",
+    "allowlist": [
+      ["git", "status"],
+      ["python", "-m", "unittest"],
+      ["make", "test"]
+    ]
+  }
+}

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,136 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.agent import SimpleAgent
+from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
+from gismo.core.models import ToolCall, ToolCallStatus
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy
+from gismo.core.state import StateStore
+from gismo.core.tools import EchoTool, ToolRegistry
+
+
+class ExportTest(unittest.TestCase):
+    def _build_orchestrator(
+        self, db_path: str, policy: PermissionPolicy
+    ) -> tuple[StateStore, Orchestrator]:
+        state_store = StateStore(db_path)
+        registry = ToolRegistry()
+        registry.register(EchoTool())
+        agent = SimpleAgent(registry=registry)
+        orchestrator = Orchestrator(
+            state_store=state_store,
+            registry=registry,
+            policy=policy,
+            agent=agent,
+        )
+        return state_store, orchestrator
+
+    def test_export_by_run_id_creates_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy = PermissionPolicy(allowed_tools={"echo"})
+            state_store, orchestrator = self._build_orchestrator(db_path, policy)
+            run = state_store.create_run(label="export", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Echo",
+                description="Echo",
+                input_json={"tool": "echo", "payload": {"message": "hi"}},
+            )
+            orchestrator.run_tool(run.id, task, "echo", {"message": "hi"})
+
+            output_path = export_run_jsonl(
+                state_store,
+                run.id,
+                base_dir=Path(tmpdir),
+            )
+
+            self.assertTrue(output_path.exists())
+            lines = output_path.read_text(encoding="utf-8").strip().splitlines()
+            records = [json.loads(line) for line in lines]
+            self.assertEqual(records[0]["record_type"], "run")
+            self.assertEqual(records[0]["id"], run.id)
+            record_types = [record["record_type"] for record in records]
+            self.assertIn("task", record_types)
+            self.assertIn("tool_call", record_types)
+            self.assertGreater(record_types.index("tool_call"), record_types.index("task"))
+
+    def test_export_latest_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            run_one = state_store.create_run(label="first", metadata={})
+            run_two = state_store.create_run(label="second", metadata={})
+
+            output_path = export_latest_run_jsonl(state_store, base_dir=Path(tmpdir))
+
+            self.assertIn(run_two.id, output_path.name)
+            self.assertNotIn(run_one.id, output_path.name)
+
+    def test_export_redact_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            run = state_store.create_run(label="redact", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Write",
+                description="Write file",
+                input_json={"tool": "write_file", "payload": {"content": "secret"}},
+            )
+            large_payload = "x" * 2048
+            task.mark_succeeded({"data": large_payload})
+            state_store.update_task(task)
+
+            tool_call = ToolCall(
+                run_id=run.id,
+                task_id=task.id,
+                tool_name="run_shell",
+                input_json={"command": ["echo", "secret"]},
+                status=ToolCallStatus.SUCCEEDED,
+                output_json={"stdout": "secret", "stderr": "oops"},
+            )
+            tool_call.finished_at = tool_call.started_at
+            state_store.record_tool_call(tool_call)
+
+            tool_call_large = ToolCall(
+                run_id=run.id,
+                task_id=task.id,
+                tool_name="echo",
+                input_json={"message": "large"},
+                status=ToolCallStatus.SUCCEEDED,
+                output_json={"blob": large_payload},
+            )
+            tool_call_large.finished_at = tool_call_large.started_at
+            state_store.record_tool_call(tool_call_large)
+
+            output_path = export_run_jsonl(
+                state_store,
+                run.id,
+                base_dir=Path(tmpdir),
+                redact=True,
+            )
+
+            records = [
+                json.loads(line)
+                for line in output_path.read_text(encoding="utf-8").strip().splitlines()
+            ]
+            task_record = next(record for record in records if record["record_type"] == "task")
+            self.assertEqual(
+                task_record["inputs"]["payload"]["content"],
+                "[REDACTED]",
+            )
+            self.assertEqual(task_record["outputs"], "[REDACTED]")
+            tool_records = [record for record in records if record["record_type"] == "tool_call"]
+            stdout_record = next(record for record in tool_records if record["tool_name"] == "run_shell")
+            self.assertEqual(stdout_record["outputs"]["stdout"], "[REDACTED]")
+            self.assertEqual(stdout_record["outputs"]["stderr"], "[REDACTED]")
+            large_record = next(record for record in tool_records if record["tool_name"] == "echo")
+            self.assertEqual(large_record["outputs"], "[REDACTED]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_policy_dev_safe.py
+++ b/tests/test_policy_dev_safe.py
@@ -1,0 +1,82 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.agent import SimpleAgent
+from gismo.core.models import FailureType
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy, load_policy
+from gismo.core.state import StateStore
+from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
+from gismo.core.tools import ToolRegistry
+
+
+class PolicyDevSafeTest(unittest.TestCase):
+    def _load_dev_safe_policy(self) -> tuple[Path, PermissionPolicy]:
+        repo_root = Path(__file__).resolve().parents[1]
+        policy_path = repo_root / "policy" / "dev-safe.json"
+        policy = load_policy(str(policy_path), repo_root=repo_root)
+        return repo_root, policy
+
+    def _build_orchestrator(
+        self, db_path: str, policy: PermissionPolicy
+    ) -> tuple[StateStore, Orchestrator]:
+        state_store = StateStore(db_path)
+        registry = ToolRegistry()
+        shell_config = ShellConfig(
+            base_dir=policy.shell.base_dir,
+            allowlist=policy.shell.allowlist,
+            timeout_seconds=policy.shell.timeout_seconds,
+        )
+        registry.register(ShellTool(shell_config))
+        agent = SimpleAgent(registry=registry)
+        orchestrator = Orchestrator(
+            state_store=state_store,
+            registry=registry,
+            policy=policy,
+            agent=agent,
+        )
+        return state_store, orchestrator
+
+    def test_dev_safe_allows_shell_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, policy = self._load_dev_safe_policy()
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store, orchestrator = self._build_orchestrator(db_path, policy)
+            run = state_store.create_run(label="dev-safe", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Shell",
+                description="Allowed command",
+                input_json={"tool": "run_shell", "payload": {"command": ["git", "status"]}},
+            )
+
+            result = orchestrator.run_tool(run.id, task, "run_shell", {"command": ["git", "status"]})
+
+            self.assertEqual(result.status.value, "SUCCEEDED")
+            tool_calls = list(state_store.list_tool_calls_for_task(task.id))
+            self.assertEqual(tool_calls[0].status.value, "SUCCEEDED")
+
+    def test_dev_safe_denies_non_allowlisted_command(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _, policy = self._load_dev_safe_policy()
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store, orchestrator = self._build_orchestrator(db_path, policy)
+            run = state_store.create_run(label="dev-safe", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Shell",
+                description="Disallowed command",
+                input_json={"tool": "run_shell", "payload": {"command": ["ls"]}},
+            )
+
+            result = orchestrator.run_tool(run.id, task, "run_shell", {"command": ["ls"]})
+
+            self.assertEqual(result.failure_type, FailureType.PERMISSION_DENIED)
+            tool_calls = list(state_store.list_tool_calls_for_task(task.id))
+            self.assertEqual(tool_calls[0].failure_type, FailureType.PERMISSION_DENIED)
+            self.assertIn("allowlist", tool_calls[0].error or "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a read-only, auditable export of runs/tasks/tool calls for offline analysis and retention.
- Offer a developer-safe policy profile that allows a minimal, exact-match set of shell commands without changing default deny-by-default security.
- Keep changes additive and Python-only while preserving existing behavior and permissions.

### Description
- Added `gismo/core/export.py` implementing `export_run_jsonl` and `export_latest_run_jsonl` with stable ordering and optional redaction of file contents, shell `stdout`/`stderr`, and outputs >1KB.
- Extended `gismo/cli/main.py` with an `export` subcommand supporting `--run`, `--latest`, `--format jsonl`, `--out`, and `--redact` flags without altering existing commands.
- Added `policy/dev-safe.json` and new state helpers `StateStore.get_run` / `get_latest_run` plus `_row_to_run`, and updated docs in `README.md` and `Handoff.md`.
- Added tests `tests/test_export.py` and `tests/test_policy_dev_safe.py` to validate export behavior, redaction, and dev-safe shell allowlist enforcement.

### Testing
- Ran verification: `python scripts/verify.py` which executed the full test suite and passed (all tests OK).
- Ran unit tests: `python -m unittest discover -s tests -p "test*.py" -v` and all tests passed.
- New tests include `tests/test_export.py` (exports, `--latest`, redaction) and `tests/test_policy_dev_safe.py` (allowed vs disallowed shell commands) and they succeeded.
- Manual CLI smoke: `python -m gismo.cli.main export --run <RUN_ID> --format jsonl --out exports/<RUN_ID>.jsonl` and `python -m gismo.cli.main export --latest --format jsonl` are supported as documented.

Risks / limitations
- Redaction targets `content`, `stdout`, `stderr` keys and any tool outputs larger than 1KB and may not catch other sensitive fields automatically.
- The `dev-safe` shell allowlist is exact-match and limited to the configured commands, so more permissive patterns must be added explicitly via policy.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1632304c8330bce018a47b7efdaa)