### PR TITLE
Fix CLI --db parsing and add IPC subcommand db support

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -31,8 +31,10 @@
 - Added optional Windows Task Scheduler startup trigger and improved install error reporting for non-admin defaults.
 - Added Windows Startup folder launcher install/uninstall commands with tests and Task Scheduler access-denied guidance.
 - Added local IPC control plane (named pipe/Unix socket) with token auth, CLI wiring, and handler tests.
+- Restored global CLI db flag parsing and IPC subcommand support for db path overrides.
 
 ## Next Steps
+- Validate IPC CLI db flag usage on Windows.
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Local IPC control plane (same-machine only, token required):
 
 ```bash
 export GISMO_IPC_TOKEN="your-token"
+python -m gismo.cli.main --db .gismo/state.db ipc queue-stats
 python -m gismo.cli.main ipc serve --db .gismo/state.db
 python -m gismo.cli.main ipc enqueue "echo: hello"
 python -m gismo.cli.main ipc queue-stats

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -784,21 +784,30 @@ def _handle_ipc_run_show(args: argparse.Namespace) -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="GISMO CLI")
+    default_db_path = str(Path(".gismo") / "state.db")
     db_parent = argparse.ArgumentParser(add_help=False)
     db_parent.add_argument(
         "--db",
         "--db-path",
         dest="db_path",
-        default=str(Path(".gismo") / "state.db"),
+        default=default_db_path,
         help="Path to SQLite state database",
     )
+    db_parent_optional = argparse.ArgumentParser(add_help=False)
+    db_parent_optional.add_argument(
+        "--db",
+        "--db-path",
+        dest="db_path",
+        default=argparse.SUPPRESS,
+        help="Path to SQLite state database",
+    )
+    parser = argparse.ArgumentParser(description="GISMO CLI", parents=[db_parent])
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     demo_parser = subparsers.add_parser(
         "demo",
         help="Run the demo workflow",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     demo_parser.add_argument(
         "--policy",
@@ -810,7 +819,7 @@ def build_parser() -> argparse.ArgumentParser:
     demo_graph_parser = subparsers.add_parser(
         "demo-graph",
         help="Run the task graph demo",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     demo_graph_parser.add_argument(
         "--policy",
@@ -822,7 +831,7 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser = subparsers.add_parser(
         "run",
         help="Run an operator command",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     run_parser.add_argument(
         "--policy",
@@ -839,7 +848,7 @@ def build_parser() -> argparse.ArgumentParser:
     export_parser = subparsers.add_parser(
         "export",
         help="Export run audit trail",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     export_parser.add_argument(
         "--policy",
@@ -877,7 +886,7 @@ def build_parser() -> argparse.ArgumentParser:
     enqueue_parser = subparsers.add_parser(
         "enqueue",
         help="Enqueue an operator command",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     enqueue_parser.add_argument(
         "--run",
@@ -901,7 +910,7 @@ def build_parser() -> argparse.ArgumentParser:
     daemon_parser = subparsers.add_parser(
         "daemon",
         help="Run the GISMO daemon loop",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     daemon_parser.add_argument(
         "--policy",
@@ -930,7 +939,7 @@ def build_parser() -> argparse.ArgumentParser:
     daemon_install_parser = daemon_subparsers.add_parser(
         "install-windows-task",
         help="Install a Windows Task Scheduler entry for the daemon",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     daemon_install_parser.add_argument(
         "--name",
@@ -976,7 +985,7 @@ def build_parser() -> argparse.ArgumentParser:
     daemon_install_startup_parser = daemon_subparsers.add_parser(
         "install-windows-startup",
         help="Install a Windows Startup folder entry for the daemon",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     daemon_install_startup_parser.add_argument(
         "--name",
@@ -1020,7 +1029,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_stats_parser = queue_subparsers.add_parser(
         "stats",
         help="Show queue summary statistics",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     queue_stats_parser.add_argument(
         "--json",
@@ -1032,7 +1041,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_list_parser = queue_subparsers.add_parser(
         "list",
         help="List queue items",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     queue_list_parser.add_argument(
         "--limit",
@@ -1065,7 +1074,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_show_parser = queue_subparsers.add_parser(
         "show",
         help="Show a single queue item by id",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     queue_show_parser.add_argument("id", help="Queue item id")
     queue_show_parser.add_argument(
@@ -1078,7 +1087,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_purge_failed_parser = queue_subparsers.add_parser(
         "purge-failed",
         help="Delete FAILED queue items",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     queue_purge_failed_parser.add_argument(
         "--yes",
@@ -1090,13 +1099,14 @@ def build_parser() -> argparse.ArgumentParser:
     ipc_parser = subparsers.add_parser(
         "ipc",
         help="Local IPC control plane",
+        parents=[db_parent_optional],
     )
     ipc_subparsers = ipc_parser.add_subparsers(dest="ipc_command", required=True)
 
     ipc_serve_parser = ipc_subparsers.add_parser(
         "serve",
         help="Start the IPC server",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     ipc_serve_parser.add_argument(
         "--token",
@@ -1108,6 +1118,7 @@ def build_parser() -> argparse.ArgumentParser:
     ipc_enqueue_parser = ipc_subparsers.add_parser(
         "enqueue",
         help="Enqueue an operator command via IPC",
+        parents=[db_parent_optional],
     )
     ipc_enqueue_parser.add_argument(
         "--token",
@@ -1136,6 +1147,7 @@ def build_parser() -> argparse.ArgumentParser:
     ipc_queue_stats_parser = ipc_subparsers.add_parser(
         "queue-stats",
         help="Show queue summary statistics via IPC",
+        parents=[db_parent_optional],
     )
     ipc_queue_stats_parser.add_argument(
         "--token",
@@ -1147,6 +1159,7 @@ def build_parser() -> argparse.ArgumentParser:
     ipc_run_show_parser = ipc_subparsers.add_parser(
         "run-show",
         help="Show a run summary via IPC",
+        parents=[db_parent_optional],
     )
     ipc_run_show_parser.add_argument(
         "--token",

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -48,6 +48,34 @@ class CliMainParserTest(unittest.TestCase):
         self.assertIs(args.handler, cli_main._handle_daemon)
         self.assertTrue(args.once)
 
+    def test_ipc_db_path_before_command(self) -> None:
+        parser = cli_main.build_parser()
+        db_path = "custom.db"
+
+        args = parser.parse_args(["--db", db_path, "ipc", "queue-stats"])
+
+        self.assertEqual(args.command, "ipc")
+        self.assertEqual(args.ipc_command, "queue-stats")
+        self.assertEqual(args.db_path, db_path)
+
+    def test_ipc_db_path_after_subcommand(self) -> None:
+        parser = cli_main.build_parser()
+        db_path = "custom.db"
+
+        enqueue_args = parser.parse_args(
+            ["ipc", "enqueue", "--db", db_path, "echo:", "hello"]
+        )
+        self.assertEqual(enqueue_args.db_path, db_path)
+
+        queue_stats_args = parser.parse_args(["ipc", "queue-stats", "--db", db_path])
+        self.assertEqual(queue_stats_args.db_path, db_path)
+
+        run_show_args = parser.parse_args(["ipc", "run-show", "--db", db_path, "run-1"])
+        self.assertEqual(run_show_args.db_path, db_path)
+
+        serve_args = parser.parse_args(["ipc", "serve", "--db", db_path])
+        self.assertEqual(serve_args.db_path, db_path)
+
     def test_enqueue_and_daemon_share_db_path(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]
         policy_path = str(repo_root / "policy" / "readonly.json")


### PR DESCRIPTION
### Motivation
- The CLI treated `--db` as a no-argument/positional value which caused paths to be parsed as the command (e.g. `invalid choice: '.gismo\state.db'`).
- IPC subcommands rejected `--db` when placed after the `ipc` subcommand, making db overrides inconvenient and platform-sensitive.
- The change restores a consistent global `--db` that accepts a path and allows per-subcommand overrides in either position.

### Description
- Add a global `--db` parent to the top-level parser and a non-overriding `db_parent_optional` for subparsers so `--db` works before or after subcommands. 
- Wire the optional `db` parent into IPC and queue-related subparsers so `ipc enqueue|queue-stats|run-show|serve` accept `--db` in either position. 
- Add parser tests in `tests/test_cli_main.py` to validate `--db` before the command and after `ipc` subcommands, and update `README.md` and `Handoff.md` to reflect the CLI behavior.  
- Risk: relies on `argparse.SUPPRESS` semantics to avoid subparser-level defaults overriding the global default, which is intentional and backward-compatible.

### Testing
- Run full verification with `python scripts/verify.py`, which executed the test suite and completed successfully (all tests passed). 
- New unit tests `tests/test_cli_main.py::CliMainParserTest::test_ipc_db_path_before_command` and `test_ipc_db_path_after_subcommand` were added and passed under verification. 
- Alternative validation commands: run `python -m unittest -v tests.test_cli_main` or `python -m unittest discover -s tests -p "test*.py" -v` and confirm success. 
- Manual repro validated via parse examples such as `python -m gismo.cli.main --db .gismo/state.db ipc queue-stats` which now parses correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d977288ec833087634212fbe44cb3)