### PR TITLE
Add IPC daemon controls and queue maintenance

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -33,10 +33,13 @@
 - Added local IPC control plane (named pipe/Unix socket) with token auth, CLI wiring, and handler tests.
 - Restored global CLI db flag parsing and IPC subcommand support for db path overrides.
 - Added IPC client connection error handling with friendly CLI messaging and tests.
+- Added daemon pause state persistence, IPC daemon controls, and queue maintenance IPC actions.
+- Added queue requeue-stale and purge-failed IPC behaviors with coverage tests.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
 - Validate IPC client connection errors on Windows named pipes.
+- Validate IPC daemon pause/resume behavior in long-running deployments.
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ python -m gismo.cli.main --db .gismo/state.db ipc queue-stats
 python -m gismo.cli.main ipc serve --db .gismo/state.db
 python -m gismo.cli.main ipc enqueue "echo: hello"
 python -m gismo.cli.main ipc queue-stats
+python -m gismo.cli.main ipc daemon-status
+python -m gismo.cli.main ipc daemon-pause
+python -m gismo.cli.main ipc daemon-resume
+python -m gismo.cli.main ipc purge-failed
+python -m gismo.cli.main ipc requeue-stale --older-than-minutes 10 --limit 25
 python -m gismo.cli.main ipc run-show <RUN_ID>
 ```
 

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -166,6 +166,37 @@ def handle_ipc_request(
             data = _serialize_queue_stats(stats)
             data["db_path"] = state_store.db_path
             return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "daemon_status":
+            data = {"paused": state_store.get_daemon_paused()}
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "daemon_pause":
+            state_store.set_daemon_paused(True)
+            data = {"paused": True}
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "daemon_resume":
+            state_store.set_daemon_paused(False)
+            data = {"paused": False}
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "queue_purge_failed":
+            deleted = state_store.delete_queue_items_by_status(QueueStatus.FAILED)
+            data = {"deleted": deleted}
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "queue_requeue_stale":
+            older_than_minutes = int(args.get("older_than_minutes", 0))
+            limit = args.get("limit")
+            limit_value = int(limit) if limit is not None else 100
+            if older_than_minutes <= 0:
+                raise ValueError("older_than_minutes must be > 0")
+            updated = state_store.requeue_stale_in_progress_queue(
+                older_than_seconds=older_than_minutes * 60,
+                limit=limit_value,
+            )
+            data = {
+                "requeued": updated,
+                "older_than_minutes": older_than_minutes,
+                "limit": limit_value,
+            }
+            return IPCResponse(True, request_id, data, None).to_dict()
         if action == "run_show":
             run_id = str(args.get("run_id") or "").strip()
             if not run_id:
@@ -357,6 +388,37 @@ def format_queue_stats_output(stats: Dict[str, Any]) -> str:
 
 def format_enqueue_output(data: Dict[str, Any]) -> str:
     return f"Enqueued {data['queue_item_id']} status={data['status']}"
+
+
+def format_daemon_status_output(data: Dict[str, Any]) -> str:
+    paused = data.get("paused", False)
+    state = "paused" if paused else "running"
+    return f"Daemon status: {state}"
+
+
+def format_daemon_pause_output(data: Dict[str, Any]) -> str:
+    paused = data.get("paused", False)
+    return "Daemon paused." if paused else "Daemon pause failed."
+
+
+def format_daemon_resume_output(data: Dict[str, Any]) -> str:
+    paused = data.get("paused", True)
+    return "Daemon resumed." if not paused else "Daemon resume failed."
+
+
+def format_queue_purge_failed_output(data: Dict[str, Any]) -> str:
+    deleted = int(data.get("deleted", 0))
+    return f"Deleted {deleted} failed queue item(s)."
+
+
+def format_queue_requeue_stale_output(data: Dict[str, Any]) -> str:
+    requeued = int(data.get("requeued", 0))
+    older_than_minutes = data.get("older_than_minutes", "-")
+    limit = data.get("limit", "-")
+    return (
+        f"Requeued {requeued} stale queue item(s) "
+        f"(older_than_minutes={older_than_minutes}, limit={limit})."
+    )
 
 
 def format_run_show_output(payload: Dict[str, Any]) -> str:

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -800,6 +800,111 @@ def _handle_ipc_run_show(args: argparse.Namespace) -> None:
     print(ipc_cli.format_run_show_output(response.data or {}))
 
 
+def _handle_ipc_daemon_status(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    try:
+        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("daemon_status", {}, token))
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_daemon_status_output(response.data or {}))
+
+
+def _handle_ipc_daemon_pause(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    try:
+        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("daemon_pause", {}, token))
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_daemon_pause_output(response.data or {}))
+
+
+def _handle_ipc_daemon_resume(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    try:
+        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("daemon_resume", {}, token))
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_daemon_resume_output(response.data or {}))
+
+
+def _handle_ipc_purge_failed(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    try:
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("queue_purge_failed", {}, token)
+        )
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_queue_purge_failed_output(response.data or {}))
+
+
+def _handle_ipc_requeue_stale(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    payload = {"older_than_minutes": args.older_than_minutes, "limit": args.limit}
+    try:
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("queue_requeue_stale", payload, token)
+        )
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_queue_requeue_stale_output(response.data or {}))
+
+
 def build_parser() -> argparse.ArgumentParser:
     default_db_path = str(Path(".gismo") / "state.db")
     db_parent = argparse.ArgumentParser(add_help=False)
@@ -1172,6 +1277,78 @@ def build_parser() -> argparse.ArgumentParser:
         help="IPC auth token (or set GISMO_IPC_TOKEN)",
     )
     ipc_queue_stats_parser.set_defaults(handler=_handle_ipc_queue_stats)
+
+    ipc_daemon_status_parser = ipc_subparsers.add_parser(
+        "daemon-status",
+        help="Show daemon status via IPC",
+        parents=[db_parent_optional],
+    )
+    ipc_daemon_status_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_daemon_status_parser.set_defaults(handler=_handle_ipc_daemon_status)
+
+    ipc_daemon_pause_parser = ipc_subparsers.add_parser(
+        "daemon-pause",
+        help="Pause daemon processing via IPC",
+        parents=[db_parent_optional],
+    )
+    ipc_daemon_pause_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_daemon_pause_parser.set_defaults(handler=_handle_ipc_daemon_pause)
+
+    ipc_daemon_resume_parser = ipc_subparsers.add_parser(
+        "daemon-resume",
+        help="Resume daemon processing via IPC",
+        parents=[db_parent_optional],
+    )
+    ipc_daemon_resume_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_daemon_resume_parser.set_defaults(handler=_handle_ipc_daemon_resume)
+
+    ipc_purge_failed_parser = ipc_subparsers.add_parser(
+        "purge-failed",
+        help="Delete failed queue items via IPC",
+        parents=[db_parent_optional],
+    )
+    ipc_purge_failed_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_purge_failed_parser.set_defaults(handler=_handle_ipc_purge_failed)
+
+    ipc_requeue_stale_parser = ipc_subparsers.add_parser(
+        "requeue-stale",
+        help="Requeue stale in-progress items via IPC",
+        parents=[db_parent_optional],
+    )
+    ipc_requeue_stale_parser.add_argument(
+        "--older-than-minutes",
+        type=int,
+        required=True,
+        help="Requeue items older than this many minutes",
+    )
+    ipc_requeue_stale_parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum number of stale items to requeue",
+    )
+    ipc_requeue_stale_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_requeue_stale_parser.set_defaults(handler=_handle_ipc_requeue_stale)
 
     ipc_run_show_parser = ipc_subparsers.add_parser(
         "run-show",

--- a/gismo/core/daemon.py
+++ b/gismo/core/daemon.py
@@ -32,6 +32,9 @@ def run_daemon_loop(
     stop_event = threading.Event()
     _register_shutdown_handlers(stop_event)
     while not stop_event.is_set():
+        if state.get_daemon_paused():
+            stop_event.wait(sleep_seconds)
+            continue
         item = state.claim_next_queue_item()
         if item is None:
             if once:

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -111,7 +111,23 @@ class StateStore:
                 )
                 """
             )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS daemon_control (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    paused INTEGER NOT NULL DEFAULT 0,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
             self._ensure_columns(connection)
+            cursor.execute(
+                """
+                INSERT OR IGNORE INTO daemon_control (id, paused, updated_at)
+                VALUES (1, 0, ?)
+                """,
+                (_utc_now().isoformat(),),
+            )
             connection.commit()
 
     def _ensure_columns(self, connection: sqlite3.Connection) -> None:
@@ -572,6 +588,92 @@ class StateStore:
                 updated += 1
             connection.commit()
         return updated
+
+    def requeue_stale_in_progress_queue(
+        self,
+        older_than_seconds: int,
+        limit: int | None = None,
+        *,
+        now: datetime | None = None,
+    ) -> int:
+        if older_than_seconds <= 0:
+            raise ValueError("older_than_seconds must be > 0")
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be > 0")
+        current_time = now or _utc_now()
+        threshold = current_time.timestamp() - older_than_seconds
+        updated = 0
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM queue_items
+                WHERE status = ? AND started_at IS NOT NULL
+                ORDER BY started_at ASC
+                """,
+                (QueueStatus.IN_PROGRESS.value,),
+            ).fetchall()
+            for row in rows:
+                if limit is not None and updated >= limit:
+                    break
+                started_at = _parse_dt(row["started_at"]).timestamp()
+                if started_at >= threshold:
+                    continue
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
+                        started_at = NULL
+                    WHERE id = ?
+                    """,
+                    (
+                        QueueStatus.QUEUED.value,
+                        current_time.isoformat(),
+                        row["attempt_count"] + 1,
+                        "Requeued stale in-progress item.",
+                        row["id"],
+                    ),
+                )
+                updated += 1
+            connection.commit()
+        return updated
+
+    def get_daemon_paused(self) -> bool:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT paused FROM daemon_control WHERE id = 1",
+            ).fetchone()
+            if row is None:
+                connection.execute(
+                    """
+                    INSERT INTO daemon_control (id, paused, updated_at)
+                    VALUES (1, 0, ?)
+                    """,
+                    (_utc_now().isoformat(),),
+                )
+                connection.commit()
+                return False
+            return bool(row["paused"])
+
+    def set_daemon_paused(self, paused: bool) -> None:
+        now = _utc_now().isoformat()
+        with self._connection() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE daemon_control
+                SET paused = ?, updated_at = ?
+                WHERE id = 1
+                """,
+                (1 if paused else 0, now),
+            )
+            if cursor.rowcount == 0:
+                connection.execute(
+                    """
+                    INSERT INTO daemon_control (id, paused, updated_at)
+                    VALUES (1, ?, ?)
+                    """,
+                    (1 if paused else 0, now),
+                )
+            connection.commit()
 
     def get_queue_item(self, item_id: str) -> Optional[QueueItem]:
         with self._connection() as connection:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -99,6 +99,44 @@ class IpcHandlerTest(unittest.TestCase):
             with self.assertRaises(ipc_cli.IPCConnectionError):
                 ipc_cli.ipc_request("queue_stats", {}, self.token)
 
+    def test_new_actions_require_token(self) -> None:
+        actions = [
+            "daemon_status",
+            "daemon_pause",
+            "daemon_resume",
+            "queue_purge_failed",
+            "queue_requeue_stale",
+        ]
+        for action in actions:
+            with self.subTest(action=action):
+                response = ipc_cli.handle_ipc_request(
+                    {"action": action, "args": {}},
+                    expected_token=self.token,
+                    state_store=self.state_store,
+                )
+                self.assertFalse(response["ok"])
+                self.assertEqual(response["error"], "unauthorized")
+
+    def test_queue_purge_failed_deletes_only_failed(self) -> None:
+        failed_item = self.state_store.enqueue_command("echo: fail")
+        self.state_store.mark_queue_item_failed(failed_item.id, "boom", retryable=False)
+        queued_item = self.state_store.enqueue_command("echo: queued")
+        succeeded_item = self.state_store.enqueue_command("echo: ok")
+        self.state_store.mark_queue_item_succeeded(succeeded_item.id)
+
+        response = ipc_cli.handle_ipc_request(
+            {"action": "queue_purge_failed", "token": self.token, "args": {}},
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertTrue(response["ok"])
+        data = response["data"]
+        assert data is not None
+        self.assertEqual(data["deleted"], 1)
+        self.assertIsNone(self.state_store.get_queue_item(failed_item.id))
+        self.assertIsNotNone(self.state_store.get_queue_item(queued_item.id))
+        self.assertIsNotNone(self.state_store.get_queue_item(succeeded_item.id))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,82 @@
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from gismo.core.models import QueueStatus
+from gismo.core.state import StateStore
+
+
+class StateStoreTest(unittest.TestCase):
+    def test_daemon_control_state_persists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            self.assertFalse(state_store.get_daemon_paused())
+            state_store.set_daemon_paused(True)
+            self.assertTrue(state_store.get_daemon_paused())
+
+            reloaded = StateStore(db_path)
+            self.assertTrue(reloaded.get_daemon_paused())
+            reloaded.set_daemon_paused(False)
+            self.assertFalse(reloaded.get_daemon_paused())
+
+    def test_requeue_stale_in_progress_queue(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            now = datetime.now(timezone.utc)
+            stale_start = now - timedelta(minutes=15)
+            recent_start = now - timedelta(minutes=2)
+
+            stale_item = state_store.enqueue_command("echo: stale")
+            recent_item = state_store.enqueue_command("echo: recent")
+
+            with state_store._connection() as connection:  # pylint: disable=protected-access
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET status = ?, started_at = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        QueueStatus.IN_PROGRESS.value,
+                        stale_start.isoformat(),
+                        stale_start.isoformat(),
+                        stale_item.id,
+                    ),
+                )
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET status = ?, started_at = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (
+                        QueueStatus.IN_PROGRESS.value,
+                        recent_start.isoformat(),
+                        recent_start.isoformat(),
+                        recent_item.id,
+                    ),
+                )
+                connection.commit()
+
+            updated = state_store.requeue_stale_in_progress_queue(
+                older_than_seconds=10 * 60,
+                limit=1,
+                now=now,
+            )
+            self.assertEqual(updated, 1)
+
+            stale = state_store.get_queue_item(stale_item.id)
+            recent = state_store.get_queue_item(recent_item.id)
+            assert stale is not None
+            assert recent is not None
+            self.assertEqual(stale.status, QueueStatus.QUEUED)
+            self.assertIsNone(stale.started_at)
+            self.assertEqual(stale.attempt_count, 1)
+            self.assertEqual(recent.status, QueueStatus.IN_PROGRESS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide safe local control over the headless daemon (status, pause, resume) and basic queue maintenance without adding network listeners or new dependencies.
- Persist daemon control state so pause/resume survives restarts and ensures the daemon can be administratively halted without interrupting in-flight work.
- Expose limited, token-protected IPC actions for operators to perform maintenance (`purge-failed`, `requeue-stale`) while preserving existing permission gating.
- Keep behavior deterministic and Windows-safe by ensuring no long-lived DB handles are kept between loop iterations.

### Description
- Added a `daemon_control` SQLite table and new `StateStore` APIs: `get_daemon_paused()` and `set_daemon_paused()` and `requeue_stale_in_progress_queue(...)` for controlled requeueing.
- Updated the daemon loop in `gismo/core/daemon.py` to check `state.get_daemon_paused()` each iteration and sleep/continue if paused, while preserving clean Ctrl+C shutdown and avoiding lingering DB connections.
- Extended the IPC handler in `gismo/cli/ipc.py` with actions `daemon_status`, `daemon_pause`, `daemon_resume`, `queue_purge_failed`, and `queue_requeue_stale`, plus corresponding formatting helpers for CLI output.
- Added CLI wiring in `gismo/cli/main.py` for `ipc daemon-status`, `ipc daemon-pause`, `ipc daemon-resume`, `ipc purge-failed`, and `ipc requeue-stale`, and added unit tests (`tests/test_state_store.py` and IPC test additions).
- Note / limitation: daemon pause applies at loop boundaries and will not interrupt tasks already in progress, and `queue_requeue_stale` increments attempt counts when requeuing (use with care).

### Testing
- Ran the repository verification: `python scripts/verify.py`, which executed the test suite and completed successfully (all tests passed).
- Added unit tests `tests/test_state_store.py` (daemon control persistence and requeue logic) and extended `tests/test_ipc.py` (token enforcement and `purge-failed`), and these tests passed under verification.
- Existing daemon and queue tests (`tests/test_daemon_queue.py`, etc.) were exercised as part of verification and passed.
- Total automated test run reported success (all tests in `tests/` passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da3bae3a88330adb11744837cefae)