### PR TITLE
Add local IPC control plane for queue and run access

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -30,6 +30,7 @@
 - Added daemon shutdown signal handling and Windows Task Scheduler install/uninstall CLI helpers.
 - Added optional Windows Task Scheduler startup trigger and improved install error reporting for non-admin defaults.
 - Added Windows Startup folder launcher install/uninstall commands with tests and Task Scheduler access-denied guidance.
+- Added local IPC control plane (named pipe/Unix socket) with token auth, CLI wiring, and handler tests.
 
 ## Next Steps
 - Expand tool catalog and add richer permission policies.
@@ -41,6 +42,7 @@
 - Consider additional CLI filters for run/task search and failure triage.
 - Add Windows-specific operational playbooks for Task Scheduler maintenance.
 - Document Windows Startup launcher maintenance steps.
+- Consider IPC integration tests over the real transport layer.
 
 ## Tests
 - `python scripts/verify.py`

--- a/README.md
+++ b/README.md
@@ -178,6 +178,16 @@ python -m gismo.cli.main enqueue "echo: daemon hello" --db .gismo/state.db
 python -m gismo.cli.main daemon --once --policy policy/readonly.json --db .gismo/state.db
 ```
 
+Local IPC control plane (same-machine only, token required):
+
+```bash
+export GISMO_IPC_TOKEN="your-token"
+python -m gismo.cli.main ipc serve --db .gismo/state.db
+python -m gismo.cli.main ipc enqueue "echo: hello"
+python -m gismo.cli.main ipc queue-stats
+python -m gismo.cli.main ipc run-show <RUN_ID>
+```
+
 Install the Windows Task Scheduler entry for an always-on daemon:
 
 ```bash

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -1,0 +1,401 @@
+"""Local IPC control plane for GISMO."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from multiprocessing.connection import Client, Listener
+from pathlib import Path
+from typing import Any, Dict
+
+from gismo.cli.operator import parse_command
+from gismo.core.models import QueueStatus, TaskStatus
+from gismo.core.state import StateStore
+
+
+@dataclass(frozen=True)
+class IPCEndpoint:
+    address: str
+    family: str
+
+
+@dataclass(frozen=True)
+class IPCResponse:
+    ok: bool
+    request_id: str
+    data: Dict[str, Any] | None
+    error: str | None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "request_id": self.request_id,
+            "data": self.data,
+            "error": self.error,
+        }
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def default_ipc_endpoint() -> IPCEndpoint:
+    if os.name == "nt":
+        return IPCEndpoint(r"\\.\pipe\gismo-ipc", "AF_PIPE")
+    return IPCEndpoint("/tmp/gismo-ipc.sock", "AF_UNIX")
+
+
+def load_ipc_token(token: str | None) -> str:
+    value = token or os.environ.get("GISMO_IPC_TOKEN")
+    if not value:
+        raise ValueError("IPC token required via --token or GISMO_IPC_TOKEN")
+    return value
+
+
+def _serialize_dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value else None
+
+
+def _serialize_queue_stats(stats: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "total": stats["total"],
+        "by_status": stats["by_status"],
+        "created_at": {
+            "oldest": _serialize_dt(stats["created_at"]["oldest"]),
+            "newest": _serialize_dt(stats["created_at"]["newest"]),
+        },
+        "updated_at": {
+            "oldest": _serialize_dt(stats["updated_at"]["oldest"]),
+            "newest": _serialize_dt(stats["updated_at"]["newest"]),
+        },
+        "attempts": stats["attempts"],
+    }
+
+
+def _serialize_run_show(state_store: StateStore, run_id: str) -> Dict[str, Any] | None:
+    run = state_store.get_run(run_id)
+    if run is None:
+        return None
+    tasks = list(state_store.list_tasks(run.id))
+    tool_calls = list(state_store.list_tool_calls(run.id))
+    task_payloads = []
+    for task in tasks:
+        task_payloads.append(
+            {
+                "id": task.id,
+                "title": task.title,
+                "status": task.status.value,
+                "error": task.error,
+                "output_json": task.output_json,
+                "created_at": _serialize_dt(task.created_at),
+                "updated_at": _serialize_dt(task.updated_at),
+                "failure_type": task.failure_type.value if task.failure_type else None,
+            }
+        )
+    call_payloads = []
+    for call in tool_calls:
+        call_payloads.append(
+            {
+                "id": call.id,
+                "task_id": call.task_id,
+                "tool_name": call.tool_name,
+                "status": call.status.value,
+                "started_at": _serialize_dt(call.started_at),
+                "finished_at": _serialize_dt(call.finished_at),
+                "output_json": call.output_json,
+                "error": call.error,
+            }
+        )
+    return {
+        "run": {
+            "id": run.id,
+            "label": run.label,
+            "created_at": _serialize_dt(run.created_at),
+        },
+        "tasks": task_payloads,
+        "tool_calls": call_payloads,
+    }
+
+
+def handle_ipc_request(
+    request: Dict[str, Any],
+    expected_token: str,
+    state_store: StateStore,
+) -> Dict[str, Any]:
+    request_id = str(request.get("request_id") or uuid.uuid4())
+    token = request.get("token")
+    action = request.get("action")
+    args = request.get("args") or {}
+
+    if token != expected_token:
+        return IPCResponse(False, request_id, None, "unauthorized").to_dict()
+
+    try:
+        if action == "enqueue":
+            command_text = str(args.get("command") or "").strip()
+            if not command_text:
+                raise ValueError("enqueue requires a command string")
+            parse_command(command_text)
+            run_id = args.get("run_id")
+            max_attempts = int(args.get("max_attempts", 3))
+            item = state_store.enqueue_command(
+                command_text=command_text,
+                run_id=run_id,
+                max_attempts=max_attempts,
+            )
+            data = {"queue_item_id": item.id, "status": item.status.value}
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "queue_stats":
+            stats = state_store.queue_stats()
+            data = _serialize_queue_stats(stats)
+            data["db_path"] = state_store.db_path
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "run_show":
+            run_id = str(args.get("run_id") or "").strip()
+            if not run_id:
+                raise ValueError("run_show requires a run id")
+            payload = _serialize_run_show(state_store, run_id)
+            if payload is None:
+                return IPCResponse(False, request_id, None, "not_found").to_dict()
+            return IPCResponse(True, request_id, payload, None).to_dict()
+        return IPCResponse(False, request_id, None, "unsupported_action").to_dict()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return IPCResponse(False, request_id, None, str(exc)).to_dict()
+
+
+def _parse_json_payload(raw: bytes) -> Dict[str, Any] | None:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _log_request(request_id: str, action: str | None, caller: str | None) -> None:
+    timestamp = datetime.now(timezone.utc).isoformat()
+    safe_action = action or "unknown"
+    safe_caller = caller or "unknown"
+    LOGGER.info(
+        "ipc_request request_id=%s action=%s timestamp=%s caller=%s",
+        request_id,
+        safe_action,
+        timestamp,
+        safe_caller,
+    )
+
+
+def serve_ipc(db_path: str, token: str) -> None:
+    endpoint = default_ipc_endpoint()
+    socket_path = Path(endpoint.address) if endpoint.family == "AF_UNIX" else None
+    if socket_path is not None:
+        if socket_path.exists():
+            if socket_path.is_socket():
+                socket_path.unlink()
+            else:
+                raise ValueError(f"IPC socket path exists and is not a socket: {socket_path}")
+        socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    listener = Listener(endpoint.address, family=endpoint.family)
+    state_store = StateStore(db_path)
+
+    try:
+        while True:
+            try:
+                conn = listener.accept()
+            except KeyboardInterrupt:
+                break
+            with conn:
+                try:
+                    raw = conn.recv_bytes()
+                except EOFError:
+                    continue
+                request = _parse_json_payload(raw)
+                if request is None:
+                    request_id = str(uuid.uuid4())
+                    _log_request(request_id, "invalid_json", None)
+                    response = IPCResponse(False, request_id, None, "invalid_json").to_dict()
+                    conn.send_bytes(json.dumps(response).encode("utf-8"))
+                    continue
+                request_id = str(request.get("request_id") or uuid.uuid4())
+                _log_request(request_id, str(request.get("action")), None)
+                response = handle_ipc_request(request, token, state_store)
+                conn.send_bytes(json.dumps(response).encode("utf-8"))
+    finally:
+        listener.close()
+        if socket_path is not None and socket_path.exists() and socket_path.is_socket():
+            socket_path.unlink()
+
+
+def ipc_request(action: str, args: Dict[str, Any], token: str) -> Dict[str, Any]:
+    endpoint = default_ipc_endpoint()
+    request_id = str(uuid.uuid4())
+    request = {
+        "request_id": request_id,
+        "token": token,
+        "action": action,
+        "args": args,
+    }
+    with Client(endpoint.address, family=endpoint.family) as conn:
+        conn.send_bytes(json.dumps(request).encode("utf-8"))
+        response_raw = conn.recv_bytes()
+    payload = _parse_json_payload(response_raw)
+    if payload is None:
+        raise ValueError("Invalid IPC response")
+    return payload
+
+
+def _fmt_dt(value: datetime | None) -> str:
+    return value.isoformat(timespec="seconds") if value else "-"
+
+
+def _truncate(text: str, max_len: int) -> str:
+    if len(text) <= max_len:
+        return text
+    return text[: max(0, max_len - 1)] + "…"
+
+
+def _summarize_value(value: object, max_len: int) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    return _truncate(text, max_len)
+
+
+def _parse_dt(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value)
+
+
+def _run_status(tasks: list[Dict[str, Any]]) -> str:
+    if not tasks:
+        return "pending"
+    statuses = {task["status"] for task in tasks}
+    if TaskStatus.FAILED.value in statuses:
+        return "failed"
+    if TaskStatus.RUNNING.value in statuses:
+        return "running"
+    if statuses.issubset({TaskStatus.SUCCEEDED.value}):
+        return "succeeded"
+    return "pending"
+
+
+def _run_time_bounds(
+    run: Dict[str, Any],
+    tasks: list[Dict[str, Any]],
+    tool_calls: list[Dict[str, Any]],
+) -> tuple[datetime | None, datetime | None]:
+    start_candidates = [
+        _parse_dt(run.get("created_at")),
+    ]
+    start_candidates.extend(_parse_dt(task.get("created_at")) for task in tasks)
+    start_candidates.extend(_parse_dt(call.get("started_at")) for call in tool_calls)
+    start_candidates = [value for value in start_candidates if value is not None]
+    start_time = min(start_candidates) if start_candidates else None
+
+    end_candidates = [
+        _parse_dt(task.get("updated_at")) for task in tasks if task.get("updated_at")
+    ]
+    end_candidates.extend(
+        _parse_dt(call.get("finished_at")) for call in tool_calls if call.get("finished_at")
+    )
+    end_candidates = [value for value in end_candidates if value is not None]
+    end_time = max(end_candidates) if end_candidates else None
+    return start_time, end_time
+
+
+def format_queue_stats_output(stats: Dict[str, Any]) -> str:
+    lines = [
+        f"DB: {stats['db_path']}",
+        f"Total: {stats['total']}",
+        "By status:",
+    ]
+    for status in QueueStatus:
+        lines.append(f"  {status.value:12} {stats['by_status'].get(status.value, 0)}")
+    created_oldest = _parse_dt(stats["created_at"]["oldest"])
+    created_newest = _parse_dt(stats["created_at"]["newest"])
+    updated_oldest = _parse_dt(stats["updated_at"]["oldest"])
+    updated_newest = _parse_dt(stats["updated_at"]["newest"])
+    lines.append(
+        f"Created: oldest={_fmt_dt(created_oldest)} newest={_fmt_dt(created_newest)}"
+    )
+    lines.append(
+        f"Updated: oldest={_fmt_dt(updated_oldest)} newest={_fmt_dt(updated_newest)}"
+    )
+    lines.append(
+        "Attempts: "
+        f"items_with_attempts={stats['attempts']['items_with_attempts']} "
+        f"max_attempt_count={stats['attempts']['max_attempt_count']}"
+    )
+    return "\n".join(lines)
+
+
+def format_enqueue_output(data: Dict[str, Any]) -> str:
+    return f"Enqueued {data['queue_item_id']} status={data['status']}"
+
+
+def format_run_show_output(payload: Dict[str, Any]) -> str:
+    run = payload["run"]
+    tasks = payload["tasks"]
+    tool_calls = payload["tool_calls"]
+    status = _run_status(tasks)
+    start_time, end_time = _run_time_bounds(run, tasks, tool_calls)
+
+    lines = [
+        "=== GISMO Run Summary ===",
+        f"Run ID:     {run['id']}",
+        f"Status:     {status}",
+        f"Started:    {_fmt_dt(start_time)}",
+        f"Finished:   {_fmt_dt(end_time)}",
+        "Tasks:",
+    ]
+
+    if not tasks:
+        lines.append("  (no tasks)")
+        return "\n".join(lines)
+
+    calls_by_task: Dict[str, list[Dict[str, Any]]] = {}
+    for call in tool_calls:
+        calls_by_task.setdefault(call["task_id"], []).append(call)
+
+    for task in tasks:
+        lines.append(f"- {task['id']} {task['title']} [{task['status']}]")
+        if task.get("error"):
+            lines.append(f"  error: {_summarize_value(task['error'], 200)}")
+        if task.get("output_json"):
+            lines.append(f"  output: {_summarize_value(task['output_json'], 200)}")
+        task_calls = calls_by_task.get(task["id"], [])
+        if not task_calls:
+            lines.append("  Tool Calls: none")
+            continue
+        lines.append("  Tool Calls:")
+        for call in task_calls:
+            lines.append(
+                "    - "
+                f"{call['id']} tool={call['tool_name']} status={call['status']} "
+                f"started={_fmt_dt(_parse_dt(call.get('started_at')))} "
+                f"finished={_fmt_dt(_parse_dt(call.get('finished_at')))}"
+            )
+            if call.get("output_json"):
+                lines.append(f"      output: {_summarize_value(call['output_json'], 200)}")
+            if call.get("error"):
+                lines.append(f"      error: {_summarize_value(call['error'], 200)}")
+
+    return "\n".join(lines)
+
+
+def parse_ipc_response(response: Dict[str, Any]) -> IPCResponse:
+    return IPCResponse(
+        ok=bool(response.get("ok")),
+        request_id=str(response.get("request_id") or ""),
+        data=response.get("data"),
+        error=response.get("error"),
+    )

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -13,6 +13,7 @@ from gismo.cli.operator import (
     parse_command,
     required_tools,
 )
+from gismo.cli import ipc as ipc_cli
 from gismo.cli.windows_startup import (
     install_windows_startup_launcher,
     uninstall_windows_startup_launcher,
@@ -708,6 +709,80 @@ def _handle_queue_purge_failed(args: argparse.Namespace) -> None:
         )
 
 
+def _handle_ipc_serve(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    ipc_cli.serve_ipc(args.db_path, token)
+
+
+def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
+    command_text = " ".join(args.operator_command).strip()
+    if not command_text:
+        raise ValueError("ipc enqueue requires a command string")
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    response = ipc_cli.parse_ipc_response(
+        ipc_cli.ipc_request(
+            "enqueue",
+            {
+                "command": command_text,
+                "run_id": args.run_id,
+                "max_attempts": args.max_attempts,
+            },
+            token,
+        )
+    )
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_enqueue_output(response.data or {}))
+
+
+def _handle_ipc_queue_stats(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("queue_stats", {}, token))
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_queue_stats_output(response.data or {}))
+
+
+def _handle_ipc_run_show(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    response = ipc_cli.parse_ipc_response(
+        ipc_cli.ipc_request("run_show", {"run_id": args.run_id}, token)
+    )
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        elif response.error == "not_found":
+            print(f"Run not found: {args.run_id}")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_run_show_output(response.data or {}))
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="GISMO CLI")
     db_parent = argparse.ArgumentParser(add_help=False)
@@ -1011,6 +1086,78 @@ def build_parser() -> argparse.ArgumentParser:
         help="Confirm deletion (omit for dry-run)",
     )
     queue_purge_failed_parser.set_defaults(handler=_handle_queue_purge_failed)
+
+    ipc_parser = subparsers.add_parser(
+        "ipc",
+        help="Local IPC control plane",
+    )
+    ipc_subparsers = ipc_parser.add_subparsers(dest="ipc_command", required=True)
+
+    ipc_serve_parser = ipc_subparsers.add_parser(
+        "serve",
+        help="Start the IPC server",
+        parents=[db_parent],
+    )
+    ipc_serve_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_serve_parser.set_defaults(handler=_handle_ipc_serve)
+
+    ipc_enqueue_parser = ipc_subparsers.add_parser(
+        "enqueue",
+        help="Enqueue an operator command via IPC",
+    )
+    ipc_enqueue_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_enqueue_parser.add_argument(
+        "--run",
+        dest="run_id",
+        default=None,
+        help="Optional existing run ID to attach tasks to",
+    )
+    ipc_enqueue_parser.add_argument(
+        "--max-attempts",
+        type=int,
+        default=3,
+        help="Maximum attempts for this queue item",
+    )
+    ipc_enqueue_parser.add_argument(
+        "operator_command",
+        nargs=argparse.REMAINDER,
+        help="Operator command string to enqueue",
+    )
+    ipc_enqueue_parser.set_defaults(handler=_handle_ipc_enqueue)
+
+    ipc_queue_stats_parser = ipc_subparsers.add_parser(
+        "queue-stats",
+        help="Show queue summary statistics via IPC",
+    )
+    ipc_queue_stats_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_queue_stats_parser.set_defaults(handler=_handle_ipc_queue_stats)
+
+    ipc_run_show_parser = ipc_subparsers.add_parser(
+        "run-show",
+        help="Show a run summary via IPC",
+    )
+    ipc_run_show_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_run_show_parser.add_argument(
+        "run_id",
+        help="Run ID to show",
+    )
+    ipc_run_show_parser.set_defaults(handler=_handle_ipc_run_show)
 
     return parser
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,0 +1,98 @@
+import tempfile
+import unittest
+
+from gismo.cli import ipc as ipc_cli
+from gismo.core.state import StateStore
+
+
+class IpcHandlerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = f"{self.tempdir.name}/state.db"
+        self.state_store = StateStore(self.db_path)
+        self.token = "secret-token"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_missing_token_unauthorized(self) -> None:
+        response = ipc_cli.handle_ipc_request(
+            {"action": "queue_stats", "args": {}},
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertFalse(response["ok"])
+        self.assertEqual(response["error"], "unauthorized")
+        self.assertTrue(response["request_id"])
+
+    def test_wrong_token_unauthorized(self) -> None:
+        response = ipc_cli.handle_ipc_request(
+            {"action": "queue_stats", "token": "bad", "args": {}},
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertFalse(response["ok"])
+        self.assertEqual(response["error"], "unauthorized")
+
+    def test_enqueue_validates_operator_command(self) -> None:
+        response = ipc_cli.handle_ipc_request(
+            {
+                "action": "enqueue",
+                "token": self.token,
+                "args": {"command": "invalid: command"},
+            },
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertFalse(response["ok"])
+        self.assertIn("Unsupported command", response["error"])
+
+    def test_enqueue_routes_to_state_store(self) -> None:
+        response = ipc_cli.handle_ipc_request(
+            {
+                "action": "enqueue",
+                "token": self.token,
+                "args": {"command": "echo: hello"},
+            },
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertTrue(response["ok"])
+        data = response["data"]
+        assert data is not None
+        item = self.state_store.get_queue_item(data["queue_item_id"])
+        self.assertIsNotNone(item)
+
+    def test_queue_stats_response_shape(self) -> None:
+        response = ipc_cli.handle_ipc_request(
+            {"action": "queue_stats", "token": self.token, "args": {}},
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertTrue(response["ok"])
+        data = response["data"]
+        assert data is not None
+        self.assertIn("total", data)
+        self.assertIn("by_status", data)
+        self.assertIn("created_at", data)
+        self.assertIn("updated_at", data)
+        self.assertIn("attempts", data)
+        self.assertIn("db_path", data)
+
+    def test_run_show_response_shape(self) -> None:
+        run = self.state_store.create_run(label="ipc-test")
+        response = ipc_cli.handle_ipc_request(
+            {"action": "run_show", "token": self.token, "args": {"run_id": run.id}},
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertTrue(response["ok"])
+        data = response["data"]
+        assert data is not None
+        self.assertEqual(data["run"]["id"], run.id)
+        self.assertIn("tasks", data)
+        self.assertIn("tool_calls", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Enable same-machine programs to enqueue operator commands and query queue/run status without opening network ports, using OS-native IPC (named pipe on Windows, Unix domain socket on POSIX).
- Preserve the existing security model by requiring a token for all IPC requests and avoiding exposure of secrets in logs.
- Reuse the existing operator parsing and state paths so IPC clients cannot bypass CLI/operator validation or permission gating.
- Provide a testable, pure-function request handler so unit tests can run without creating real sockets/pipes.

### Description
- Added `gismo/cli/ipc.py` which implements a JSON-over-IPC protocol, token validation, a pure `handle_ipc_request` router, server (`serve_ipc`) and client helper (`ipc_request`), and safe formatting helpers for responses.
- Wired a new `ipc` CLI group into `gismo/cli/main.py` with subcommands `serve`, `enqueue`, `queue-stats`, and `run-show`, reusing existing operator parsing and output formatting functions.
- Added unit tests `tests/test_ipc.py` that validate token enforcement, request routing for each action, and that `enqueue` uses existing operator validation without touching real IPC transports.
- Updated `README.md` and `Handoff.md`, ensured Unix socket cleanup and Windows named-pipe support, and avoided any new third-party dependencies.

### Testing
- Ran the repository verification: `python scripts/verify.py`, which executed the full unit test suite and completed with all tests passing.
- The new `tests/test_ipc.py` tests (auth, routing, operator-validation) were executed under verification and passed.
- Existing test suites (CLI, daemon, toolpacks, Windows helpers, etc.) were run as part of verification and remained green with no regressions.
- No automated tests failed during the verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d936c66548330b62d85f456aa8550)