### PR TITLE
Add daemon mode with SQLite-backed queue (enqueue/daemon) and tests

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -19,6 +19,8 @@
 - Added dev-safe shell policy profile and tests for allowlisted shell execution.
 - Extended CLI and documentation with export and policy usage.
 - Wired CLI subcommand handlers for demo, run, and export with parser routing tests.
+- Added SQLite-backed queue with daemon execution loop and CLI enqueue/daemon commands.
+- Added daemon queue tests for enqueue/claim, execution, retries, and non-retryable failures.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -26,9 +28,12 @@
 - Extend orchestration tests to cover recovery workflows.
 - Consider richer operator command validation and error messaging.
 - Add policy-driven examples for operator tasks using the new toolpack.
+- Extend daemon workflows with observability metrics and backoff tuning.
 
 ## Tests
 - `python scripts/verify.py`
+- `python -m gismo.cli.main enqueue "echo: daemon smoke"`
+- `python -m gismo.cli.main daemon --once --policy policy/readonly.json`
 
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ Run operator commands with a policy:
 python -m gismo.cli.main run --policy policy/dev.json "echo: hello"
 ```
 
+Daemon mode (queue + headless execution):
+
+```bash
+python -m gismo.cli.main enqueue "echo: daemon hello"
+python -m gismo.cli.main daemon --once --policy policy/readonly.json
+```
+
 Export a run audit trail as JSONL:
 
 ```bash
@@ -231,6 +238,17 @@ GISMO supports deterministic operator-like commands that map to tasks and tools.
   ```bash
   python -m gismo.cli.main run "graph: echo A -> note B -> echo C"
   ```
+
+## Daemon Mode
+
+Queue commands for headless execution and run the daemon to process them:
+
+```bash
+python -m gismo.cli.main enqueue "echo: daemon hello"
+python -m gismo.cli.main daemon --once --policy policy/readonly.json
+```
+
+Daemon runs always enforce policies; keep policies least-privilege and explicitly allow only the tools you need.
 
 ## Toolpack Policy & Safety
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -12,6 +12,7 @@ from gismo.cli.operator import (
     required_tools,
 )
 from gismo.core.agent import SimpleAgent
+from gismo.core.daemon import run_daemon_loop
 from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy, load_policy
@@ -233,6 +234,40 @@ def run_export(
     print(f"Exported run audit to {export_path}")
 
 
+def run_enqueue(
+    db_path: str,
+    command_text: str,
+    *,
+    run_id: str | None,
+    max_attempts: int,
+) -> None:
+    state_store = StateStore(db_path)
+    item = state_store.enqueue_command(
+        command_text=command_text,
+        run_id=run_id,
+        max_attempts=max_attempts,
+    )
+    print(f"Enqueued {item.id} status={item.status.value}")
+
+
+def run_daemon(
+    db_path: str,
+    policy_path: str | None,
+    *,
+    sleep_seconds: float,
+    once: bool,
+    requeue_stale_seconds: int,
+) -> None:
+    state_store = StateStore(db_path)
+    state_store.requeue_stale_in_progress(older_than_seconds=requeue_stale_seconds)
+    run_daemon_loop(
+        state_store,
+        policy_path=policy_path,
+        sleep_seconds=sleep_seconds,
+        once=once,
+    )
+
+
 def _print_operator_summary(state_store: StateStore, run_id: str) -> None:
     print("=== GISMO Operator Summary ===")
     print(f"Run: {run_id}")
@@ -285,6 +320,28 @@ def _handle_export(args: argparse.Namespace) -> None:
         out_path=args.out,
         redact=args.redact,
         policy_path=args.policy,
+    )
+
+
+def _handle_enqueue(args: argparse.Namespace) -> None:
+    command_text = " ".join(args.operator_command).strip()
+    if not command_text:
+        raise ValueError("enqueue requires a command string")
+    run_enqueue(
+        args.db_path,
+        command_text,
+        run_id=args.run_id,
+        max_attempts=args.max_attempts,
+    )
+
+
+def _handle_daemon(args: argparse.Namespace) -> None:
+    run_daemon(
+        args.db_path,
+        args.policy,
+        sleep_seconds=args.sleep,
+        once=args.once,
+        requeue_stale_seconds=args.requeue_stale_seconds,
     )
 
 
@@ -370,6 +427,59 @@ def build_parser() -> argparse.ArgumentParser:
         help="Redact file contents, shell output, and large tool outputs",
     )
     export_parser.set_defaults(handler=_handle_export)
+    enqueue_parser = subparsers.add_parser("enqueue", help="Enqueue an operator command")
+    enqueue_parser.add_argument(
+        "--db-path",
+        default=str(Path(".gismo") / "state.db"),
+        help="Path to SQLite state database",
+    )
+    enqueue_parser.add_argument(
+        "--run",
+        dest="run_id",
+        default=None,
+        help="Optional existing run ID to attach tasks to",
+    )
+    enqueue_parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=3,
+        help="Maximum attempts for this queue item",
+    )
+    enqueue_parser.add_argument(
+        "operator_command",
+        nargs=argparse.REMAINDER,
+        help="Operator command string to enqueue",
+    )
+    enqueue_parser.set_defaults(handler=_handle_enqueue)
+    daemon_parser = subparsers.add_parser("daemon", help="Run the GISMO daemon loop")
+    daemon_parser.add_argument(
+        "--db-path",
+        default=str(Path(".gismo") / "state.db"),
+        help="Path to SQLite state database",
+    )
+    daemon_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
+    daemon_parser.add_argument(
+        "--sleep",
+        type=float,
+        default=2.0,
+        help="Sleep interval between queue polls",
+    )
+    daemon_parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Process queued items once and exit when the queue is empty",
+    )
+    daemon_parser.add_argument(
+        "--requeue-stale-seconds",
+        type=int,
+        default=600,
+        help="Requeue IN_PROGRESS items older than this many seconds",
+    )
+    daemon_parser.set_defaults(handler=_handle_daemon)
     return parser
 
 

--- a/gismo/core/daemon.py
+++ b/gismo/core/daemon.py
@@ -1,0 +1,186 @@
+"""Daemon loop for executing queued operator commands."""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+from gismo.cli.operator import make_idempotency_key, normalize_command, parse_command, required_tools
+from gismo.core.agent import SimpleAgent
+from gismo.core.models import FailureType, QueueItem, Task, TaskStatus
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy, load_policy
+from gismo.core.state import StateStore
+from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
+from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFileTool, WriteFileTool
+from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
+
+
+RegistryFactory = Callable[[StateStore, PermissionPolicy], ToolRegistry]
+
+
+def run_daemon_loop(
+    state: StateStore,
+    policy_path: str | None,
+    sleep_seconds: float,
+    once: bool,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    while True:
+        item = state.claim_next_queue_item()
+        if item is None:
+            if once:
+                return
+            time.sleep(sleep_seconds)
+            continue
+        _execute_queue_item(state, item, policy_path, repo_root)
+
+
+def _execute_queue_item(
+    state: StateStore,
+    item: QueueItem,
+    policy_path: str | None,
+    repo_root: Path,
+    *,
+    registry_factory: Optional[RegistryFactory] = None,
+) -> None:
+    try:
+        policy, plan, normalized = _load_policy_and_plan(policy_path, repo_root, item.command_text)
+        registry = (registry_factory or build_registry)(state, policy)
+        agent = SimpleAgent(registry=registry)
+        orchestrator = Orchestrator(
+            state_store=state,
+            registry=registry,
+            policy=policy,
+            agent=agent,
+        )
+
+        run_id = _resolve_run_id(state, item, normalized)
+        created_tasks = []
+        previous_task_id = None
+        for index, step in enumerate(plan["steps"]):
+            tool_name = step["tool_name"]
+            tool_input = step["input_json"]
+            idempotency_key = make_idempotency_key(step, normalized, index)
+            depends_on = [previous_task_id] if plan["mode"] == "graph" and previous_task_id else None
+            task = state.create_task(
+                run_id=run_id,
+                title=step["title"],
+                description="Daemon queue step",
+                input_json={"tool": tool_name, "payload": tool_input},
+                depends_on=depends_on,
+                idempotency_key=idempotency_key,
+            )
+            created_tasks.append(task)
+            previous_task_id = task.id
+
+        if plan["mode"] == "single":
+            task = created_tasks[0]
+            result = orchestrator.run_tool(
+                run_id,
+                task,
+                task.input_json["tool"],
+                task.input_json["payload"],
+            )
+            _raise_on_failed_tasks([result])
+        else:
+            results = orchestrator.run_task_graph(run_id)
+            _raise_on_failed_tasks(list(results.values()))
+
+        state.mark_queue_item_succeeded(item.id)
+    except Exception as exc:  # noqa: BLE001
+        retryable = _is_retryable_queue_error(exc)
+        state.mark_queue_item_failed(item.id, _safe_error_message(exc), retryable=retryable)
+
+
+def _resolve_run_id(state: StateStore, item: QueueItem, normalized_command: str) -> str:
+    metadata = {
+        "command": normalized_command,
+        "queue_item_id": item.id,
+        "source": "daemon",
+    }
+    if item.run_id:
+        existing = state.get_run(item.run_id)
+        if existing is not None:
+            return existing.id
+        metadata["requested_run_id"] = item.run_id
+    run = state.create_run(label="daemon", metadata=metadata)
+    return run.id
+
+
+def _load_policy_and_plan(
+    policy_path: str | None,
+    repo_root: Path,
+    command_text: str,
+) -> tuple[PermissionPolicy, dict, str]:
+    plan = parse_command(command_text)
+    normalized = normalize_command(command_text)
+    default_tools = required_tools(plan) if policy_path is None else ()
+    resolved_policy_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
+    policy = load_policy(
+        resolved_policy_path,
+        repo_root=repo_root,
+        default_allowed_tools=default_tools,
+    )
+    return policy, plan, normalized
+
+
+def _raise_on_failed_tasks(tasks: list[Task]) -> None:
+    failed = [task for task in tasks if task.status == TaskStatus.FAILED]
+    if not failed:
+        return
+    task = failed[0]
+    error = task.error or "Task failed"
+    if task.failure_type == FailureType.PERMISSION_DENIED:
+        raise PermissionError(error)
+    if task.failure_type == FailureType.INVALID_INPUT:
+        raise ValueError(error)
+    raise RuntimeError(error)
+
+
+def _is_retryable_queue_error(exc: BaseException) -> bool:
+    if isinstance(exc, (PermissionError, ValueError)):
+        return False
+    return isinstance(exc, (RuntimeError, sqlite3.OperationalError))
+
+
+def _safe_error_message(exc: BaseException) -> str:
+    message = str(exc)
+    return message or exc.__class__.__name__
+
+
+def _resolve_default_policy_path(policy_path: str | None, repo_root: Path) -> tuple[str | None, bool]:
+    if policy_path:
+        return policy_path, False
+    readonly_path = repo_root / "policy" / "readonly.json"
+    if readonly_path.exists():
+        return str(readonly_path), False
+    return None, True
+
+
+def _warn_missing_default_policy() -> None:
+    print(
+        "Warning: no policy provided and no policy/readonly.json found; "
+        "continuing with existing default tool allowances.",
+        flush=True,
+    )
+
+
+def build_registry(state_store: StateStore, policy: PermissionPolicy) -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(EchoTool())
+    registry.register(WriteNoteTool(state_store))
+    fs_config = FileSystemConfig(base_dir=policy.fs.base_dir)
+    registry.register(ReadFileTool(fs_config))
+    registry.register(WriteFileTool(fs_config))
+    registry.register(ListDirTool(fs_config))
+    shell_config = ShellConfig(
+        base_dir=policy.shell.base_dir,
+        allowlist=policy.shell.allowlist,
+        timeout_seconds=policy.shell.timeout_seconds,
+    )
+    registry.register(ShellTool(shell_config))
+    return registry

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -34,6 +34,13 @@ class ToolCallStatus(str, Enum):
     SKIPPED = "SKIPPED"
 
 
+class QueueStatus(str, Enum):
+    QUEUED = "QUEUED"
+    IN_PROGRESS = "IN_PROGRESS"
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+
+
 @dataclass
 class Run:
     id: str = field(default_factory=lambda: str(uuid4()))
@@ -114,3 +121,18 @@ class ToolCall:
         self.error = error
         self.failure_type = failure_type
         self.finished_at = _utc_now()
+
+
+@dataclass
+class QueueItem:
+    command_text: str
+    run_id: Optional[str] = None
+    id: str = field(default_factory=lambda: str(uuid4()))
+    status: QueueStatus = QueueStatus.QUEUED
+    created_at: datetime = field(default_factory=_utc_now)
+    updated_at: datetime = field(default_factory=_utc_now)
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    attempt_count: int = 0
+    max_attempts: int = 3
+    last_error: Optional[str] = None

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
-from gismo.core.models import FailureType, Run, Task, TaskStatus, ToolCall, ToolCallStatus
+from gismo.core.models import (
+    FailureType,
+    QueueItem,
+    QueueStatus,
+    Run,
+    Task,
+    TaskStatus,
+    ToolCall,
+    ToolCallStatus,
+)
 
 
 class StateStore:
@@ -77,6 +86,23 @@ class StateStore:
                 )
                 """
             )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue_items (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT,
+                    command_text TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    attempt_count INTEGER NOT NULL DEFAULT 0,
+                    max_attempts INTEGER NOT NULL DEFAULT 3,
+                    last_error TEXT
+                )
+                """
+            )
             self._ensure_columns(connection)
             connection.commit()
 
@@ -108,6 +134,26 @@ class StateStore:
             "INTEGER NOT NULL DEFAULT 1",
         )
         self._ensure_column(connection, "tool_calls", "failure_type", "TEXT")
+        self._ensure_column(
+            connection,
+            "queue_items",
+            "attempt_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        )
+        self._ensure_column(
+            connection,
+            "queue_items",
+            "max_attempts",
+            "INTEGER NOT NULL DEFAULT 3",
+        )
+        self._ensure_column(connection, "queue_items", "last_error", "TEXT")
+        self._ensure_column(connection, "queue_items", "started_at", "TEXT")
+        self._ensure_column(connection, "queue_items", "finished_at", "TEXT")
+        self._ensure_column(connection, "queue_items", "run_id", "TEXT")
+        self._ensure_column(connection, "queue_items", "command_text", "TEXT NOT NULL")
+        self._ensure_column(connection, "queue_items", "status", "TEXT NOT NULL")
+        self._ensure_column(connection, "queue_items", "created_at", "TEXT NOT NULL")
+        self._ensure_column(connection, "queue_items", "updated_at", "TEXT NOT NULL")
 
     def _ensure_column(
         self,
@@ -333,6 +379,202 @@ class StateStore:
             return None
         return self._row_to_run(row)
 
+    def enqueue_command(
+        self,
+        command_text: str,
+        run_id: Optional[str] = None,
+        max_attempts: int = 3,
+    ) -> QueueItem:
+        if not command_text or not command_text.strip():
+            raise ValueError("command_text must be a non-empty string")
+        item = QueueItem(
+            command_text=command_text.strip(),
+            run_id=run_id,
+            max_attempts=max_attempts,
+        )
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO queue_items (
+                    id, run_id, command_text, status, created_at, updated_at,
+                    started_at, finished_at, attempt_count, max_attempts, last_error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    item.id,
+                    item.run_id,
+                    item.command_text,
+                    item.status.value,
+                    item.created_at.isoformat(),
+                    item.updated_at.isoformat(),
+                    item.started_at.isoformat() if item.started_at else None,
+                    item.finished_at.isoformat() if item.finished_at else None,
+                    item.attempt_count,
+                    item.max_attempts,
+                    item.last_error,
+                ),
+            )
+            connection.commit()
+        return item
+
+    def claim_next_queue_item(self) -> Optional[QueueItem]:
+        connection = self._connect()
+        connection.row_factory = sqlite3.Row
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT * FROM queue_items
+                WHERE status = ?
+                ORDER BY created_at
+                LIMIT 1
+                """,
+                (QueueStatus.QUEUED.value,),
+            ).fetchone()
+            if row is None:
+                connection.commit()
+                return None
+            now = _utc_now().isoformat()
+            updated = connection.execute(
+                """
+                UPDATE queue_items
+                SET status = ?, started_at = ?, updated_at = ?
+                WHERE id = ? AND status = ?
+                """,
+                (
+                    QueueStatus.IN_PROGRESS.value,
+                    now,
+                    now,
+                    row["id"],
+                    QueueStatus.QUEUED.value,
+                ),
+            )
+            if updated.rowcount == 0:
+                connection.commit()
+                return None
+            connection.commit()
+            row = connection.execute(
+                "SELECT * FROM queue_items WHERE id = ?",
+                (row["id"],),
+            ).fetchone()
+            return self._row_to_queue_item(row) if row else None
+        except Exception:  # noqa: BLE001
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+    def mark_queue_item_succeeded(self, item_id: str) -> None:
+        now = _utc_now().isoformat()
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE queue_items
+                SET status = ?, updated_at = ?, finished_at = ?
+                WHERE id = ?
+                """,
+                (QueueStatus.SUCCEEDED.value, now, now, item_id),
+            )
+            connection.commit()
+
+    def mark_queue_item_failed(self, item_id: str, error: str, retryable: bool) -> None:
+        item = self.get_queue_item(item_id)
+        if item is None:
+            return
+        now = _utc_now().isoformat()
+        if retryable and item.attempt_count < item.max_attempts:
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
+                        started_at = NULL
+                    WHERE id = ?
+                    """,
+                    (
+                        QueueStatus.QUEUED.value,
+                        now,
+                        item.attempt_count + 1,
+                        error,
+                        item_id,
+                    ),
+                )
+                connection.commit()
+            return
+        with self._connect() as connection:
+            connection.execute(
+                """
+                UPDATE queue_items
+                SET status = ?, updated_at = ?, finished_at = ?, last_error = ?
+                WHERE id = ?
+                """,
+                (QueueStatus.FAILED.value, now, now, error, item_id),
+            )
+            connection.commit()
+
+    def requeue_stale_in_progress(self, older_than_seconds: int = 600) -> int:
+        threshold = _utc_now().timestamp() - older_than_seconds
+        updated = 0
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM queue_items
+                WHERE status = ? AND started_at IS NOT NULL
+                """,
+                (QueueStatus.IN_PROGRESS.value,),
+            ).fetchall()
+            now = _utc_now().isoformat()
+            for row in rows:
+                started_at = _parse_dt(row["started_at"]).timestamp()
+                if started_at >= threshold:
+                    continue
+                attempt_count = row["attempt_count"]
+                max_attempts = row["max_attempts"]
+                if attempt_count < max_attempts:
+                    connection.execute(
+                        """
+                        UPDATE queue_items
+                        SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
+                            started_at = NULL
+                        WHERE id = ?
+                        """,
+                        (
+                            QueueStatus.QUEUED.value,
+                            now,
+                            attempt_count + 1,
+                            "Requeued stale in-progress item.",
+                            row["id"],
+                        ),
+                    )
+                else:
+                    connection.execute(
+                        """
+                        UPDATE queue_items
+                        SET status = ?, updated_at = ?, finished_at = ?, last_error = ?
+                        WHERE id = ?
+                        """,
+                        (
+                            QueueStatus.FAILED.value,
+                            now,
+                            now,
+                            "Exceeded max attempts after stale in-progress.",
+                            row["id"],
+                        ),
+                    )
+                updated += 1
+            connection.commit()
+        return updated
+
+    def get_queue_item(self, item_id: str) -> Optional[QueueItem]:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT * FROM queue_items WHERE id = ?",
+                (item_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_queue_item(row)
+
     def get_latest_run(self) -> Optional[Run]:
         with self._connect() as connection:
             row = connection.execute(
@@ -424,6 +666,25 @@ class StateStore:
         )
         return tool_call
 
+    def _row_to_queue_item(self, row: sqlite3.Row) -> QueueItem:
+        return QueueItem(
+            id=row["id"],
+            run_id=row["run_id"],
+            command_text=row["command_text"],
+            status=QueueStatus(row["status"]),
+            created_at=_parse_dt(row["created_at"]),
+            updated_at=_parse_dt(row["updated_at"]),
+            started_at=_parse_dt(row["started_at"]) if row["started_at"] else None,
+            finished_at=_parse_dt(row["finished_at"]) if row["finished_at"] else None,
+            attempt_count=row["attempt_count"],
+            max_attempts=row["max_attempts"],
+            last_error=row["last_error"],
+        )
+
 
 def _parse_dt(value: str) -> datetime:
     return datetime.fromisoformat(value)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -28,6 +28,22 @@ class CliMainParserTest(unittest.TestCase):
         self.assertEqual(args.command, "demo")
         self.assertIs(args.handler, cli_main._handle_demo)
 
+    def test_enqueue_subcommand_routes_to_enqueue(self) -> None:
+        parser = cli_main.build_parser()
+        args = parser.parse_args(["enqueue", "echo:", "hello"])
+
+        self.assertEqual(args.command, "enqueue")
+        self.assertIs(args.handler, cli_main._handle_enqueue)
+        self.assertEqual(args.operator_command, ["echo:", "hello"])
+
+    def test_daemon_subcommand_routes_to_daemon(self) -> None:
+        parser = cli_main.build_parser()
+        args = parser.parse_args(["daemon", "--once"])
+
+        self.assertEqual(args.command, "daemon")
+        self.assertIs(args.handler, cli_main._handle_daemon)
+        self.assertTrue(args.once)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_daemon_queue.py
+++ b/tests/test_daemon_queue.py
@@ -1,0 +1,121 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core import daemon as daemon_module
+from gismo.core.models import QueueStatus
+from gismo.core.state import StateStore
+from gismo.core.tools import Tool, ToolRegistry
+
+
+class FlakyEchoTool(Tool):
+    def __init__(self) -> None:
+        super().__init__(name="echo", description="Fails once then succeeds")
+        self.calls = 0
+
+    def run(self, tool_input: dict) -> dict:
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("flaky echo")
+        return {"echo": tool_input}
+
+
+class DaemonQueueTest(unittest.TestCase):
+    def _policy_path(self) -> str:
+        repo_root = Path(__file__).resolve().parents[1]
+        return str(repo_root / "policy" / "readonly.json")
+
+    def test_enqueue_and_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            first = state_store.enqueue_command("echo: first")
+            second = state_store.enqueue_command("echo: second")
+
+            claimed = state_store.claim_next_queue_item()
+            assert claimed is not None
+            self.assertEqual(claimed.id, first.id)
+            self.assertEqual(claimed.status, QueueStatus.IN_PROGRESS)
+
+            claimed_second = state_store.claim_next_queue_item()
+            assert claimed_second is not None
+            self.assertEqual(claimed_second.id, second.id)
+            self.assertEqual(claimed_second.status, QueueStatus.IN_PROGRESS)
+            self.assertIsNone(state_store.claim_next_queue_item())
+
+    def test_daemon_once_executes_one_item(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            item = state_store.enqueue_command("echo: hi")
+
+            daemon_module.run_daemon_loop(
+                state_store,
+                policy_path=self._policy_path(),
+                sleep_seconds=0.0,
+                once=True,
+            )
+
+            updated = state_store.get_queue_item(item.id)
+            assert updated is not None
+            self.assertEqual(updated.status, QueueStatus.SUCCEEDED)
+
+            run = state_store.get_latest_run()
+            assert run is not None
+            self.assertEqual(run.metadata_json["queue_item_id"], item.id)
+            tasks = list(state_store.list_tasks(run.id))
+            tool_calls = list(state_store.list_tool_calls(run.id))
+            self.assertGreaterEqual(len(tasks), 1)
+            self.assertGreaterEqual(len(tool_calls), 1)
+
+    def test_retry_behavior(self) -> None:
+        flaky_tool = FlakyEchoTool()
+
+        def _build_flaky_registry(state_store: StateStore, policy) -> ToolRegistry:
+            registry = ToolRegistry()
+            registry.register(flaky_tool)
+            return registry
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            item = state_store.enqueue_command("echo: retry", max_attempts=3)
+
+            original_factory = daemon_module.build_registry
+            try:
+                daemon_module.build_registry = _build_flaky_registry
+                daemon_module.run_daemon_loop(
+                    state_store,
+                    policy_path=self._policy_path(),
+                    sleep_seconds=0.0,
+                    once=True,
+                )
+            finally:
+                daemon_module.build_registry = original_factory
+
+            updated = state_store.get_queue_item(item.id)
+            assert updated is not None
+            self.assertEqual(updated.status, QueueStatus.SUCCEEDED)
+            self.assertEqual(updated.attempt_count, 1)
+
+    def test_non_retryable_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            item = state_store.enqueue_command("note: forbidden")
+
+            daemon_module.run_daemon_loop(
+                state_store,
+                policy_path=self._policy_path(),
+                sleep_seconds=0.0,
+                once=True,
+            )
+
+            updated = state_store.get_queue_item(item.id)
+            assert updated is not None
+            self.assertEqual(updated.status, QueueStatus.FAILED)
+            self.assertEqual(updated.attempt_count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Allow GISMO to run headless and process operator commands reliably from a persistent queue.  
- Provide restart-safe, retryable execution that preserves audit trails, idempotency, and existing permission gating.  
- Keep changes additive and minimal while enabling a simple home-server daemon workflow.  
- Ensure queued items are not lost and stale in-progress items are recoverable deterministically.

### Description
- Added a `QueueItem` dataclass and `QueueStatus` enum and created a `queue_items` table in `gismo/core/state.py` with migration-safe `_ensure_columns` handling.  
- Implemented queue APIs on `StateStore`: `enqueue_command`, `claim_next_queue_item`, `mark_queue_item_succeeded`, `mark_queue_item_failed`, `get_queue_item`, and `requeue_stale_in_progress`.  
- Added `gismo/core/daemon.py` implementing `run_daemon_loop` to claim items, create runs/tasks, execute via existing `Orchestrator`/agent flow, and classify retryable vs non-retryable failures.  
- Exposed CLI commands in `gismo/cli/main.py`: `enqueue` and `daemon` (with `--once`, `--sleep`, and `--requeue-stale-seconds`), added tests in `tests/test_daemon_queue.py`, and updated `README.md` and `Handoff.md`; note risk: command-level retries re-run the command end-to-end and policy scope remains enforced.

### Testing
- Ran full verification with `python scripts/verify.py`, which executed the unit test suite and passed.  
- Added and ran `tests/test_daemon_queue.py` covering enqueue/claim, one-shot execution, retry behavior, and non-retryable failure handling (all tests passed).  
- Performed manual smoke commands: `python -m gismo.cli.main enqueue "echo: daemon smoke"` followed by `python -m gismo.cli.main daemon --once --policy policy/readonly.json` to validate end-to-end behavior.  
- Note: CI/local verification confirmed the new queue table migration, daemon loop behavior, and that policies continue to enforce least-privilege tool access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1b7940cc83308ecd4b9ab9744f9a)