### PR TITLE
Add IPC ping CLI and supervise reuse of existing IPC (Windows startup fix)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -36,6 +36,7 @@
 - Added daemon pause state persistence, IPC daemon controls, and queue maintenance IPC actions.
 - Added queue requeue-stale and purge-failed IPC behaviors with coverage tests.
 - Added supervise CLI command to run IPC server and daemon together with PID-based control.
+- Added IPC ping CLI wiring plus supervisor reuse/authorization checks and PID tracking for started children.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ export GISMO_IPC_TOKEN="your-token"
 python -m gismo.cli.main --db .gismo/state.db ipc queue-stats
 python -m gismo.cli.main ipc serve --db .gismo/state.db
 python -m gismo.cli.main ipc enqueue "echo: hello"
+python -m gismo.cli.main ipc ping
 python -m gismo.cli.main ipc queue-stats
 python -m gismo.cli.main ipc daemon-status
 python -m gismo.cli.main ipc daemon-pause

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -389,6 +389,11 @@ def format_queue_stats_output(stats: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def format_ping_output(data: Dict[str, Any]) -> str:
+    status = data.get("status", "unknown")
+    return f"IPC: {status}"
+
+
 def format_enqueue_output(data: Dict[str, Any]) -> str:
     return f"Enqueued {data['queue_item_id']} status={data['status']}"
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -757,6 +757,26 @@ def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
     print(ipc_cli.format_enqueue_output(response.data or {}))
 
 
+def _handle_ipc_ping(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    try:
+        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("ping", {}, token))
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_ping_output(response.data or {}))
+
+
 def _handle_ipc_queue_stats(args: argparse.Namespace) -> None:
     try:
         token = ipc_cli.load_ipc_token(args.token)
@@ -1330,6 +1350,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Operator command string to enqueue",
     )
     ipc_enqueue_parser.set_defaults(handler=_handle_ipc_enqueue)
+
+    ipc_ping_parser = ipc_subparsers.add_parser(
+        "ping",
+        help="Ping the IPC server",
+        parents=[db_parent_optional],
+    )
+    ipc_ping_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_ping_parser.set_defaults(handler=_handle_ipc_ping)
 
     ipc_queue_stats_parser = ipc_subparsers.add_parser(
         "queue-stats",

--- a/gismo/cli/supervise.py
+++ b/gismo/cli/supervise.py
@@ -20,6 +20,8 @@ from gismo.cli import ipc as ipc_cli
 class SupervisorRecord:
     ipc_pid: int
     daemon_pid: int
+    ipc_started: bool
+    daemon_started: bool
     db_path: str
     started_at: str
 
@@ -27,6 +29,8 @@ class SupervisorRecord:
         return {
             "ipc_pid": self.ipc_pid,
             "daemon_pid": self.daemon_pid,
+            "ipc_started": self.ipc_started,
+            "daemon_started": self.daemon_started,
             "db_path": self.db_path,
             "started_at": self.started_at,
         }
@@ -34,8 +38,10 @@ class SupervisorRecord:
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> "SupervisorRecord":
         return cls(
-            ipc_pid=int(data["ipc_pid"]),
-            daemon_pid=int(data["daemon_pid"]),
+            ipc_pid=int(data.get("ipc_pid", 0)),
+            daemon_pid=int(data.get("daemon_pid", 0)),
+            ipc_started=bool(data.get("ipc_started", True)),
+            daemon_started=bool(data.get("daemon_started", True)),
             db_path=str(data["db_path"]),
             started_at=str(data["started_at"]),
         )
@@ -141,6 +147,11 @@ def run_supervise_up(
             return
         pid_path.unlink(missing_ok=True)
 
+    ipc_reachable, ipc_authorized = _probe_ipc_server(token)
+    if ipc_reachable and not ipc_authorized:
+        print("IPC authorization failed. Ensure the supervisor token matches the running IPC server.")
+        raise SystemExit(1)
+
     env = os.environ.copy()
     env["GISMO_IPC_TOKEN"] = token
     env["PYTHONUNBUFFERED"] = "1"
@@ -164,32 +175,47 @@ def run_supervise_up(
         db_path,
     ]
 
-    ipc_proc = process_ops.spawn(ipc_args, env=env)
+    ipc_proc = None
+    ipc_pid = 0
+    ipc_started = False
+    if ipc_reachable and ipc_authorized:
+        print("[supervise] IPC already running; reusing existing server.")
+    else:
+        ipc_proc = process_ops.spawn(ipc_args, env=env)
+        ipc_pid = ipc_proc.pid
+        ipc_started = True
+
     daemon_proc = process_ops.spawn(daemon_args, env=env)
     record = SupervisorRecord(
-        ipc_pid=ipc_proc.pid,
+        ipc_pid=ipc_pid,
         daemon_pid=daemon_proc.pid,
+        ipc_started=ipc_started,
+        daemon_started=True,
         db_path=db_path,
         started_at=datetime.now(timezone.utc).isoformat(),
     )
     save_supervisor_record(pid_path, record)
 
     stop_event = threading.Event()
-    threads = [
-        _start_output_thread(ipc_proc, "[ipc]", stop_event),
-        _start_output_thread(daemon_proc, "[daemon]", stop_event),
-    ]
+    threads = []
+    if ipc_proc is not None:
+        threads.append(_start_output_thread(ipc_proc, "[ipc]", stop_event))
+    threads.append(_start_output_thread(daemon_proc, "[daemon]", stop_event))
 
+    processes = [proc for proc in (ipc_proc, daemon_proc) if proc is not None]
     try:
         while True:
-            if ipc_proc.poll() is not None or daemon_proc.poll() is not None:
+            if not processes:
+                break
+            if any(proc.poll() is not None for proc in processes):
                 break
             time.sleep(0.2)
     except KeyboardInterrupt:
         pass
     finally:
         stop_event.set()
-        _terminate_process(ipc_proc.pid, process_ops)
+        if ipc_proc is not None:
+            _terminate_process(ipc_proc.pid, process_ops)
         _terminate_process(daemon_proc.pid, process_ops)
         pid_path.unlink(missing_ok=True)
         for thread in threads:
@@ -252,8 +278,10 @@ def run_supervise_down(
     if record is None:
         print("not running")
         return
-    _terminate_process(record.ipc_pid, process_ops)
-    _terminate_process(record.daemon_pid, process_ops)
+    if record.ipc_started:
+        _terminate_process(record.ipc_pid, process_ops)
+    if record.daemon_started:
+        _terminate_process(record.daemon_pid, process_ops)
     pid_path.unlink(missing_ok=True)
     print("stopped")
 
@@ -306,3 +334,31 @@ def _fmt_ping(ok: bool, error: str | None) -> str:
     if error:
         return f"error ({error})"
     return "error"
+
+
+def _probe_ipc_server(token: str) -> tuple[bool, bool]:
+    try:
+        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("ping", {}, token))
+    except ipc_cli.IPCConnectionError:
+        return False, False
+    if response.ok:
+        return True, True
+    if response.error == "unauthorized":
+        return True, False
+    if response.error == "unsupported_action":
+        return _probe_ipc_fallback(token)
+    return False, False
+
+
+def _probe_ipc_fallback(token: str) -> tuple[bool, bool]:
+    try:
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("daemon_status", {}, token)
+        )
+    except ipc_cli.IPCConnectionError:
+        return False, False
+    if response.ok:
+        return True, True
+    if response.error == "unauthorized":
+        return True, False
+    return False, False

--- a/tests/test_supervise.py
+++ b/tests/test_supervise.py
@@ -1,25 +1,47 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from gismo.cli import supervise as supervise_cli
 
 
-class FakeProcessOps:
-    def __init__(self, running: set[int]) -> None:
-        self._running = running
+class FakeProcess:
+    def __init__(self, pid: int, poll_result: int | None = 0) -> None:
+        self.pid = pid
+        self._poll_result = poll_result
+        self.stdout = None
 
-    def spawn(self, argv: list[str], env: dict[str, str]) -> None:
-        raise AssertionError("spawn should not be called in tests")
+    def poll(self) -> int | None:
+        return self._poll_result
+
+
+class FakeProcessOps:
+    def __init__(
+        self,
+        spawn_processes: list[FakeProcess] | None = None,
+        running: set[int] | None = None,
+    ) -> None:
+        self._running = running or set()
+        self._spawn_processes = list(spawn_processes or [])
+        self.spawn_calls: list[list[str]] = []
+        self.terminated: list[int] = []
+        self.killed: list[int] = []
+
+    def spawn(self, argv: list[str], env: dict[str, str]) -> FakeProcess:
+        self.spawn_calls.append(argv)
+        if not self._spawn_processes:
+            raise AssertionError("unexpected spawn call")
+        return self._spawn_processes.pop(0)
 
     def is_running(self, pid: int) -> bool:
         return pid in self._running
 
     def terminate(self, pid: int) -> None:
-        raise AssertionError("terminate should not be called in tests")
+        self.terminated.append(pid)
 
     def kill(self, pid: int) -> None:
-        raise AssertionError("kill should not be called in tests")
+        self.killed.append(pid)
 
 
 class SupervisePidFileTest(unittest.TestCase):
@@ -27,6 +49,8 @@ class SupervisePidFileTest(unittest.TestCase):
         record = supervise_cli.SupervisorRecord(
             ipc_pid=1001,
             daemon_pid=1002,
+            ipc_started=True,
+            daemon_started=False,
             db_path=".gismo/state.db",
             started_at="2024-01-01T00:00:00Z",
         )
@@ -48,6 +72,8 @@ class SuperviseStatusTest(unittest.TestCase):
         record = supervise_cli.SupervisorRecord(
             ipc_pid=2001,
             daemon_pid=2002,
+            ipc_started=True,
+            daemon_started=True,
             db_path="state.db",
             started_at="2024-01-02T00:00:00Z",
         )
@@ -55,6 +81,82 @@ class SuperviseStatusTest(unittest.TestCase):
         status = supervise_cli.summarize_supervisor_status(record, process_ops)
         self.assertFalse(status.ipc_running)
         self.assertTrue(status.daemon_running)
+
+
+class SuperviseUpTest(unittest.TestCase):
+    def test_ipc_already_running_skips_ipc_spawn(self) -> None:
+        process_ops = FakeProcessOps(spawn_processes=[FakeProcess(3001)])
+        ping_response = {
+            "ok": True,
+            "request_id": "ping-1",
+            "data": {"status": "ok"},
+            "error": None,
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            pid_path = Path(tempdir) / "supervise.json"
+            with mock.patch(
+                "gismo.cli.supervise.ipc_cli.ipc_request",
+                return_value=ping_response,
+            ):
+                with mock.patch(
+                    "gismo.cli.supervise.save_supervisor_record"
+                ) as save_mock:
+                    supervise_cli.run_supervise_up(
+                        "state.db",
+                        "token",
+                        pid_path=pid_path,
+                        process_ops=process_ops,
+                    )
+        self.assertEqual(len(process_ops.spawn_calls), 1)
+        self.assertIn("daemon", process_ops.spawn_calls[0])
+        saved_record = save_mock.call_args.args[1]
+        self.assertFalse(saved_record.ipc_started)
+        self.assertTrue(saved_record.daemon_started)
+
+    def test_ipc_unauthorized_fails_cleanly(self) -> None:
+        process_ops = FakeProcessOps()
+        unauthorized_response = {
+            "ok": False,
+            "request_id": "ping-2",
+            "data": None,
+            "error": "unauthorized",
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            pid_path = Path(tempdir) / "supervise.json"
+            with mock.patch(
+                "gismo.cli.supervise.ipc_cli.ipc_request",
+                return_value=unauthorized_response,
+            ):
+                with self.assertRaises(SystemExit) as context:
+                    supervise_cli.run_supervise_up(
+                        "state.db",
+                        "bad-token",
+                        pid_path=pid_path,
+                        process_ops=process_ops,
+                    )
+        self.assertNotEqual(context.exception.code, 0)
+        self.assertEqual(process_ops.spawn_calls, [])
+
+    def test_pid_record_captures_started_children(self) -> None:
+        process_ops = FakeProcessOps(spawn_processes=[FakeProcess(4001), FakeProcess(4002)])
+        with tempfile.TemporaryDirectory() as tempdir:
+            pid_path = Path(tempdir) / "supervise.json"
+            with mock.patch(
+                "gismo.cli.supervise.ipc_cli.ipc_request",
+                side_effect=supervise_cli.ipc_cli.IPCConnectionError("down"),
+            ):
+                with mock.patch(
+                    "gismo.cli.supervise.save_supervisor_record"
+                ) as save_mock:
+                    supervise_cli.run_supervise_up(
+                        "state.db",
+                        "token",
+                        pid_path=pid_path,
+                        process_ops=process_ops,
+                    )
+        saved_record = save_mock.call_args.args[1]
+        self.assertTrue(saved_record.ipc_started)
+        self.assertTrue(saved_record.daemon_started)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Prevent supervise from crashing on Windows when an IPC server is already running by avoiding attempts to start a second IPC endpoint that cause permission errors.
- Provide a lightweight, stable IPC health-check command so the supervisor and tooling can probe the IPC server without side effects.
- Ensure supervisor only stops processes it started by recording which children it launched in the PID file.
- Fail cleanly when an existing IPC server is reachable but the token is unauthorized to avoid tracebacks and unclear errors.

### Description
- Added `ipc ping` CLI wiring in `gismo/cli/main.py` and `format_ping_output` in `gismo/cli/ipc.py` to emit a stable `IPC: ok` style response and respect token auth via `load_ipc_token`.
- Implemented IPC probing in `gismo/cli/supervise.py` with `_probe_ipc_server` (and `_probe_ipc_fallback`) that uses the new `ping` request and falls back to `daemon_status`, skipping spawning the IPC child when reachable and authorized and printing `[supervise] IPC already running; reusing existing server.`
- Extended `SupervisorRecord` to include `ipc_started` and `daemon_started`, persisted those flags in the PID file, and adjusted `run_supervise_down` so only children the supervisor started are terminated.
- Added and updated unit tests in `tests/test_supervise.py` (fake process ops, tests for IPC-already-running skip, IPC-unauthorized clean failure, and PID-record started flags), and updated `README.md` and `Handoff.md` to reflect the new command and behavior.

### Testing
- Ran the repository verification script `python scripts/verify.py`, which executed the test-suite and completed successfully (all tests passed).
- New unit tests `tests/test_supervise.py` were added and run as part of verification, and they passed (covering IPC reuse, unauthorized path, and PID flags).
- Existing IPC handler tests (ping response shape, enqueue, queue stats, daemon controls) were exercised by the verification run and remained green.
- No real processes were spawned in the new tests; `FakeProcessOps` and mocks were used to simulate `spawn` and IPC responses.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694db1a2add48330b3a5696a199b50e5)