### PR TITLE
Ensure supervise status truthiness

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -37,12 +37,14 @@
 - Added queue requeue-stale and purge-failed IPC behaviors with coverage tests.
 - Added supervise CLI command to run IPC server and daemon together with PID-based control.
 - Added IPC ping CLI wiring plus supervisor reuse/authorization checks and PID tracking for started children.
+- Reconciled supervise status against IPC reachability and daemon status with Windows-safe PID checks.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
 - Validate IPC client connection errors on Windows named pipes.
 - Validate IPC daemon pause/resume behavior in long-running deployments.
 - Validate supervise up/down behavior on Windows named pipes and terminal restarts.
+- Validate supervise status output on Windows when IPC is running outside supervise.
 - Expand tool catalog and add richer permission policies.
 - Add query/reporting helpers for audit trails.
 - Extend orchestration tests to cover recovery workflows.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ python -m gismo.cli.main supervise status --db .gismo/state.db
 python -m gismo.cli.main supervise down --db .gismo/state.db
 ```
 
+Note: `supervise status` reconciles IPC reachability and daemon status with the PID file; the PID file is best-effort metadata only.
+
 Install the Windows Task Scheduler entry for an always-on daemon:
 
 ```bash

--- a/gismo/cli/supervise.py
+++ b/gismo/cli/supervise.py
@@ -1,6 +1,7 @@
 """Supervisor helpers for running IPC + daemon together."""
 from __future__ import annotations
 
+import ctypes
 import json
 import os
 import signal
@@ -11,6 +12,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from ctypes import wintypes
 from typing import Protocol
 
 from gismo.cli import ipc as ipc_cli
@@ -21,6 +23,7 @@ class SupervisorRecord:
     ipc_pid: int
     daemon_pid: int
     ipc_started: bool
+    ipc_reused: bool
     daemon_started: bool
     db_path: str
     started_at: str
@@ -30,6 +33,7 @@ class SupervisorRecord:
             "ipc_pid": self.ipc_pid,
             "daemon_pid": self.daemon_pid,
             "ipc_started": self.ipc_started,
+            "ipc_reused": self.ipc_reused,
             "daemon_started": self.daemon_started,
             "db_path": self.db_path,
             "started_at": self.started_at,
@@ -41,6 +45,7 @@ class SupervisorRecord:
             ipc_pid=int(data.get("ipc_pid", 0)),
             daemon_pid=int(data.get("daemon_pid", 0)),
             ipc_started=bool(data.get("ipc_started", True)),
+            ipc_reused=bool(data.get("ipc_reused", False)),
             daemon_started=bool(data.get("daemon_started", True)),
             db_path=str(data["db_path"]),
             started_at=str(data["started_at"]),
@@ -85,6 +90,8 @@ class DefaultProcessOps:
     def is_running(self, pid: int) -> bool:
         if pid <= 0:
             return False
+        if os.name == "nt":
+            return _windows_is_running(pid)
         try:
             os.kill(pid, 0)
         except PermissionError:
@@ -94,9 +101,15 @@ class DefaultProcessOps:
         return True
 
     def terminate(self, pid: int) -> None:
+        if os.name == "nt":
+            _windows_terminate(pid)
+            return
         os.kill(pid, signal.SIGTERM)
 
     def kill(self, pid: int) -> None:
+        if os.name == "nt":
+            _windows_terminate(pid)
+            return
         sig = signal.SIGKILL if hasattr(signal, "SIGKILL") else signal.SIGTERM
         os.kill(pid, sig)
 
@@ -178,8 +191,10 @@ def run_supervise_up(
     ipc_proc = None
     ipc_pid = 0
     ipc_started = False
+    ipc_reused = False
     if ipc_reachable and ipc_authorized:
         print("[supervise] IPC already running; reusing existing server.")
+        ipc_reused = True
     else:
         ipc_proc = process_ops.spawn(ipc_args, env=env)
         ipc_pid = ipc_proc.pid
@@ -190,6 +205,7 @@ def run_supervise_up(
         ipc_pid=ipc_pid,
         daemon_pid=daemon_proc.pid,
         ipc_started=ipc_started,
+        ipc_reused=ipc_reused,
         daemon_started=True,
         db_path=db_path,
         started_at=datetime.now(timezone.utc).isoformat(),
@@ -232,18 +248,22 @@ def run_supervise_status(
     process_ops = process_ops or DefaultProcessOps()
     pid_path = pid_path or default_pid_path()
     record = load_supervisor_record(pid_path)
-    if record is None:
-        print("not running")
-        return
-    status = summarize_supervisor_status(record, process_ops)
+    status = (
+        summarize_supervisor_status(record, process_ops)
+        if record is not None
+        else SupervisorProcessStatus(ipc_running=False, daemon_running=False)
+    )
+    pid_suffix = "" if record is not None else " (missing)"
     lines = [
         "GISMO supervise status",
-        f"pid_file: {pid_path}",
-        f"db_path: {record.db_path}",
-        f"ipc_pid: {record.ipc_pid} ({_fmt_running(status.ipc_running)})",
-        f"daemon_pid: {record.daemon_pid} ({_fmt_running(status.daemon_running)})",
+        f"pid_file: {pid_path}{pid_suffix}",
+        f"db_path: {record.db_path if record is not None else (db_path or 'unknown')}",
+        f"ipc_pid: {_fmt_pid(record, 'ipc_pid')} ({_fmt_pid_running(record, status.ipc_running)})",
+        f"daemon_pid: {_fmt_pid(record, 'daemon_pid')} ({_fmt_pid_running(record, status.daemon_running)})",
     ]
-    if db_path and db_path != record.db_path:
+    if record is not None:
+        lines.append(f"ipc_reused: {record.ipc_reused}")
+    if db_path and record is not None and db_path != record.db_path:
         lines.append(f"db_path_mismatch: requested={db_path}")
     ipc_reachable = False
     ipc_error = None
@@ -255,6 +275,7 @@ def run_supervise_status(
     except ipc_cli.IPCConnectionError:
         ipc_error = "connection_failed"
     lines.append(f"ipc_ping: {_fmt_ping(ipc_reachable, ipc_error)}")
+    lines.append(_fmt_ipc_status(ipc_reachable, status.ipc_running))
     if ipc_reachable:
         daemon_status = ipc_cli.parse_ipc_response(
             ipc_cli.ipc_request("daemon_status", {}, token)
@@ -262,8 +283,12 @@ def run_supervise_status(
         if daemon_status.ok:
             paused = bool(daemon_status.data and daemon_status.data.get("paused"))
             lines.append(f"daemon_paused: {paused}")
+            lines.append(_fmt_daemon_status(paused))
         else:
             lines.append(f"daemon_paused: error ({daemon_status.error})")
+            lines.append(f"daemon_status: error ({daemon_status.error})")
+    else:
+        lines.append(_fmt_daemon_status(None))
     print("\n".join(lines))
 
 
@@ -324,10 +349,6 @@ def _start_output_thread(
     return thread
 
 
-def _fmt_running(value: bool) -> str:
-    return "running" if value else "stopped"
-
-
 def _fmt_ping(ok: bool, error: str | None) -> str:
     if ok:
         return "ok"
@@ -362,3 +383,53 @@ def _probe_ipc_fallback(token: str) -> tuple[bool, bool]:
     if response.error == "unauthorized":
         return True, False
     return False, False
+
+
+def _fmt_pid(record: SupervisorRecord | None, field: str) -> str:
+    if record is None:
+        return "0"
+    return str(getattr(record, field))
+
+
+def _fmt_pid_running(record: SupervisorRecord | None, running: bool) -> str:
+    if record is None:
+        return "pid_file_missing"
+    return f"pid_file_running={running}"
+
+
+def _fmt_ipc_status(ipc_reachable: bool, pid_running: bool) -> str:
+    if ipc_reachable:
+        return "ipc_status: running (observed: ping)"
+    return f"ipc_status: unknown (unreachable; pid_file_running={pid_running})"
+
+
+def _fmt_daemon_status(paused: bool | None) -> str:
+    if paused is None:
+        return "daemon_status: unknown (ipc_unreachable)"
+    return "daemon_status: paused" if paused else "daemon_status: running"
+
+
+def _windows_is_running(pid: int) -> bool:
+    access = 0x1000  # PROCESS_QUERY_LIMITED_INFORMATION
+    handle = ctypes.windll.kernel32.OpenProcess(access, False, pid)
+    if not handle:
+        return False
+    try:
+        exit_code = wintypes.DWORD()
+        if not ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == 259  # STILL_ACTIVE
+    finally:
+        ctypes.windll.kernel32.CloseHandle(handle)
+
+
+def _windows_terminate(pid: int) -> None:
+    access = 0x0001  # PROCESS_TERMINATE
+    handle = ctypes.windll.kernel32.OpenProcess(access, False, pid)
+    if not handle:
+        raise OSError("process not found")
+    try:
+        if not ctypes.windll.kernel32.TerminateProcess(handle, 1):
+            raise OSError("terminate failed")
+    finally:
+        ctypes.windll.kernel32.CloseHandle(handle)

--- a/tests/test_supervise.py
+++ b/tests/test_supervise.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import tempfile
 import unittest
 from pathlib import Path
@@ -50,6 +52,7 @@ class SupervisePidFileTest(unittest.TestCase):
             ipc_pid=1001,
             daemon_pid=1002,
             ipc_started=True,
+            ipc_reused=False,
             daemon_started=False,
             db_path=".gismo/state.db",
             started_at="2024-01-01T00:00:00Z",
@@ -73,6 +76,7 @@ class SuperviseStatusTest(unittest.TestCase):
             ipc_pid=2001,
             daemon_pid=2002,
             ipc_started=True,
+            ipc_reused=False,
             daemon_started=True,
             db_path="state.db",
             started_at="2024-01-02T00:00:00Z",
@@ -111,6 +115,7 @@ class SuperviseUpTest(unittest.TestCase):
         self.assertIn("daemon", process_ops.spawn_calls[0])
         saved_record = save_mock.call_args.args[1]
         self.assertFalse(saved_record.ipc_started)
+        self.assertTrue(saved_record.ipc_reused)
         self.assertTrue(saved_record.daemon_started)
 
     def test_ipc_unauthorized_fails_cleanly(self) -> None:
@@ -156,7 +161,91 @@ class SuperviseUpTest(unittest.TestCase):
                     )
         saved_record = save_mock.call_args.args[1]
         self.assertTrue(saved_record.ipc_started)
+        self.assertFalse(saved_record.ipc_reused)
         self.assertTrue(saved_record.daemon_started)
+
+
+class SuperviseStatusOutputTest(unittest.TestCase):
+    def test_status_reports_running_when_ipc_reachable(self) -> None:
+        record = supervise_cli.SupervisorRecord(
+            ipc_pid=0,
+            daemon_pid=0,
+            ipc_started=False,
+            ipc_reused=True,
+            daemon_started=True,
+            db_path="state.db",
+            started_at="2024-01-03T00:00:00Z",
+        )
+        ping_response = {
+            "ok": True,
+            "request_id": "ping-1",
+            "data": {"status": "ok"},
+            "error": None,
+        }
+        daemon_response = {
+            "ok": True,
+            "request_id": "daemon-1",
+            "data": {"paused": False},
+            "error": None,
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            pid_path = Path(tempdir) / "supervise.json"
+            supervise_cli.save_supervisor_record(pid_path, record)
+            with mock.patch(
+                "gismo.cli.supervise.ipc_cli.ipc_request",
+                side_effect=[ping_response, daemon_response],
+            ):
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    supervise_cli.run_supervise_status(
+                        "token",
+                        db_path="state.db",
+                        pid_path=pid_path,
+                        process_ops=FakeProcessOps(),
+                    )
+        output = buffer.getvalue()
+        self.assertIn("ipc_status: running (observed: ping)", output)
+        self.assertIn("daemon_status: running", output)
+
+    def test_status_reports_paused_from_ipc(self) -> None:
+        record = supervise_cli.SupervisorRecord(
+            ipc_pid=1234,
+            daemon_pid=5678,
+            ipc_started=True,
+            ipc_reused=False,
+            daemon_started=True,
+            db_path="state.db",
+            started_at="2024-01-04T00:00:00Z",
+        )
+        ping_response = {
+            "ok": True,
+            "request_id": "ping-2",
+            "data": {"status": "ok"},
+            "error": None,
+        }
+        daemon_response = {
+            "ok": True,
+            "request_id": "daemon-2",
+            "data": {"paused": True},
+            "error": None,
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            pid_path = Path(tempdir) / "supervise.json"
+            supervise_cli.save_supervisor_record(pid_path, record)
+            with mock.patch(
+                "gismo.cli.supervise.ipc_cli.ipc_request",
+                side_effect=[ping_response, daemon_response],
+            ):
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    supervise_cli.run_supervise_status(
+                        "token",
+                        db_path="state.db",
+                        pid_path=pid_path,
+                        process_ops=FakeProcessOps(),
+                    )
+        output = buffer.getvalue()
+        self.assertIn("daemon_status: paused", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- `supervise status` could contradict IPC reachability and daemon state when PID files are stale or services were started outside supervise. 
- The PID file should be treated as best-effort metadata and not the authoritative source of truth for liveness. 
- Windows PID checks must be accurate without relying on Unix signals or requiring admin privileges. 
- Tests must cover IPC-driven status reporting so outputs cannot lie about reachability or daemon pause state.

### Description
- Reconciled `supervise status` to prefer observed IPC reachability and `ipc daemon-status` over stale PID file values and annotated PID fields to make metadata vs observed state explicit. 
- Added an `ipc_reused` flag to `SupervisorRecord` and ensure `supervise up` records reuse when an external IPC server is detected. 
- Implemented Windows-safe PID existence and termination helpers (`_windows_is_running` and `_windows_terminate`) and used them in `DefaultProcessOps`. 
- Expanded unit tests in `tests/test_supervise.py`, updated `README.md` and `Handoff.md` to document the behavior change and clarified supervise output formatting.

### Testing
- Ran the repository verification script with `python scripts/verify.py`, which executed the unit test suite and completed successfully. 
- Added unit tests exercising `supervise status` that mock IPC responses and assert that IPC reachability forces reporting of running IPC and daemon status. 
- Existing test suite including new tests passed (see `tests/test_supervise.py` additions). 
- No integration/network tests were added; IPC client calls are mocked per the mandate to avoid real named pipes/sockets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dba278c108330af9732df6b8cb9ff)