### PR TITLE
Add Windows Task Scheduler install/uninstall for daemon and graceful shutdown

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -27,6 +27,7 @@
 - Added CLI run show summaries with task/tool call output details for operator introspection.
 - Added queue purge-failed CLI command with dry-run confirmation and enriched queue list columns.
 - Added tests covering run show output and purge-failed safety behavior.
+- Added daemon shutdown signal handling and Windows Task Scheduler install/uninstall CLI helpers.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -36,9 +37,12 @@
 - Add policy-driven examples for operator tasks using the new toolpack.
 - Extend daemon workflows with observability metrics and backoff tuning.
 - Consider additional CLI filters for run/task search and failure triage.
+- Add Windows-specific operational playbooks for Task Scheduler maintenance.
 
 ## Tests
 - `python scripts/verify.py`
 
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.
+- Windows daemon task install: `python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db`
+- Windows daemon task uninstall: `python -m gismo.cli.main daemon uninstall-windows-task --name "GISMO Daemon" --yes`

--- a/README.md
+++ b/README.md
@@ -178,6 +178,19 @@ python -m gismo.cli.main enqueue "echo: daemon hello" --db .gismo/state.db
 python -m gismo.cli.main daemon --once --policy policy/readonly.json --db .gismo/state.db
 ```
 
+Install the Windows Task Scheduler entry for an always-on daemon:
+
+```bash
+python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db
+python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db --name "GISMO Daemon" --force
+```
+
+Remove the Windows Task Scheduler entry:
+
+```bash
+python -m gismo.cli.main daemon uninstall-windows-task --name "GISMO Daemon" --yes
+```
+
 Inspect queue items (DB flag can be supplied before or after the queue subcommand):
 
 ```bash

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -13,6 +13,7 @@ from gismo.cli.operator import (
     parse_command,
     required_tools,
 )
+from gismo.cli.windows_tasks import WindowsTaskConfig, install_windows_task, uninstall_windows_task
 from gismo.core.agent import SimpleAgent
 from gismo.core.daemon import run_daemon_loop
 from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
@@ -33,6 +34,7 @@ def _truncate(text: str, max_len: int) -> str:
     if len(text) <= max_len:
         return text
     return text[: max(0, max_len - 1)] + "…"
+
 
 def _summarize_value(value: object, max_len: int) -> str:
     if value is None:
@@ -362,6 +364,31 @@ def run_daemon(
     )
 
 
+def run_daemon_install_windows_task(
+    name: str,
+    db_path: str,
+    python_exe: str,
+    user: str | None,
+    force: bool,
+) -> None:
+    config = WindowsTaskConfig(
+        name=name,
+        db_path=db_path,
+        python_exe=python_exe,
+        user=user,
+        force=force,
+    )
+    install_windows_task(config)
+
+
+def run_daemon_uninstall_windows_task(name: str, *, yes: bool) -> None:
+    if not yes:
+        print(f"Dry run: would remove task \"{name}\".")
+        print("Re-run with --yes to confirm removal.")
+        return
+    uninstall_windows_task(name)
+
+
 def _print_operator_summary(state_store: StateStore, run_id: str) -> None:
     print("=== GISMO Operator Summary ===")
     print(f"Run: {run_id}")
@@ -442,6 +469,20 @@ def _handle_daemon(args: argparse.Namespace) -> None:
         once=args.once,
         requeue_stale_seconds=args.requeue_stale_seconds,
     )
+
+
+def _handle_daemon_install_windows_task(args: argparse.Namespace) -> None:
+    run_daemon_install_windows_task(
+        name=args.name,
+        db_path=args.db_path,
+        python_exe=args.python,
+        user=args.user,
+        force=args.force,
+    )
+
+
+def _handle_daemon_uninstall_windows_task(args: argparse.Namespace) -> None:
+    run_daemon_uninstall_windows_task(args.name, yes=args.yes)
 
 
 def _handle_queue_stats(args: argparse.Namespace) -> None:
@@ -762,6 +803,48 @@ def build_parser() -> argparse.ArgumentParser:
         help="Requeue IN_PROGRESS items older than this many seconds",
     )
     daemon_parser.set_defaults(handler=_handle_daemon)
+    daemon_subparsers = daemon_parser.add_subparsers(dest="daemon_command")
+    daemon_install_parser = daemon_subparsers.add_parser(
+        "install-windows-task",
+        help="Install a Windows Task Scheduler entry for the daemon",
+        parents=[db_parent],
+    )
+    daemon_install_parser.add_argument(
+        "--name",
+        default="GISMO Daemon",
+        help="Task Scheduler task name",
+    )
+    daemon_install_parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable to run the daemon",
+    )
+    daemon_install_parser.add_argument(
+        "--user",
+        default=None,
+        help="Optional Windows username for the task (defaults to current user)",
+    )
+    daemon_install_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite task if it already exists",
+    )
+    daemon_install_parser.set_defaults(handler=_handle_daemon_install_windows_task)
+    daemon_uninstall_parser = daemon_subparsers.add_parser(
+        "uninstall-windows-task",
+        help="Remove the Windows Task Scheduler entry for the daemon",
+    )
+    daemon_uninstall_parser.add_argument(
+        "--name",
+        default="GISMO Daemon",
+        help="Task Scheduler task name",
+    )
+    daemon_uninstall_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm removal (required to delete the task)",
+    )
+    daemon_uninstall_parser.set_defaults(handler=_handle_daemon_uninstall_windows_task)
 
     queue_parser = subparsers.add_parser(
         "queue",

--- a/gismo/cli/windows_tasks.py
+++ b/gismo/cli/windows_tasks.py
@@ -1,0 +1,162 @@
+"""Windows Task Scheduler helpers for GISMO daemon."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import getpass
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Iterable
+from xml.sax.saxutils import escape
+
+
+@dataclass(frozen=True)
+class WindowsTaskConfig:
+    name: str
+    db_path: str
+    python_exe: str
+    user: str | None = None
+    force: bool = False
+
+
+def build_daemon_command(python_exe: str, db_path: str) -> list[str]:
+    return [python_exe, "-m", "gismo.cli.main", "daemon", "--db", db_path]
+
+
+def build_schtasks_create_args(task_name: str, xml_path: str, force: bool) -> list[str]:
+    args = ["schtasks.exe", "/Create", "/TN", task_name, "/XML", xml_path]
+    if force:
+        args.append("/F")
+    return args
+
+
+def build_schtasks_delete_args(task_name: str) -> list[str]:
+    return ["schtasks.exe", "/Delete", "/TN", task_name, "/F"]
+
+
+def install_windows_task(config: WindowsTaskConfig) -> None:
+    _ensure_windows()
+    command = build_daemon_command(config.python_exe, config.db_path)
+    task_user = _resolve_task_user(config.user)
+    task_xml = build_task_xml(command, task_user)
+    removal = build_schtasks_delete_args(config.name)
+    print(f"Task command: {_format_command(command)}")
+    print(f"Remove with: {_format_command(removal)}")
+    _run_schtasks_create(config, task_xml)
+
+
+def uninstall_windows_task(task_name: str) -> None:
+    _ensure_windows()
+    args = build_schtasks_delete_args(task_name)
+    subprocess.run(args, check=True)
+
+
+def build_task_xml(command: list[str], user: str) -> str:
+    command_path, arguments = _split_exec_command(command)
+    now = datetime.now(timezone.utc).isoformat()
+    return f"""<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Date>{escape(now)}</Date>
+    <Author>GISMO</Author>
+  </RegistrationInfo>
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>{escape(user)}</UserId>
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Priority>7</Priority>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>999</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>{escape(command_path)}</Command>
+      <Arguments>{escape(arguments)}</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"""
+
+
+def _ensure_windows() -> None:
+    if os.name != "nt":
+        raise RuntimeError("Windows Task Scheduler commands are only supported on Windows.")
+
+
+def _resolve_task_user(user: str | None) -> str:
+    if user:
+        return user
+    username = os.environ.get("USERNAME") or getpass.getuser()
+    domain = os.environ.get("USERDOMAIN")
+    if domain:
+        return f"{domain}\\{username}"
+    return username
+
+
+def _run_schtasks_create(config: WindowsTaskConfig, task_xml: str) -> None:
+    xml_path = _write_task_xml(task_xml, Path(config.db_path))
+    try:
+        args = build_schtasks_create_args(config.name, str(xml_path), config.force)
+        subprocess.run(args, check=True)
+    finally:
+        xml_path.unlink(missing_ok=True)
+
+
+def _write_task_xml(task_xml: str, db_path: Path) -> Path:
+    directory = db_path.parent if db_path.parent.exists() else Path(".")
+    with tempfile.NamedTemporaryFile("w", encoding="utf-16", delete=False, dir=directory, suffix=".xml") as handle:
+        handle.write(task_xml)
+        return Path(handle.name)
+
+
+def _split_exec_command(command: list[str]) -> tuple[str, str]:
+    if not command:
+        raise ValueError("Command cannot be empty")
+    command_path = command[0]
+    arguments = " ".join(_quote_windows_arg(arg) for arg in command[1:])
+    return command_path, arguments
+
+
+def _quote_windows_arg(value: str) -> str:
+    if not value:
+        return "\"\""
+    if any(ch in value for ch in (" ", "\t", "\"")):
+        escaped = value.replace("\"", "\\\"")
+        return f"\"{escaped}\""
+    return value
+
+
+def _format_command(args: Iterable[str]) -> str:
+    return " ".join(_quote_windows_arg(arg) for arg in args)

--- a/gismo/core/daemon.py
+++ b/gismo/core/daemon.py
@@ -1,8 +1,10 @@
 """Daemon loop for executing queued operator commands."""
 from __future__ import annotations
 
+import signal
 import sqlite3
 import time
+import threading
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -27,12 +29,14 @@ def run_daemon_loop(
     once: bool,
 ) -> None:
     repo_root = Path(__file__).resolve().parents[2]
-    while True:
+    stop_event = threading.Event()
+    _register_shutdown_handlers(stop_event)
+    while not stop_event.is_set():
         item = state.claim_next_queue_item()
         if item is None:
             if once:
                 return
-            time.sleep(sleep_seconds)
+            stop_event.wait(sleep_seconds)
             continue
         _execute_queue_item(state, item, policy_path, repo_root)
 
@@ -184,3 +188,19 @@ def build_registry(state_store: StateStore, policy: PermissionPolicy) -> ToolReg
     )
     registry.register(ShellTool(shell_config))
     return registry
+
+
+def _register_shutdown_handlers(stop_event: threading.Event) -> None:
+    if threading.current_thread() is not threading.main_thread():
+        return
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        stop_event.set()
+        signal_name = getattr(signal.Signals(signum), "name", str(signum))
+        print(f"Daemon shutdown requested ({signal_name}).", flush=True)
+
+    for signal_name in ("SIGINT", "SIGTERM"):
+        sig = getattr(signal, signal_name, None)
+        if sig is None:
+            continue
+        signal.signal(sig, _handle_signal)

--- a/tests/test_windows_tasks.py
+++ b/tests/test_windows_tasks.py
@@ -1,0 +1,46 @@
+import unittest
+
+from gismo.cli import windows_tasks
+
+
+class WindowsTasksCommandTest(unittest.TestCase):
+    def test_build_daemon_command(self) -> None:
+        command = windows_tasks.build_daemon_command("py.exe", "state.db")
+        self.assertEqual(
+            command,
+            ["py.exe", "-m", "gismo.cli.main", "daemon", "--db", "state.db"],
+        )
+
+    def test_build_schtasks_create_args(self) -> None:
+        args = windows_tasks.build_schtasks_create_args("GISMO Daemon", "task.xml", False)
+        self.assertEqual(
+            args,
+            ["schtasks.exe", "/Create", "/TN", "GISMO Daemon", "/XML", "task.xml"],
+        )
+
+    def test_build_schtasks_create_args_with_force(self) -> None:
+        args = windows_tasks.build_schtasks_create_args("GISMO Daemon", "task.xml", True)
+        self.assertEqual(
+            args,
+            ["schtasks.exe", "/Create", "/TN", "GISMO Daemon", "/XML", "task.xml", "/F"],
+        )
+
+    def test_build_schtasks_delete_args(self) -> None:
+        args = windows_tasks.build_schtasks_delete_args("GISMO Daemon")
+        self.assertEqual(
+            args,
+            ["schtasks.exe", "/Delete", "/TN", "GISMO Daemon", "/F"],
+        )
+
+    def test_build_task_xml_includes_triggers_and_restart(self) -> None:
+        command = windows_tasks.build_daemon_command("C:\\Python\\python.exe", "state.db")
+        xml = windows_tasks.build_task_xml(command, "ACME\\operator")
+        self.assertIn("<BootTrigger>", xml)
+        self.assertIn("<LogonTrigger>", xml)
+        self.assertIn("<RestartOnFailure>", xml)
+        self.assertIn("C:\\Python\\python.exe", xml)
+        self.assertIn("-m gismo.cli.main daemon --db state.db", xml)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide first-class, always-on Windows support for the GISMO daemon without introducing networking.
- Ensure the daemon can exit promptly and cleanly on Ctrl+C or termination to avoid lingering SQLite locks.
- Offer a safe, auditable way to register the daemon with Task Scheduler via `schtasks.exe` for non-admin current-user installs.
- Keep behavior deterministic and avoid shell injection risks when constructing Task Scheduler commands.

### Description
- Add `gismo/cli/windows_tasks.py` with functions to build schtasks arguments, produce Task Scheduler XML, and safely invoke `schtasks.exe` using `subprocess.run` (no `shell=True`).
- Add CLI handlers and subcommands `daemon install-windows-task` and `daemon uninstall-windows-task` in `gismo/cli/main.py` with flags `--name`, `--db`, `--python`, `--user`, and `--force`, and a dry-run `--yes` guard on uninstall.
- Implement graceful shutdown in `gismo/core/daemon.py` by registering signal handlers (`SIGINT`/`SIGTERM` where available) and using a `threading.Event` so the loop can stop promptly and close SQLite connections between iterations.
- Update documentation in `README.md` and `Handoff.md` and add unit tests `tests/test_windows_tasks.py` that validate command and XML construction without invoking Windows scheduler.

### Testing
- Ran verification: `python scripts/verify.py`, which executed the full test suite and returned `OK`.
- Added unit tests in `tests/test_windows_tasks.py` that assert `build_daemon_command`, `build_schtasks_create_args`, `build_schtasks_delete_args`, and `build_task_xml` produce correct, safe outputs, and these tests passed.
- Existing daemon and smoke tests were re-run as part of verification and succeeded, including `tests/test_daemon_queue.py` and CLI parser tests.
- No integration with Task Scheduler was executed during tests; schtasks invocations are covered only by command-construction tests to avoid requiring Windows during CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d699534948330b487f345990a85ca)