### PR TITLE
Windows Task Scheduler: default logon install, optional startup trigger, and improved error reporting

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -28,6 +28,7 @@
 - Added queue purge-failed CLI command with dry-run confirmation and enriched queue list columns.
 - Added tests covering run show output and purge-failed safety behavior.
 - Added daemon shutdown signal handling and Windows Task Scheduler install/uninstall CLI helpers.
+- Added optional Windows Task Scheduler startup trigger and improved install error reporting for non-admin defaults.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -45,4 +46,5 @@
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.
 - Windows daemon task install: `python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db`
+- Optional startup trigger (may require admin): `python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db --on-startup`
 - Windows daemon task uninstall: `python -m gismo.cli.main daemon uninstall-windows-task --name "GISMO Daemon" --yes`

--- a/README.md
+++ b/README.md
@@ -183,7 +183,10 @@ Install the Windows Task Scheduler entry for an always-on daemon:
 ```bash
 python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db
 python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db --name "GISMO Daemon" --force
+python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db --on-startup
 ```
+
+Note: `--on-startup` may require running PowerShell as Administrator.
 
 Remove the Windows Task Scheduler entry:
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -370,6 +370,7 @@ def run_daemon_install_windows_task(
     python_exe: str,
     user: str | None,
     force: bool,
+    on_startup: bool,
 ) -> None:
     config = WindowsTaskConfig(
         name=name,
@@ -377,6 +378,7 @@ def run_daemon_install_windows_task(
         python_exe=python_exe,
         user=user,
         force=force,
+        on_startup=on_startup,
     )
     install_windows_task(config)
 
@@ -478,6 +480,7 @@ def _handle_daemon_install_windows_task(args: argparse.Namespace) -> None:
         python_exe=args.python,
         user=args.user,
         force=args.force,
+        on_startup=args.on_startup,
     )
 
 
@@ -828,6 +831,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--force",
         action="store_true",
         help="Overwrite task if it already exists",
+    )
+    daemon_install_parser.add_argument(
+        "--on-startup",
+        action="store_true",
+        help="Also trigger at system startup (may require Administrator)",
     )
     daemon_install_parser.set_defaults(handler=_handle_daemon_install_windows_task)
     daemon_uninstall_parser = daemon_subparsers.add_parser(

--- a/gismo/cli/windows_tasks.py
+++ b/gismo/cli/windows_tasks.py
@@ -7,6 +7,7 @@ import getpass
 import os
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 from typing import Iterable
 from xml.sax.saxutils import escape
@@ -19,6 +20,7 @@ class WindowsTaskConfig:
     python_exe: str
     user: str | None = None
     force: bool = False
+    on_startup: bool = False
 
 
 def build_daemon_command(python_exe: str, db_path: str) -> list[str]:
@@ -40,7 +42,7 @@ def install_windows_task(config: WindowsTaskConfig) -> None:
     _ensure_windows()
     command = build_daemon_command(config.python_exe, config.db_path)
     task_user = _resolve_task_user(config.user)
-    task_xml = build_task_xml(command, task_user)
+    task_xml = build_task_xml(command, task_user, on_startup=config.on_startup)
     removal = build_schtasks_delete_args(config.name)
     print(f"Task command: {_format_command(command)}")
     print(f"Remove with: {_format_command(removal)}")
@@ -53,9 +55,15 @@ def uninstall_windows_task(task_name: str) -> None:
     subprocess.run(args, check=True)
 
 
-def build_task_xml(command: list[str], user: str) -> str:
+def build_task_xml(command: list[str], user: str, *, on_startup: bool) -> str:
     command_path, arguments = _split_exec_command(command)
     now = datetime.now(timezone.utc).isoformat()
+    boot_trigger = ""
+    if on_startup:
+        boot_trigger = """
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>"""
     return f"""<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
@@ -63,9 +71,7 @@ def build_task_xml(command: list[str], user: str) -> str:
     <Author>GISMO</Author>
   </RegistrationInfo>
   <Triggers>
-    <BootTrigger>
-      <Enabled>true</Enabled>
-    </BootTrigger>
+{boot_trigger}
     <LogonTrigger>
       <Enabled>true</Enabled>
     </LogonTrigger>
@@ -129,7 +135,21 @@ def _run_schtasks_create(config: WindowsTaskConfig, task_xml: str) -> None:
     xml_path = _write_task_xml(task_xml, Path(config.db_path))
     try:
         args = build_schtasks_create_args(config.name, str(xml_path), config.force)
-        subprocess.run(args, check=True)
+        subprocess.run(args, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.strip() if exc.stderr else ""
+        stdout = exc.stdout.strip() if exc.stdout else ""
+        if stderr:
+            print(f"schtasks.exe stderr:\n{stderr}", file=sys.stderr)
+        if stdout:
+            print(f"schtasks.exe stdout:\n{stdout}", file=sys.stderr)
+        hint = (
+            "Try running PowerShell as Administrator."
+            if not config.on_startup
+            else "Re-run without --on-startup."
+        )
+        print(f"Hint: {hint}", file=sys.stderr)
+        raise
     finally:
         xml_path.unlink(missing_ok=True)
 

--- a/tests/test_windows_tasks.py
+++ b/tests/test_windows_tasks.py
@@ -32,14 +32,20 @@ class WindowsTasksCommandTest(unittest.TestCase):
             ["schtasks.exe", "/Delete", "/TN", "GISMO Daemon", "/F"],
         )
 
-    def test_build_task_xml_includes_triggers_and_restart(self) -> None:
+    def test_build_task_xml_includes_logon_trigger_by_default(self) -> None:
         command = windows_tasks.build_daemon_command("C:\\Python\\python.exe", "state.db")
-        xml = windows_tasks.build_task_xml(command, "ACME\\operator")
-        self.assertIn("<BootTrigger>", xml)
+        xml = windows_tasks.build_task_xml(command, "ACME\\operator", on_startup=False)
+        self.assertNotIn("<BootTrigger>", xml)
         self.assertIn("<LogonTrigger>", xml)
         self.assertIn("<RestartOnFailure>", xml)
         self.assertIn("C:\\Python\\python.exe", xml)
         self.assertIn("-m gismo.cli.main daemon --db state.db", xml)
+
+    def test_build_task_xml_includes_boot_trigger_with_startup_flag(self) -> None:
+        command = windows_tasks.build_daemon_command("C:\\Python\\python.exe", "state.db")
+        xml = windows_tasks.build_task_xml(command, "ACME\\operator", on_startup=True)
+        self.assertIn("<BootTrigger>", xml)
+        self.assertIn("<LogonTrigger>", xml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make the default Windows Task Scheduler install work for non-admin users by using a per-user logon trigger instead of requiring startup/boot privileges.
- Preserve the ability to install a system startup/boot trigger as an opt-in feature that may require elevation.
- Improve diagnostics so failures from `schtasks.exe` are actionable for operators.
- Keep subprocess usage safe (`shell=False` and arg lists) and preserve least-privilege principal behavior.

### Description
- Added `on_startup: bool` to `WindowsTaskConfig` and a CLI `--on-startup` flag wired through `run_daemon_install_windows_task` to `install_windows_task` so startup trigger is opt-in.
- Updated `build_task_xml` to always include an `LogonTrigger` and only include a `BootTrigger` when `on_startup=True`, while keeping the `Principal` `RunLevel` as `LeastPrivilege` and resolving the current user without requiring a password.
- Enhanced `_run_schtasks_create` to capture `stdout`/`stderr` (`capture_output=True, text=True`) and on `CalledProcessError` print captured output plus an actionable hint about running as Administrator or re-running without `--on-startup`, then re-raise the error.
- Updated unit tests (`tests/test_windows_tasks.py`) to assert default XML contains only the logon trigger and that `--on-startup` adds the boot trigger, and updated `README.md` and `Handoff.md` to document the new flag and its admin implications.

### Testing
- Ran the repository verification script with `python scripts/verify.py`, which executed the test suite and completed successfully (all tests passed).
- Updated unit tests include `tests/test_windows_tasks.py` which validate `build_task_xml` behavior for default and `on_startup=True` cases and these tests passed under verification.
- No changes to subprocess call patterns were introduced, preserving safety and deterministic argument lists.
- Manual acceptance notes: install with `python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db` defaults to logon-only and should succeed for non-admin users, while `--on-startup` remains optional and may require Administrator privileges.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d8dbafb2c833090ef6446185abc79)