### PR TITLE
Add supervise CLI for IPC and daemon control

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -35,11 +35,13 @@
 - Added IPC client connection error handling with friendly CLI messaging and tests.
 - Added daemon pause state persistence, IPC daemon controls, and queue maintenance IPC actions.
 - Added queue requeue-stale and purge-failed IPC behaviors with coverage tests.
+- Added supervise CLI command to run IPC server and daemon together with PID-based control.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
 - Validate IPC client connection errors on Windows named pipes.
 - Validate IPC daemon pause/resume behavior in long-running deployments.
+- Validate supervise up/down behavior on Windows named pipes and terminal restarts.
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ python -m gismo.cli.main ipc requeue-stale --older-than-minutes 10 --limit 25
 python -m gismo.cli.main ipc run-show <RUN_ID>
 ```
 
+Local supervisor (IPC + daemon in one terminal):
+
+```bash
+export GISMO_IPC_TOKEN="your-token"
+python -m gismo.cli.main supervise up --db .gismo/state.db
+python -m gismo.cli.main supervise status --db .gismo/state.db
+python -m gismo.cli.main supervise down --db .gismo/state.db
+```
+
 Install the Windows Task Scheduler entry for an always-on daemon:
 
 ```bash

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -166,6 +166,9 @@ def handle_ipc_request(
             data = _serialize_queue_stats(stats)
             data["db_path"] = state_store.db_path
             return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "ping":
+            data = {"status": "ok"}
+            return IPCResponse(True, request_id, data, None).to_dict()
         if action == "daemon_status":
             data = {"paused": state_store.get_daemon_paused()}
             return IPCResponse(True, request_id, data, None).to_dict()

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -14,6 +14,7 @@ from gismo.cli.operator import (
     required_tools,
 )
 from gismo.cli import ipc as ipc_cli
+from gismo.cli import supervise as supervise_cli
 from gismo.cli.windows_startup import (
     install_windows_startup_launcher,
     uninstall_windows_startup_launcher,
@@ -905,6 +906,28 @@ def _handle_ipc_requeue_stale(args: argparse.Namespace) -> None:
     print(ipc_cli.format_queue_requeue_stale_output(response.data or {}))
 
 
+def _handle_supervise_up(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    supervise_cli.run_supervise_up(args.db_path, token)
+
+
+def _handle_supervise_status(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    supervise_cli.run_supervise_status(token, db_path=args.db_path)
+
+
+def _handle_supervise_down(_args: argparse.Namespace) -> None:
+    supervise_cli.run_supervise_down()
+
+
 def build_parser() -> argparse.ArgumentParser:
     default_db_path = str(Path(".gismo") / "state.db")
     db_parent = argparse.ArgumentParser(add_help=False)
@@ -1140,6 +1163,48 @@ def build_parser() -> argparse.ArgumentParser:
         help="Confirm removal (required to delete the launcher)",
     )
     daemon_uninstall_startup_parser.set_defaults(handler=_handle_daemon_uninstall_windows_startup)
+
+    supervise_parser = subparsers.add_parser(
+        "supervise",
+        aliases=["svc"],
+        help="Run IPC + daemon together",
+        parents=[db_parent_optional],
+    )
+    supervise_subparsers = supervise_parser.add_subparsers(
+        dest="supervise_command",
+        required=True,
+    )
+
+    supervise_up_parser = supervise_subparsers.add_parser(
+        "up",
+        help="Start IPC server and daemon worker",
+        parents=[db_parent_optional],
+    )
+    supervise_up_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    supervise_up_parser.set_defaults(handler=_handle_supervise_up)
+
+    supervise_status_parser = supervise_subparsers.add_parser(
+        "status",
+        help="Show supervisor status",
+        parents=[db_parent_optional],
+    )
+    supervise_status_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    supervise_status_parser.set_defaults(handler=_handle_supervise_status)
+
+    supervise_down_parser = supervise_subparsers.add_parser(
+        "down",
+        help="Stop supervisor-managed processes",
+        parents=[db_parent_optional],
+    )
+    supervise_down_parser.set_defaults(handler=_handle_supervise_down)
 
     queue_parser = subparsers.add_parser(
         "queue",

--- a/gismo/cli/supervise.py
+++ b/gismo/cli/supervise.py
@@ -1,0 +1,308 @@
+"""Supervisor helpers for running IPC + daemon together."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+
+from gismo.cli import ipc as ipc_cli
+
+
+@dataclass(frozen=True)
+class SupervisorRecord:
+    ipc_pid: int
+    daemon_pid: int
+    db_path: str
+    started_at: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ipc_pid": self.ipc_pid,
+            "daemon_pid": self.daemon_pid,
+            "db_path": self.db_path,
+            "started_at": self.started_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "SupervisorRecord":
+        return cls(
+            ipc_pid=int(data["ipc_pid"]),
+            daemon_pid=int(data["daemon_pid"]),
+            db_path=str(data["db_path"]),
+            started_at=str(data["started_at"]),
+        )
+
+
+@dataclass(frozen=True)
+class SupervisorProcessStatus:
+    ipc_running: bool
+    daemon_running: bool
+
+
+class ProcessOps(Protocol):
+    def spawn(self, argv: list[str], env: dict[str, str]) -> subprocess.Popen[str]:
+        """Spawn a child process."""
+
+    def is_running(self, pid: int) -> bool:
+        """Check if a PID is running."""
+
+    def terminate(self, pid: int) -> None:
+        """Terminate a PID."""
+
+    def kill(self, pid: int) -> None:
+        """Kill a PID."""
+
+
+class DefaultProcessOps:
+    def spawn(self, argv: list[str], env: dict[str, str]) -> subprocess.Popen[str]:
+        kwargs: dict[str, object] = {
+            "stdout": subprocess.PIPE,
+            "stderr": subprocess.STDOUT,
+            "text": True,
+            "bufsize": 1,
+            "env": env,
+        }
+        if os.name == "nt":
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+        else:
+            kwargs["start_new_session"] = True
+        return subprocess.Popen(argv, **kwargs)
+
+    def is_running(self, pid: int) -> bool:
+        if pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except PermissionError:
+            return True
+        except OSError:
+            return False
+        return True
+
+    def terminate(self, pid: int) -> None:
+        os.kill(pid, signal.SIGTERM)
+
+    def kill(self, pid: int) -> None:
+        sig = signal.SIGKILL if hasattr(signal, "SIGKILL") else signal.SIGTERM
+        os.kill(pid, sig)
+
+
+def default_pid_path() -> Path:
+    return Path(".gismo") / "supervise.json"
+
+
+def load_supervisor_record(path: Path) -> SupervisorRecord | None:
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Supervisor PID file is invalid.")
+    return SupervisorRecord.from_dict(data)
+
+
+def save_supervisor_record(path: Path, record: SupervisorRecord) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(record.to_dict(), indent=2, sort_keys=True)
+    path.write_text(payload, encoding="utf-8")
+
+
+def summarize_supervisor_status(
+    record: SupervisorRecord,
+    process_ops: ProcessOps,
+) -> SupervisorProcessStatus:
+    return SupervisorProcessStatus(
+        ipc_running=process_ops.is_running(record.ipc_pid),
+        daemon_running=process_ops.is_running(record.daemon_pid),
+    )
+
+
+def run_supervise_up(
+    db_path: str,
+    token: str,
+    *,
+    pid_path: Path | None = None,
+    process_ops: ProcessOps | None = None,
+) -> None:
+    process_ops = process_ops or DefaultProcessOps()
+    pid_path = pid_path or default_pid_path()
+    existing = load_supervisor_record(pid_path)
+    if existing is not None:
+        status = summarize_supervisor_status(existing, process_ops)
+        if status.ipc_running or status.daemon_running:
+            print("Supervisor already running.")
+            return
+        pid_path.unlink(missing_ok=True)
+
+    env = os.environ.copy()
+    env["GISMO_IPC_TOKEN"] = token
+    env["PYTHONUNBUFFERED"] = "1"
+    ipc_args = [
+        sys.executable,
+        "-m",
+        "gismo.cli.main",
+        "ipc",
+        "serve",
+        "--db",
+        db_path,
+        "--token",
+        token,
+    ]
+    daemon_args = [
+        sys.executable,
+        "-m",
+        "gismo.cli.main",
+        "daemon",
+        "--db",
+        db_path,
+    ]
+
+    ipc_proc = process_ops.spawn(ipc_args, env=env)
+    daemon_proc = process_ops.spawn(daemon_args, env=env)
+    record = SupervisorRecord(
+        ipc_pid=ipc_proc.pid,
+        daemon_pid=daemon_proc.pid,
+        db_path=db_path,
+        started_at=datetime.now(timezone.utc).isoformat(),
+    )
+    save_supervisor_record(pid_path, record)
+
+    stop_event = threading.Event()
+    threads = [
+        _start_output_thread(ipc_proc, "[ipc]", stop_event),
+        _start_output_thread(daemon_proc, "[daemon]", stop_event),
+    ]
+
+    try:
+        while True:
+            if ipc_proc.poll() is not None or daemon_proc.poll() is not None:
+                break
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop_event.set()
+        _terminate_process(ipc_proc.pid, process_ops)
+        _terminate_process(daemon_proc.pid, process_ops)
+        pid_path.unlink(missing_ok=True)
+        for thread in threads:
+            thread.join(timeout=1.0)
+
+
+def run_supervise_status(
+    token: str,
+    *,
+    db_path: str | None = None,
+    pid_path: Path | None = None,
+    process_ops: ProcessOps | None = None,
+) -> None:
+    process_ops = process_ops or DefaultProcessOps()
+    pid_path = pid_path or default_pid_path()
+    record = load_supervisor_record(pid_path)
+    if record is None:
+        print("not running")
+        return
+    status = summarize_supervisor_status(record, process_ops)
+    lines = [
+        "GISMO supervise status",
+        f"pid_file: {pid_path}",
+        f"db_path: {record.db_path}",
+        f"ipc_pid: {record.ipc_pid} ({_fmt_running(status.ipc_running)})",
+        f"daemon_pid: {record.daemon_pid} ({_fmt_running(status.daemon_running)})",
+    ]
+    if db_path and db_path != record.db_path:
+        lines.append(f"db_path_mismatch: requested={db_path}")
+    ipc_reachable = False
+    ipc_error = None
+    try:
+        ping = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("ping", {}, token))
+        ipc_reachable = ping.ok
+        if not ping.ok:
+            ipc_error = ping.error or "unknown"
+    except ipc_cli.IPCConnectionError:
+        ipc_error = "connection_failed"
+    lines.append(f"ipc_ping: {_fmt_ping(ipc_reachable, ipc_error)}")
+    if ipc_reachable:
+        daemon_status = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("daemon_status", {}, token)
+        )
+        if daemon_status.ok:
+            paused = bool(daemon_status.data and daemon_status.data.get("paused"))
+            lines.append(f"daemon_paused: {paused}")
+        else:
+            lines.append(f"daemon_paused: error ({daemon_status.error})")
+    print("\n".join(lines))
+
+
+def run_supervise_down(
+    *,
+    pid_path: Path | None = None,
+    process_ops: ProcessOps | None = None,
+) -> None:
+    process_ops = process_ops or DefaultProcessOps()
+    pid_path = pid_path or default_pid_path()
+    record = load_supervisor_record(pid_path)
+    if record is None:
+        print("not running")
+        return
+    _terminate_process(record.ipc_pid, process_ops)
+    _terminate_process(record.daemon_pid, process_ops)
+    pid_path.unlink(missing_ok=True)
+    print("stopped")
+
+
+def _terminate_process(pid: int, process_ops: ProcessOps, timeout_seconds: float = 5.0) -> None:
+    if not process_ops.is_running(pid):
+        return
+    try:
+        process_ops.terminate(pid)
+    except OSError:
+        return
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if not process_ops.is_running(pid):
+            return
+        time.sleep(0.1)
+    try:
+        process_ops.kill(pid)
+    except OSError:
+        return
+
+
+def _start_output_thread(
+    process: subprocess.Popen[str],
+    prefix: str,
+    stop_event: threading.Event,
+) -> threading.Thread:
+    def _runner() -> None:
+        stream = process.stdout
+        if stream is None:
+            return
+        for line in iter(stream.readline, ""):
+            if stop_event.is_set():
+                break
+            print(f"{prefix} {line.rstrip()}")
+        stream.close()
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    return thread
+
+
+def _fmt_running(value: bool) -> str:
+    return "running" if value else "stopped"
+
+
+def _fmt_ping(ok: bool, error: str | None) -> str:
+    if ok:
+        return "ok"
+    if error:
+        return f"error ({error})"
+    return "error"

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -81,6 +81,14 @@ class CliMainParserTest(unittest.TestCase):
         serve_args = parser.parse_args(["ipc", "serve", "--db", db_path])
         self.assertEqual(serve_args.db_path, db_path)
 
+    def test_supervise_subcommand_routes_to_supervise(self) -> None:
+        parser = cli_main.build_parser()
+        args = parser.parse_args(["supervise", "status", "--token", "token"])
+
+        self.assertEqual(args.command, "supervise")
+        self.assertEqual(args.supervise_command, "status")
+        self.assertIs(args.handler, cli_main._handle_supervise_status)
+
     def test_enqueue_and_daemon_share_db_path(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]
         policy_path = str(repo_root / "policy" / "readonly.json")

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -101,6 +101,7 @@ class IpcHandlerTest(unittest.TestCase):
 
     def test_new_actions_require_token(self) -> None:
         actions = [
+            "ping",
             "daemon_status",
             "daemon_pause",
             "daemon_resume",
@@ -136,6 +137,17 @@ class IpcHandlerTest(unittest.TestCase):
         self.assertIsNone(self.state_store.get_queue_item(failed_item.id))
         self.assertIsNotNone(self.state_store.get_queue_item(queued_item.id))
         self.assertIsNotNone(self.state_store.get_queue_item(succeeded_item.id))
+
+    def test_ping_response_shape(self) -> None:
+        response = ipc_cli.handle_ipc_request(
+            {"action": "ping", "token": self.token, "args": {}},
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertTrue(response["ok"])
+        data = response["data"]
+        assert data is not None
+        self.assertEqual(data["status"], "ok")
 
 
 if __name__ == "__main__":

--- a/tests/test_supervise.py
+++ b/tests/test_supervise.py
@@ -1,0 +1,61 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.cli import supervise as supervise_cli
+
+
+class FakeProcessOps:
+    def __init__(self, running: set[int]) -> None:
+        self._running = running
+
+    def spawn(self, argv: list[str], env: dict[str, str]) -> None:
+        raise AssertionError("spawn should not be called in tests")
+
+    def is_running(self, pid: int) -> bool:
+        return pid in self._running
+
+    def terminate(self, pid: int) -> None:
+        raise AssertionError("terminate should not be called in tests")
+
+    def kill(self, pid: int) -> None:
+        raise AssertionError("kill should not be called in tests")
+
+
+class SupervisePidFileTest(unittest.TestCase):
+    def test_save_and_load_supervisor_record(self) -> None:
+        record = supervise_cli.SupervisorRecord(
+            ipc_pid=1001,
+            daemon_pid=1002,
+            db_path=".gismo/state.db",
+            started_at="2024-01-01T00:00:00Z",
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "supervise.json"
+            supervise_cli.save_supervisor_record(path, record)
+            loaded = supervise_cli.load_supervisor_record(path)
+            self.assertEqual(record, loaded)
+
+    def test_load_missing_supervisor_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "missing.json"
+            loaded = supervise_cli.load_supervisor_record(path)
+            self.assertIsNone(loaded)
+
+
+class SuperviseStatusTest(unittest.TestCase):
+    def test_summarize_supervisor_status(self) -> None:
+        record = supervise_cli.SupervisorRecord(
+            ipc_pid=2001,
+            daemon_pid=2002,
+            db_path="state.db",
+            started_at="2024-01-02T00:00:00Z",
+        )
+        process_ops = FakeProcessOps(running={2002})
+        status = supervise_cli.summarize_supervisor_status(record, process_ops)
+        self.assertFalse(status.ipc_running)
+        self.assertTrue(status.daemon_running)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a single, operator-friendly command to start/stop GISMO's IPC server and daemon together in one terminal.
- Support Windows usage without requiring admin privileges and avoid TCP networking by using the existing IPC transport and token auth.
- Allow supervisor-managed processes to persist across terminal restarts via a PID file under `.gismo/`.

### Description

- Added a new CLI helper module `gismo.cli.supervise` implementing `run_supervise_up`, `run_supervise_status`, and `run_supervise_down` and a `SupervisorRecord` persisted to `.gismo/supervise.json`.
- Implemented `DefaultProcessOps` which uses `subprocess.Popen` (no `shell=True`) and safe termination semantics for Windows and POSIX, and an abstract `ProcessOps` protocol so process ops are faked in tests.
- Wired `supervise` (alias `svc`) subcommands into `gismo.cli.main` (`supervise up`, `supervise status`, `supervise down`) and added an IPC `ping` action to `gismo.cli.ipc` to allow reachability checks.
- Added unit tests `tests/test_supervise.py`, updated `tests/test_ipc.py` and `tests/test_cli_main.py`, and documented usage in `README.md` and `Handoff.md`.

### Testing

- Ran the repository verification suite with `python scripts/verify.py`, which executed the unit test suite and completed successfully (all tests passed).
- New and updated unit tests include `tests/test_supervise.py`, updated `tests/test_ipc.py` (added `ping` response test), and `tests/test_cli_main.py` (supervise parser test), and they passed as part of the verification run.
- Existing automated tests were left unchanged in behavior and passed during verification.
- To re-run verification locally use `python scripts/verify.py` (this runs the full `unittest` suite used for CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da9bb13b483309e4f5b87c93ca3c4)