### PR TITLE
Add systemd service templates and configurable DB path for daemon

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -21,6 +21,7 @@
 - Wired CLI subcommand handlers for demo, run, and export with parser routing tests.
 - Added SQLite-backed queue with daemon execution loop and CLI enqueue/daemon commands.
 - Added daemon queue tests for enqueue/claim, execution, retries, and non-retryable failures.
+- Added systemd service templates plus documentation and CLI support for consistent DB paths via --db.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -32,8 +33,8 @@
 
 ## Tests
 - `python scripts/verify.py`
-- `python -m gismo.cli.main enqueue "echo: daemon smoke"`
-- `python -m gismo.cli.main daemon --once --policy policy/readonly.json`
+- `python -m gismo.cli.main enqueue "echo: systemd smoke" --db /tmp/gismo_test.db`
+- `python -m gismo.cli.main daemon --once --policy policy/readonly.json --db /tmp/gismo_test.db`
 
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ python -m gismo.cli.main run --policy policy/dev.json "echo: hello"
 Daemon mode (queue + headless execution):
 
 ```bash
-python -m gismo.cli.main enqueue "echo: daemon hello"
-python -m gismo.cli.main daemon --once --policy policy/readonly.json
+python -m gismo.cli.main enqueue "echo: daemon hello" --db .gismo/state.db
+python -m gismo.cli.main daemon --once --policy policy/readonly.json --db .gismo/state.db
 ```
 
 Export a run audit trail as JSONL:
@@ -244,11 +244,15 @@ GISMO supports deterministic operator-like commands that map to tasks and tools.
 Queue commands for headless execution and run the daemon to process them:
 
 ```bash
-python -m gismo.cli.main enqueue "echo: daemon hello"
-python -m gismo.cli.main daemon --once --policy policy/readonly.json
+python -m gismo.cli.main enqueue "echo: daemon hello" --db /var/lib/gismo/gismo.db
+python -m gismo.cli.main daemon --once --policy policy/readonly.json --db /var/lib/gismo/gismo.db
 ```
 
 Daemon runs always enforce policies; keep policies least-privilege and explicitly allow only the tools you need.
+
+## Run as a service (systemd)
+
+See [deploy/systemd/README.md](deploy/systemd/README.md) for production-safe systemd units, hardening defaults, and steps to install a dedicated service user with a stable database path.
 
 ## Toolpack Policy & Safety
 

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,100 @@
+# GISMO systemd service
+
+This directory provides production-safe systemd units for running the GISMO daemon on a Linux host.
+The units assume a dedicated service user and a read-only policy by default.
+
+## 1) Create the service user/group
+
+```bash
+sudo useradd --system --user-group --home /opt/gismo --shell /usr/sbin/nologin gismo
+```
+
+## 2) Install GISMO under /opt/gismo
+
+```bash
+sudo mkdir -p /opt/gismo
+sudo rsync -a --delete /path/to/GISMO/ /opt/gismo/
+```
+
+Alternatively, clone directly:
+
+```bash
+sudo git clone https://example.com/GISMO.git /opt/gismo
+```
+
+## 3) Prepare the state directory
+
+The service writes its SQLite state database under `/var/lib/gismo`.
+
+```bash
+sudo mkdir -p /var/lib/gismo
+sudo chown gismo:gismo /var/lib/gismo
+sudo chmod 0750 /var/lib/gismo
+```
+
+## 4) Install the unit file
+
+```bash
+sudo cp /opt/gismo/deploy/systemd/gismo.service /etc/systemd/system/
+sudo systemctl daemon-reload
+```
+
+Optionally configure overrides via `/etc/gismo/gismo.env` (see below).
+
+## 5) Enable and start
+
+```bash
+sudo systemctl enable --now gismo.service
+```
+
+## 6) Logs
+
+```bash
+journalctl -u gismo -f
+```
+
+## 7) Template instance (optional)
+
+The template unit lets you run isolated instances that map to policy files and DB paths:
+
+```bash
+sudo cp /opt/gismo/deploy/systemd/gismo@.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now gismo@dev-safe.service
+```
+
+This starts the daemon with:
+
+- Policy: `/opt/gismo/policy/dev-safe.json`
+- Database: `/var/lib/gismo/gismo-dev-safe.db`
+
+## 8) Enqueue work against the same database
+
+Use the same DB path the daemon is configured with:
+
+```bash
+/usr/bin/python3 -m gismo.cli.main enqueue "echo: hi" --db /var/lib/gismo/gismo.db
+```
+
+For the templated instance:
+
+```bash
+/usr/bin/python3 -m gismo.cli.main enqueue "echo: hi" --db /var/lib/gismo/gismo-dev-safe.db
+```
+
+## 9) Optional environment overrides
+
+The unit reads `/etc/gismo/gismo.env` if present. Override values like:
+
+```bash
+GISMO_DB_PATH=/var/lib/gismo/gismo.db
+GISMO_POLICY_PATH=/opt/gismo/policy/readonly.json
+GISMO_SLEEP_SECONDS=2.0
+```
+
+Apply changes with:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart gismo.service
+```

--- a/deploy/systemd/gismo.service
+++ b/deploy/systemd/gismo.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=GISMO daemon
+After=network.target
+
+[Service]
+Type=simple
+User=gismo
+Group=gismo
+WorkingDirectory=/opt/gismo
+Environment=GISMO_DB_PATH=/var/lib/gismo/gismo.db
+Environment=GISMO_POLICY_PATH=/opt/gismo/policy/readonly.json
+Environment=GISMO_SLEEP_SECONDS=2.0
+EnvironmentFile=-/etc/gismo/gismo.env
+ExecStart=/usr/bin/python3 -m gismo.cli.main daemon --policy ${GISMO_POLICY_PATH} --db ${GISMO_DB_PATH} --sleep ${GISMO_SLEEP_SECONDS}
+Restart=on-failure
+RestartSec=2
+StateDirectory=gismo
+StateDirectoryMode=0750
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/gismo
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+CapabilityBoundingSet=
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/gismo@.service
+++ b/deploy/systemd/gismo@.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=GISMO daemon (%i)
+After=network.target
+
+[Service]
+Type=simple
+User=gismo
+Group=gismo
+WorkingDirectory=/opt/gismo
+Environment=GISMO_DB_PATH=/var/lib/gismo/gismo-%i.db
+Environment=GISMO_POLICY_PATH=/opt/gismo/policy/%i.json
+Environment=GISMO_SLEEP_SECONDS=2.0
+EnvironmentFile=-/etc/gismo/gismo.env
+ExecStart=/usr/bin/python3 -m gismo.cli.main daemon --policy ${GISMO_POLICY_PATH} --db ${GISMO_DB_PATH} --sleep ${GISMO_SLEEP_SECONDS}
+Restart=on-failure
+RestartSec=2
+StateDirectory=gismo
+StateDirectoryMode=0750
+
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/gismo
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+CapabilityBoundingSet=
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -347,12 +347,19 @@ def _handle_daemon(args: argparse.Namespace) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="GISMO CLI")
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    demo_parser = subparsers.add_parser("demo", help="Run the demo workflow")
-    demo_parser.add_argument(
+    db_parent = argparse.ArgumentParser(add_help=False)
+    db_parent.add_argument(
+        "--db",
         "--db-path",
+        dest="db_path",
         default=str(Path(".gismo") / "state.db"),
         help="Path to SQLite state database",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    demo_parser = subparsers.add_parser(
+        "demo",
+        help="Run the demo workflow",
+        parents=[db_parent],
     )
     demo_parser.add_argument(
         "--policy",
@@ -360,11 +367,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a JSON policy file",
     )
     demo_parser.set_defaults(handler=_handle_demo)
-    demo_graph_parser = subparsers.add_parser("demo-graph", help="Run the task graph demo")
-    demo_graph_parser.add_argument(
-        "--db-path",
-        default=str(Path(".gismo") / "state.db"),
-        help="Path to SQLite state database",
+    demo_graph_parser = subparsers.add_parser(
+        "demo-graph",
+        help="Run the task graph demo",
+        parents=[db_parent],
     )
     demo_graph_parser.add_argument(
         "--policy",
@@ -372,11 +378,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a JSON policy file",
     )
     demo_graph_parser.set_defaults(handler=_handle_demo_graph)
-    run_parser = subparsers.add_parser("run", help="Run an operator command")
-    run_parser.add_argument(
-        "--db-path",
-        default=str(Path(".gismo") / "state.db"),
-        help="Path to SQLite state database",
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run an operator command",
+        parents=[db_parent],
     )
     run_parser.add_argument(
         "--policy",
@@ -389,11 +394,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Operator command string (echo:, note:, or graph:)",
     )
     run_parser.set_defaults(handler=_handle_run)
-    export_parser = subparsers.add_parser("export", help="Export run audit trail")
-    export_parser.add_argument(
-        "--db-path",
-        default=str(Path(".gismo") / "state.db"),
-        help="Path to SQLite state database",
+    export_parser = subparsers.add_parser(
+        "export",
+        help="Export run audit trail",
+        parents=[db_parent],
     )
     export_parser.add_argument(
         "--policy",
@@ -427,11 +431,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Redact file contents, shell output, and large tool outputs",
     )
     export_parser.set_defaults(handler=_handle_export)
-    enqueue_parser = subparsers.add_parser("enqueue", help="Enqueue an operator command")
-    enqueue_parser.add_argument(
-        "--db-path",
-        default=str(Path(".gismo") / "state.db"),
-        help="Path to SQLite state database",
+    enqueue_parser = subparsers.add_parser(
+        "enqueue",
+        help="Enqueue an operator command",
+        parents=[db_parent],
     )
     enqueue_parser.add_argument(
         "--run",
@@ -451,11 +454,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Operator command string to enqueue",
     )
     enqueue_parser.set_defaults(handler=_handle_enqueue)
-    daemon_parser = subparsers.add_parser("daemon", help="Run the GISMO daemon loop")
-    daemon_parser.add_argument(
-        "--db-path",
-        default=str(Path(".gismo") / "state.db"),
-        help="Path to SQLite state database",
+    daemon_parser = subparsers.add_parser(
+        "daemon",
+        help="Run the GISMO daemon loop",
+        parents=[db_parent],
     )
     daemon_parser.add_argument(
         "--policy",

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,6 +1,10 @@
+import tempfile
 import unittest
+from pathlib import Path
 
 from gismo.cli import main as cli_main
+from gismo.core.models import QueueStatus
+from gismo.core.state import StateStore
 
 
 class CliMainParserTest(unittest.TestCase):
@@ -43,6 +47,29 @@ class CliMainParserTest(unittest.TestCase):
         self.assertEqual(args.command, "daemon")
         self.assertIs(args.handler, cli_main._handle_daemon)
         self.assertTrue(args.once)
+
+    def test_enqueue_and_daemon_share_db_path(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        policy_path = str(repo_root / "policy" / "readonly.json")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+
+            cli_main.run_enqueue(db_path, "echo: systemd", run_id=None, max_attempts=1)
+            cli_main.run_daemon(
+                db_path,
+                policy_path,
+                sleep_seconds=0.0,
+                once=True,
+                requeue_stale_seconds=600,
+            )
+
+            state_store = StateStore(db_path)
+            run = state_store.get_latest_run()
+            assert run is not None
+            queue_item_id = run.metadata_json["queue_item_id"]
+            item = state_store.get_queue_item(queue_item_id)
+            assert item is not None
+            self.assertEqual(item.status, QueueStatus.SUCCEEDED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Enable running GISMO as a systemd-managed daemon with auto-start and restart-on-failure behavior for home servers.
- Ensure the daemon runs with least privilege and a deterministic, non-ephemeral state location so CLI and service share the same SQLite DB.
- Provide safe, read-only policy defaults and clear override paths for operators installing GISMO as a service.

### Description
- Added `deploy/systemd/gismo.service`, `deploy/systemd/gismo@.service`, and `deploy/systemd/README.md` containing production-safe unit templates, hardening defaults, and install instructions.
- Introduced a global `--db`/`--db-path` CLI option in `gismo.cli.main` (used by `enqueue`, `daemon`, `run`, `export`, and demo commands) so all CLI actions can target the same SQLite DB path.
- Updated `README.md` and `Handoff.md` with systemd guidance and added a unit test `test_enqueue_and_daemon_share_db_path` to verify enqueue and daemon share the same DB; kept changes minimal and Python-only.
- Risk: the units assume installation at `/opt/gismo` and state under `/var/lib/gismo`, and `ProtectSystem=strict` (and related hardening) may need relaxation for custom deployments that require additional write access.

### Testing
- Ran `python scripts/verify.py` which executed the full test suite and completed successfully (`OK`).
- Ran `python -m gismo.cli.main enqueue "echo: systemd smoke" --db /tmp/gismo_test.db` and observed an `Enqueued` ID as expected.
- Ran `python -m gismo.cli.main daemon --once --policy policy/readonly.json --db /tmp/gismo_test.db` which processed the queued item and completed successfully.
- The added unit test (`tests.test_cli_main.CliMainParserTest.test_enqueue_and_daemon_share_db_path`) passed as part of verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c1e1022e883309c42a566adb41d12)