### PR TITLE
Fix Windows queue CLI parsing and SQLite cleanup

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -22,6 +22,8 @@
 - Added SQLite-backed queue with daemon execution loop and CLI enqueue/daemon commands.
 - Added daemon queue tests for enqueue/claim, execution, retries, and non-retryable failures.
 - Added systemd service templates plus documentation and CLI support for consistent DB paths via --db.
+- Closed SQLite connections deterministically and fixed queue CLI db flag parsing for Windows.
+- Adjusted shell tool execution to support Windows built-in commands via cmd.exe.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -33,8 +35,6 @@
 
 ## Tests
 - `python scripts/verify.py`
-- `python -m gismo.cli.main enqueue "echo: systemd smoke" --db /tmp/gismo_test.db`
-- `python -m gismo.cli.main daemon --once --policy policy/readonly.json --db /tmp/gismo_test.db`
 
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ python -m gismo.cli.main enqueue "echo: daemon hello" --db .gismo/state.db
 python -m gismo.cli.main daemon --once --policy policy/readonly.json --db .gismo/state.db
 ```
 
+Inspect queue items (DB flag can be supplied before or after the queue subcommand):
+
+```bash
+python -m gismo.cli.main queue stats --db .gismo/state.db
+python -m gismo.cli.main queue list --db .gismo/state.db --limit 10 --json
+python -m gismo.cli.main queue show --db .gismo/state.db <QUEUE_ITEM_ID>
+```
+
 Export a run audit trail as JSONL:
 
 ```bash

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -656,6 +656,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_stats_parser = queue_subparsers.add_parser(
         "stats",
         help="Show queue summary statistics",
+        parents=[db_parent],
     )
     queue_stats_parser.add_argument(
         "--json",
@@ -667,6 +668,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_list_parser = queue_subparsers.add_parser(
         "list",
         help="List queue items",
+        parents=[db_parent],
     )
     queue_list_parser.add_argument(
         "--limit",
@@ -699,6 +701,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_show_parser = queue_subparsers.add_parser(
         "show",
         help="Show a single queue item by id",
+        parents=[db_parent],
     )
     queue_show_parser.add_argument("id", help="Queue item id")
     queue_show_parser.add_argument(

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -30,9 +30,17 @@ class StateStore:
         connection.row_factory = sqlite3.Row
         return connection
 
+    @contextmanager
+    def _connection(self) -> Iterable[sqlite3.Connection]:
+        connection = self._connect()
+        try:
+            yield connection
+        finally:
+            connection.close()
+
     def _init_db(self) -> None:
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
-        with self._connect() as connection:
+        with self._connection() as connection:
             cursor = connection.cursor()
             cursor.execute(
                 """
@@ -184,7 +192,7 @@ class StateStore:
 
     def create_run(self, label: str, metadata: Optional[Dict[str, Any]] = None) -> Run:
         run = Run(label=label, metadata_json=metadata or {})
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 "INSERT INTO runs (id, created_at, label, metadata_json) VALUES (?, ?, ?, ?)",
                 (
@@ -216,7 +224,7 @@ class StateStore:
             idempotency_key=idempotency_key,
             input_hash=input_hash,
         )
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 INSERT INTO tasks (
@@ -249,7 +257,7 @@ class StateStore:
 
     def update_task(self, task: Task, connection: Optional[sqlite3.Connection] = None) -> None:
         if connection is None:
-            with self._connect() as connection:
+            with self._connection() as connection:
                 self.update_task(task, connection=connection)
                 connection.commit()
                 return
@@ -281,7 +289,7 @@ class StateStore:
         connection: Optional[sqlite3.Connection] = None,
     ) -> None:
         if connection is None:
-            with self._connect() as connection:
+            with self._connection() as connection:
                 self.record_tool_call(tool_call, connection=connection)
                 connection.commit()
                 return
@@ -314,7 +322,7 @@ class StateStore:
         connection: Optional[sqlite3.Connection] = None,
     ) -> None:
         if connection is None:
-            with self._connect() as connection:
+            with self._connection() as connection:
                 self.update_tool_call(tool_call, connection=connection)
                 connection.commit()
                 return
@@ -335,7 +343,7 @@ class StateStore:
         )
 
     def list_tasks(self, run_id: str) -> Iterable[Task]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT * FROM tasks WHERE run_id = ? ORDER BY created_at",
                 (run_id,),
@@ -346,7 +354,7 @@ class StateStore:
         if not task_ids:
             return []
         placeholders = ",".join("?" for _ in task_ids)
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 f"SELECT * FROM tasks WHERE id IN ({placeholders})",
                 tuple(task_ids),
@@ -354,7 +362,7 @@ class StateStore:
         return [self._row_to_task(row) for row in rows]
 
     def list_tool_calls(self, run_id: str) -> Iterable[ToolCall]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT * FROM tool_calls WHERE run_id = ? ORDER BY started_at",
                 (run_id,),
@@ -362,7 +370,7 @@ class StateStore:
         return [self._row_to_tool_call(row) for row in rows]
 
     def list_tool_calls_for_task(self, task_id: str) -> Iterable[ToolCall]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT * FROM tool_calls WHERE task_id = ? ORDER BY started_at",
                 (task_id,),
@@ -370,7 +378,7 @@ class StateStore:
         return [self._row_to_tool_call(row) for row in rows]
 
     def get_run(self, run_id: str) -> Optional[Run]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT * FROM runs WHERE id = ?",
                 (run_id,),
@@ -392,7 +400,7 @@ class StateStore:
             run_id=run_id,
             max_attempts=max_attempts,
         )
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 INSERT INTO queue_items (
@@ -466,7 +474,7 @@ class StateStore:
 
     def mark_queue_item_succeeded(self, item_id: str) -> None:
         now = _utc_now().isoformat()
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 UPDATE queue_items
@@ -483,7 +491,7 @@ class StateStore:
             return
         now = _utc_now().isoformat()
         if retryable and item.attempt_count < item.max_attempts:
-            with self._connect() as connection:
+            with self._connection() as connection:
                 connection.execute(
                     """
                     UPDATE queue_items
@@ -501,7 +509,7 @@ class StateStore:
                 )
                 connection.commit()
             return
-        with self._connect() as connection:
+        with self._connection() as connection:
             connection.execute(
                 """
                 UPDATE queue_items
@@ -515,7 +523,7 @@ class StateStore:
     def requeue_stale_in_progress(self, older_than_seconds: int = 600) -> int:
         threshold = _utc_now().timestamp() - older_than_seconds
         updated = 0
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 """
                 SELECT * FROM queue_items
@@ -566,7 +574,7 @@ class StateStore:
         return updated
 
     def get_queue_item(self, item_id: str) -> Optional[QueueItem]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT * FROM queue_items WHERE id = ?",
                 (item_id,),
@@ -585,7 +593,7 @@ class StateStore:
         if not value:
             return []
 
-        with self._connect() as connection:
+        with self._connection() as connection:
             exact = connection.execute(
                 "SELECT id FROM queue_items WHERE id = ?",
                 (value,),
@@ -602,7 +610,7 @@ class StateStore:
 
     def queue_stats(self) -> Dict[str, Any]:
         """Return summary statistics for queue_items."""
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT status, COUNT(*) AS count FROM queue_items GROUP BY status"
             ).fetchall()
@@ -682,12 +690,12 @@ class StateStore:
             ORDER BY created_at {order}
             LIMIT ?
         """
-        with self._connect() as connection:
+        with self._connection() as connection:
             rows = connection.execute(sql, (*params, limit)).fetchall()
         return [self._row_to_queue_item(row) for row in rows]
 
     def get_latest_run(self) -> Optional[Run]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT * FROM runs ORDER BY created_at DESC LIMIT 1",
             ).fetchone()
@@ -702,7 +710,7 @@ class StateStore:
     ) -> Optional[Task]:
         if not idempotency_key:
             return None
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 """
                 SELECT * FROM tasks
@@ -717,7 +725,7 @@ class StateStore:
         return self._row_to_task(row)
 
     def get_task(self, task_id: str) -> Optional[Task]:
-        with self._connect() as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT * FROM tasks WHERE id = ?",
                 (task_id,),

--- a/gismo/core/toolpacks/shell_tool.py
+++ b/gismo/core/toolpacks/shell_tool.py
@@ -1,6 +1,7 @@
 """Restricted shell tool for safe local execution."""
 from __future__ import annotations
 
+import os
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -46,8 +47,12 @@ class ShellTool(Tool):
         else:
             cwd = resolve_within_base(self._config.base_dir, cwd_input)
 
+        run_command = command
+        if os.name == "nt":
+            run_command = ["cmd", "/c", *command]
+
         result = subprocess.run(
-            command,
+            run_command,
             cwd=str(cwd),
             capture_output=True,
             text=True,


### PR DESCRIPTION
### Motivation
- Windows tests were failing due to `argparse` rejecting `--db` when placed after `queue <subcommand>`, SQLite file locks from lingering connections, and shell commands like `echo` being cmd.exe builtins on Windows.
- The CLI must accept `--db` either before or after `queue` subcommands without changing behavior elsewhere.
- SQLite connections must be deterministically closed to avoid WinError 32 on TemporaryDirectory cleanup.
- Allowlisted shell commands that are shell builtins must run on Windows while preserving allowlist checks.

### Description
- Updated CLI parser so `queue` subcommands `stats`, `list`, and `show` accept the `--db/--db-path` parent option (keeps top-level usage unchanged). 
- Added a dedicated `_connection` context manager in `StateStore` and switched call sites to use it so all SQLite connections are closed reliably. 
- Modified `ShellTool` to run allowlisted commands through `cmd /c` on Windows (`os.name == 'nt'`) while preserving the strict allowlist check. 
- Documentation updates: added brief examples for queue inspection in `README.md` and noted the fixes in `Handoff.md`.

### Testing
- Ran the repository verification suite with `python scripts/verify.py` and it completed successfully (all tests passed). 
- The change was validated by the test-suite that exercises CLI enqueue/queue/show/list behavior and the shell tool tests. 
- As an alternative verification, run `python -m unittest discover -s tests -p "test*.py" -v` to reproduce test runs locally. 
- Manual CLI spot-checks used commands like `python -m gismo.cli.main queue stats --db <path>` and `python -m gismo.cli.main enqueue --db <path> "echo: hello"` to confirm behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4ef240688330b949f06e78e8bfb3)