### PR TITLE
Add per-user Windows Startup launcher and Task Scheduler access-denied handling

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -29,6 +29,7 @@
 - Added tests covering run show output and purge-failed safety behavior.
 - Added daemon shutdown signal handling and Windows Task Scheduler install/uninstall CLI helpers.
 - Added optional Windows Task Scheduler startup trigger and improved install error reporting for non-admin defaults.
+- Added Windows Startup folder launcher install/uninstall commands with tests and Task Scheduler access-denied guidance.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -39,6 +40,7 @@
 - Extend daemon workflows with observability metrics and backoff tuning.
 - Consider additional CLI filters for run/task search and failure triage.
 - Add Windows-specific operational playbooks for Task Scheduler maintenance.
+- Document Windows Startup launcher maintenance steps.
 
 ## Tests
 - `python scripts/verify.py`
@@ -48,3 +50,5 @@
 - Windows daemon task install: `python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db`
 - Optional startup trigger (may require admin): `python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db --on-startup`
 - Windows daemon task uninstall: `python -m gismo.cli.main daemon uninstall-windows-task --name "GISMO Daemon" --yes`
+- Windows startup launcher install: `python -m gismo.cli.main daemon install-windows-startup --db .gismo/state.db`
+- Windows startup launcher uninstall: `python -m gismo.cli.main daemon uninstall-windows-startup --name "GISMO Daemon" --yes`

--- a/README.md
+++ b/README.md
@@ -188,10 +188,23 @@ python -m gismo.cli.main daemon install-windows-task --db .gismo/state.db --on-s
 
 Note: `--on-startup` may require running PowerShell as Administrator.
 
+If Task Scheduler is blocked by policy, install a per-user Startup launcher instead:
+
+```bash
+python -m gismo.cli.main daemon install-windows-startup --db .gismo/state.db
+python -m gismo.cli.main daemon install-windows-startup --db .gismo/state.db --name "GISMO Daemon" --force
+```
+
 Remove the Windows Task Scheduler entry:
 
 ```bash
 python -m gismo.cli.main daemon uninstall-windows-task --name "GISMO Daemon" --yes
+```
+
+Remove the Windows Startup launcher:
+
+```bash
+python -m gismo.cli.main daemon uninstall-windows-startup --name "GISMO Daemon" --yes
 ```
 
 Inspect queue items (DB flag can be supplied before or after the queue subcommand):

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -13,7 +13,12 @@ from gismo.cli.operator import (
     parse_command,
     required_tools,
 )
+from gismo.cli.windows_startup import (
+    install_windows_startup_launcher,
+    uninstall_windows_startup_launcher,
+)
 from gismo.cli.windows_tasks import WindowsTaskConfig, install_windows_task, uninstall_windows_task
+from gismo.cli.windows_utils import quote_windows_arg
 from gismo.core.agent import SimpleAgent
 from gismo.core.daemon import run_daemon_loop
 from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
@@ -391,6 +396,33 @@ def run_daemon_uninstall_windows_task(name: str, *, yes: bool) -> None:
     uninstall_windows_task(name)
 
 
+def run_daemon_install_windows_startup(
+    name: str,
+    db_path: str,
+    python_exe: str,
+    *,
+    force: bool,
+) -> None:
+    launcher_path = install_windows_startup_launcher(
+        name=name,
+        db_path=db_path,
+        python_exe=python_exe,
+        force=force,
+    )
+    print(f"Startup launcher: {launcher_path}")
+    python_arg = quote_windows_arg(python_exe)
+    print(
+        "Remove with: "
+        f"{python_arg} -m gismo.cli.main daemon uninstall-windows-startup --name \"{name}\" --yes"
+    )
+
+
+def run_daemon_uninstall_windows_startup(name: str, *, yes: bool) -> None:
+    launcher_path = uninstall_windows_startup_launcher(name, yes=yes)
+    if yes:
+        print(f"Removed startup launcher: {launcher_path}")
+
+
 def _print_operator_summary(state_store: StateStore, run_id: str) -> None:
     print("=== GISMO Operator Summary ===")
     print(f"Run: {run_id}")
@@ -486,6 +518,19 @@ def _handle_daemon_install_windows_task(args: argparse.Namespace) -> None:
 
 def _handle_daemon_uninstall_windows_task(args: argparse.Namespace) -> None:
     run_daemon_uninstall_windows_task(args.name, yes=args.yes)
+
+
+def _handle_daemon_install_windows_startup(args: argparse.Namespace) -> None:
+    run_daemon_install_windows_startup(
+        name=args.name,
+        db_path=args.db_path,
+        python_exe=args.python,
+        force=args.force,
+    )
+
+
+def _handle_daemon_uninstall_windows_startup(args: argparse.Namespace) -> None:
+    run_daemon_uninstall_windows_startup(args.name, yes=args.yes)
 
 
 def _handle_queue_stats(args: argparse.Namespace) -> None:
@@ -853,6 +898,42 @@ def build_parser() -> argparse.ArgumentParser:
         help="Confirm removal (required to delete the task)",
     )
     daemon_uninstall_parser.set_defaults(handler=_handle_daemon_uninstall_windows_task)
+    daemon_install_startup_parser = daemon_subparsers.add_parser(
+        "install-windows-startup",
+        help="Install a Windows Startup folder entry for the daemon",
+        parents=[db_parent],
+    )
+    daemon_install_startup_parser.add_argument(
+        "--name",
+        default="GISMO Daemon",
+        help="Startup launcher base name",
+    )
+    daemon_install_startup_parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable to run the daemon",
+    )
+    daemon_install_startup_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite launcher if it already exists",
+    )
+    daemon_install_startup_parser.set_defaults(handler=_handle_daemon_install_windows_startup)
+    daemon_uninstall_startup_parser = daemon_subparsers.add_parser(
+        "uninstall-windows-startup",
+        help="Remove the Windows Startup folder entry for the daemon",
+    )
+    daemon_uninstall_startup_parser.add_argument(
+        "--name",
+        default="GISMO Daemon",
+        help="Startup launcher base name",
+    )
+    daemon_uninstall_startup_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm removal (required to delete the launcher)",
+    )
+    daemon_uninstall_startup_parser.set_defaults(handler=_handle_daemon_uninstall_windows_startup)
 
     queue_parser = subparsers.add_parser(
         "queue",

--- a/gismo/cli/windows_startup.py
+++ b/gismo/cli/windows_startup.py
@@ -1,0 +1,79 @@
+"""Windows Startup folder helpers for GISMO daemon."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from gismo.cli.windows_utils import quote_windows_arg
+
+
+def get_windows_startup_folder(appdata: str | None = None) -> Path:
+    base = appdata or os.environ.get("APPDATA")
+    if not base:
+        raise RuntimeError("APPDATA is not set; cannot locate Windows Startup folder.")
+    return (
+        Path(base)
+        / "Microsoft"
+        / "Windows"
+        / "Start Menu"
+        / "Programs"
+        / "Startup"
+    )
+
+
+def build_windows_startup_launcher_content(python_exe: str, db_path: str) -> str:
+    command = [
+        python_exe,
+        "-m",
+        "gismo.cli.main",
+        "daemon",
+        "--db",
+        db_path,
+    ]
+    quoted = " ".join(quote_windows_arg(arg) for arg in command)
+    return f"@echo off\n{quoted}\n"
+
+
+def install_windows_startup_launcher(
+    name: str,
+    db_path: str,
+    python_exe: str,
+    *,
+    force: bool,
+    startup_dir: Path | None = None,
+) -> Path:
+    if startup_dir is None:
+        _ensure_windows()
+        startup_dir = get_windows_startup_folder()
+    startup_dir.mkdir(parents=True, exist_ok=True)
+    launcher_path = startup_dir / f"{name}.cmd"
+    if launcher_path.exists() and not force:
+        print(f"Launcher already exists at {launcher_path}.")
+        print("Re-run with --force to overwrite.")
+        return launcher_path
+    content = build_windows_startup_launcher_content(python_exe, db_path)
+    launcher_path.write_text(content, encoding="utf-8")
+    return launcher_path
+
+
+def uninstall_windows_startup_launcher(
+    name: str,
+    *,
+    yes: bool,
+    startup_dir: Path | None = None,
+) -> Path:
+    if startup_dir is None:
+        _ensure_windows()
+        startup_dir = get_windows_startup_folder()
+    launcher_path = startup_dir / f"{name}.cmd"
+    if not yes:
+        print(f"Dry run: would remove launcher \"{launcher_path}\".")
+        print("Re-run with --yes to confirm removal.")
+        return launcher_path
+    launcher_path.unlink(missing_ok=True)
+    return launcher_path
+
+
+def _ensure_windows() -> None:
+    if os.name != "nt":
+        raise RuntimeError("Windows Startup folder commands are only supported on Windows.")

--- a/gismo/cli/windows_tasks.py
+++ b/gismo/cli/windows_tasks.py
@@ -12,6 +12,7 @@ import tempfile
 from typing import Iterable
 from xml.sax.saxutils import escape
 
+from gismo.cli.windows_utils import quote_windows_arg
 
 @dataclass(frozen=True)
 class WindowsTaskConfig:
@@ -139,6 +140,14 @@ def _run_schtasks_create(config: WindowsTaskConfig, task_xml: str) -> None:
     except subprocess.CalledProcessError as exc:
         stderr = exc.stderr.strip() if exc.stderr else ""
         stdout = exc.stdout.strip() if exc.stdout else ""
+        combined = f"{stderr}\n{stdout}".lower()
+        if "access is denied" in combined:
+            print("Task Scheduler install blocked by permissions/policy.", file=sys.stderr)
+            print(
+                "Suggestion: re-run as Administrator or use install-windows-startup.",
+                file=sys.stderr,
+            )
+            return
         if stderr:
             print(f"schtasks.exe stderr:\n{stderr}", file=sys.stderr)
         if stdout:
@@ -165,18 +174,9 @@ def _split_exec_command(command: list[str]) -> tuple[str, str]:
     if not command:
         raise ValueError("Command cannot be empty")
     command_path = command[0]
-    arguments = " ".join(_quote_windows_arg(arg) for arg in command[1:])
+    arguments = " ".join(quote_windows_arg(arg) for arg in command[1:])
     return command_path, arguments
 
 
-def _quote_windows_arg(value: str) -> str:
-    if not value:
-        return "\"\""
-    if any(ch in value for ch in (" ", "\t", "\"")):
-        escaped = value.replace("\"", "\\\"")
-        return f"\"{escaped}\""
-    return value
-
-
 def _format_command(args: Iterable[str]) -> str:
-    return " ".join(_quote_windows_arg(arg) for arg in args)
+    return " ".join(quote_windows_arg(arg) for arg in args)

--- a/gismo/cli/windows_utils.py
+++ b/gismo/cli/windows_utils.py
@@ -1,0 +1,11 @@
+"""Shared Windows command helpers for GISMO."""
+from __future__ import annotations
+
+
+def quote_windows_arg(value: str) -> str:
+    if not value:
+        return "\"\""
+    if any(ch in value for ch in (" ", "\t", "\"")):
+        escaped = value.replace("\"", "\\\"")
+        return f"\"{escaped}\""
+    return value

--- a/tests/test_windows_startup.py
+++ b/tests/test_windows_startup.py
@@ -1,0 +1,68 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.cli import windows_startup
+
+
+class WindowsStartupTest(unittest.TestCase):
+    def test_get_windows_startup_folder_uses_appdata(self) -> None:
+        base = "C:\\Users\\alice\\AppData\\Roaming"
+        path = windows_startup.get_windows_startup_folder(appdata=base)
+        self.assertEqual(
+            path,
+            Path(base)
+            / "Microsoft"
+            / "Windows"
+            / "Start Menu"
+            / "Programs"
+            / "Startup",
+        )
+
+    def test_build_launcher_content_quotes_paths(self) -> None:
+        content = windows_startup.build_windows_startup_launcher_content(
+            "C:\\Program Files\\Python\\python.exe",
+            "C:\\Users\\Alice\\GISMO State\\state.db",
+        )
+        expected = (
+            "@echo off\n"
+            "\"C:\\Program Files\\Python\\python.exe\" -m gismo.cli.main daemon "
+            "--db \"C:\\Users\\Alice\\GISMO State\\state.db\"\n"
+        )
+        self.assertEqual(content, expected)
+
+    def test_install_does_not_overwrite_without_force(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            startup_dir = Path(temp_dir)
+            launcher = startup_dir / "GISMO Daemon.cmd"
+            launcher.write_text("original\n", encoding="utf-8")
+            windows_startup.install_windows_startup_launcher(
+                name="GISMO Daemon",
+                db_path="state.db",
+                python_exe="python.exe",
+                force=False,
+                startup_dir=startup_dir,
+            )
+            self.assertEqual(launcher.read_text(encoding="utf-8"), "original\n")
+
+    def test_uninstall_requires_yes(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            startup_dir = Path(temp_dir)
+            launcher = startup_dir / "GISMO Daemon.cmd"
+            launcher.write_text("content\n", encoding="utf-8")
+            windows_startup.uninstall_windows_startup_launcher(
+                name="GISMO Daemon",
+                yes=False,
+                startup_dir=startup_dir,
+            )
+            self.assertTrue(launcher.exists())
+            windows_startup.uninstall_windows_startup_launcher(
+                name="GISMO Daemon",
+                yes=True,
+                startup_dir=startup_dir,
+            )
+            self.assertFalse(launcher.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Task Scheduler installs can be blocked by non-admin policies which prevents creating a scheduled task for the daemon, so a per-user Startup-folder launcher provides a reliable non-admin "run at login" alternative.
- The launcher must be safe and deterministic: avoid `shell=True`, quote arguments correctly to handle spaces, and produce a simple `.cmd` that runs the daemon with the configured Python and DB path.
- Surface a friendly, expected-error path when `schtasks` fails with "Access is denied" and suggest the Startup-folder fallback instead of printing a full traceback.

### Description
- Add `gismo/cli/windows_startup.py` implementing `get_windows_startup_folder`, `build_windows_startup_launcher_content`, `install_windows_startup_launcher`, and `uninstall_windows_startup_launcher` to create/remove a per-user `.cmd` launcher.
- Add `gismo/cli/windows_utils.py` with `quote_windows_arg` and reuse it from `gismo/cli/windows_tasks.py` to ensure consistent, correct argument quoting across Task Scheduler and Startup launcher code.
- Update `gismo/cli/windows_tasks.py` to detect `schtasks` "Access is denied" output and print a concise suggestion to re-run as Administrator or use the Startup launcher without emitting a full traceback.
- Wire CLI subcommands `daemon install-windows-startup` and `daemon uninstall-windows-startup` in `gismo/cli/main.py`, add tests `tests/test_windows_startup.py`, and update `README.md` and `Handoff.md` documentation.

### Testing
- Run full verification with `python scripts/verify.py` which executes the unit test suite including the new `tests/test_windows_startup.py`.
- Manual CLI smoke commands to exercise the new flow are: `python -m gismo.cli.main daemon install-windows-startup --db .gismo/state.db` and `python -m gismo.cli.main daemon uninstall-windows-startup --name "GISMO Daemon" --yes`.
- The test suite completed successfully (all tests passed) when `python scripts/verify.py` was run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d8f679c1c833094b59a639327cde2)