### PR TITLE
Handle IPC client connection failures cleanly

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -32,9 +32,11 @@
 - Added Windows Startup folder launcher install/uninstall commands with tests and Task Scheduler access-denied guidance.
 - Added local IPC control plane (named pipe/Unix socket) with token auth, CLI wiring, and handler tests.
 - Restored global CLI db flag parsing and IPC subcommand support for db path overrides.
+- Added IPC client connection error handling with friendly CLI messaging and tests.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
+- Validate IPC client connection errors on Windows named pipes.
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -41,6 +41,20 @@ class IPCResponse:
 LOGGER = logging.getLogger(__name__)
 
 
+class IPCConnectionError(RuntimeError):
+    """Raised when the IPC client cannot connect to the server."""
+
+
+def _connection_error_types() -> tuple[type[BaseException], ...]:
+    if os.name == "nt":
+        return (FileNotFoundError, OSError, EOFError)
+    return (FileNotFoundError, ConnectionRefusedError, OSError, EOFError)
+
+
+def _connect(endpoint: IPCEndpoint) -> Client:
+    return Client(endpoint.address, family=endpoint.family)
+
+
 def default_ipc_endpoint() -> IPCEndpoint:
     if os.name == "nt":
         return IPCEndpoint(r"\\.\pipe\gismo-ipc", "AF_PIPE")
@@ -240,9 +254,12 @@ def ipc_request(action: str, args: Dict[str, Any], token: str) -> Dict[str, Any]
         "action": action,
         "args": args,
     }
-    with Client(endpoint.address, family=endpoint.family) as conn:
-        conn.send_bytes(json.dumps(request).encode("utf-8"))
-        response_raw = conn.recv_bytes()
+    try:
+        with _connect(endpoint) as conn:
+            conn.send_bytes(json.dumps(request).encode("utf-8"))
+            response_raw = conn.recv_bytes()
+    except _connection_error_types() as exc:
+        raise IPCConnectionError("IPC connection failed") from exc
     payload = _parse_json_payload(response_raw)
     if payload is None:
         raise ValueError("Invalid IPC response")

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -718,6 +718,11 @@ def _handle_ipc_serve(args: argparse.Namespace) -> None:
     ipc_cli.serve_ipc(args.db_path, token)
 
 
+def _print_ipc_connection_error() -> None:
+    print("IPC server not running. Start it with: python -m gismo.cli.main ipc serve")
+    print("Ensure GISMO_IPC_TOKEN matches on server and client.")
+
+
 def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
     command_text = " ".join(args.operator_command).strip()
     if not command_text:
@@ -727,17 +732,21 @@ def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(str(exc))
         raise SystemExit(2) from exc
-    response = ipc_cli.parse_ipc_response(
-        ipc_cli.ipc_request(
-            "enqueue",
-            {
-                "command": command_text,
-                "run_id": args.run_id,
-                "max_attempts": args.max_attempts,
-            },
-            token,
+    try:
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request(
+                "enqueue",
+                {
+                    "command": command_text,
+                    "run_id": args.run_id,
+                    "max_attempts": args.max_attempts,
+                },
+                token,
+            )
         )
-    )
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
     if not response.ok:
         if response.error == "unauthorized":
             print("IPC unauthorized")
@@ -753,7 +762,11 @@ def _handle_ipc_queue_stats(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(str(exc))
         raise SystemExit(2) from exc
-    response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("queue_stats", {}, token))
+    try:
+        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("queue_stats", {}, token))
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
     if not response.ok:
         if response.error == "unauthorized":
             print("IPC unauthorized")
@@ -769,9 +782,13 @@ def _handle_ipc_run_show(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(str(exc))
         raise SystemExit(2) from exc
-    response = ipc_cli.parse_ipc_response(
-        ipc_cli.ipc_request("run_show", {"run_id": args.run_id}, token)
-    )
+    try:
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("run_show", {"run_id": args.run_id}, token)
+        )
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
     if not response.ok:
         if response.error == "unauthorized":
             print("IPC unauthorized")

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,8 +1,13 @@
+import argparse
+import contextlib
+import io
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from gismo.cli import main as cli_main
+from gismo.cli import ipc as ipc_cli
 from gismo.core.models import QueueStatus
 from gismo.core.state import StateStore
 
@@ -98,6 +103,28 @@ class CliMainParserTest(unittest.TestCase):
             item = state_store.get_queue_item(queue_item_id)
             assert item is not None
             self.assertEqual(item.status, QueueStatus.SUCCEEDED)
+
+    def test_ipc_queue_stats_connection_error(self) -> None:
+        args = argparse.Namespace(token="secret-token")
+        with mock.patch.object(
+            ipc_cli,
+            "ipc_request",
+            side_effect=ipc_cli.IPCConnectionError("connection failed"),
+        ):
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                with self.assertRaises(SystemExit) as exc:
+                    cli_main._handle_ipc_queue_stats(args)
+            self.assertEqual(exc.exception.code, 2)
+            output = buffer.getvalue().strip().splitlines()
+            self.assertEqual(
+                output[0],
+                "IPC server not running. Start it with: python -m gismo.cli.main ipc serve",
+            )
+            self.assertEqual(
+                output[1],
+                "Ensure GISMO_IPC_TOKEN matches on server and client.",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from unittest import mock
 
 from gismo.cli import ipc as ipc_cli
 from gismo.core.state import StateStore
@@ -92,6 +93,11 @@ class IpcHandlerTest(unittest.TestCase):
         self.assertEqual(data["run"]["id"], run.id)
         self.assertIn("tasks", data)
         self.assertIn("tool_calls", data)
+
+    def test_ipc_request_wraps_connection_error(self) -> None:
+        with mock.patch.object(ipc_cli, "_connect", side_effect=FileNotFoundError()):
+            with self.assertRaises(ipc_cli.IPCConnectionError):
+                ipc_cli.ipc_request("queue_stats", {}, self.token)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent full tracebacks when the local IPC server (named pipe / Unix socket) is missing or unreachable and provide clear, CLI-grade UX.  
- Make IPC client failures deterministic and surface a consistent exit code so calling scripts can handle the failure.  
- Preserve the existing IPC protocol and security model while improving error handling only in the client/CLI path.  

### Description

- Add an `IPCConnectionError` and a `_connect` wrapper in `gismo/cli/ipc.py` that centralizes `Client` creation and a platform-aware set of connection error types.  
- Wrap the client connect/recv in `ipc_request` and raise `IPCConnectionError` on connection failures instead of letting low-level exceptions propagate.  
- Catch `IPCConnectionError` in the IPC CLI handlers in `gismo/cli/main.py`, print a friendly two-line message and exit with status code `2`.  
- Add unit tests for the new behavior and update `Handoff.md` to note the change (tests added: `tests/test_ipc.py::test_ipc_request_wraps_connection_error` and `tests/test_cli_main.py::test_ipc_queue_stats_connection_error`).  

### Testing

- Run the full verification suite with `python scripts/verify.py`, which completed successfully in CI for this change.  
- Unit tests added are `tests/test_ipc.py::test_ipc_request_wraps_connection_error` and `tests/test_cli_main.py::test_ipc_queue_stats_connection_error`, and both pass under `pytest`/`unittest` run via the verifier.  
- Manual CLI smoke check: running `python -m gismo.cli.main ipc queue-stats` when the IPC server is not running prints the two-line message `IPC server not running. Start it with: python -m gismo.cli.main ipc serve` and `Ensure GISMO_IPC_TOKEN matches on server and client.` and exits with code `2`.  
- No changes were made to the IPC protocol or security semantics; only client-side error handling and CLI messaging were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d9b56e6088330a66184806adceabc)