### PR TITLE
Fix Windows IPC pipe selection for supervise

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -38,10 +38,13 @@
 - Added supervise CLI command to run IPC server and daemon together with PID-based control.
 - Added IPC ping CLI wiring plus supervisor reuse/authorization checks and PID tracking for started children.
 - Reconciled supervise status against IPC reachability and daemon status with Windows-safe PID checks.
+- Derived Windows IPC pipe names from the database path and aligned supervise/IPC client discovery.
+- Added Windows IPC endpoint unit coverage and supervise db-path probe validation.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
 - Validate IPC client connection errors on Windows named pipes.
+- Validate Windows IPC pipe binding error messaging and supervise cleanup.
 - Validate IPC daemon pause/resume behavior in long-running deployments.
 - Validate supervise up/down behavior on Windows named pipes and terminal restarts.
 - Validate supervise status output on Windows when IPC is running outside supervise.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ python -m gismo.cli.main ipc requeue-stale --older-than-minutes 10 --limit 25
 python -m gismo.cli.main ipc run-show <RUN_ID>
 ```
 
+Note: On Windows, the IPC named pipe is derived from the database path. Ensure the
+same `--db` value is used for `ipc serve`, `ipc ...` clients, and `supervise`.
+
 Local supervisor (IPC + daemon in one terminal):
 
 ```bash

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -1,6 +1,7 @@
 """Local IPC control plane for GISMO."""
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -39,6 +40,7 @@ class IPCResponse:
 
 
 LOGGER = logging.getLogger(__name__)
+DEFAULT_DB_PATH = Path(".gismo") / "state.db"
 
 
 class IPCConnectionError(RuntimeError):
@@ -55,9 +57,25 @@ def _connect(endpoint: IPCEndpoint) -> Client:
     return Client(endpoint.address, family=endpoint.family)
 
 
-def default_ipc_endpoint() -> IPCEndpoint:
-    if os.name == "nt":
-        return IPCEndpoint(r"\\.\pipe\gismo-ipc", "AF_PIPE")
+def _resolve_db_path(db_path: str | None) -> str:
+    if db_path:
+        resolved = Path(db_path).expanduser().resolve(strict=False)
+        return os.path.normcase(str(resolved))
+    resolved_default = DEFAULT_DB_PATH.resolve(strict=False)
+    return os.path.normcase(str(resolved_default))
+
+
+def _ipc_pipe_suffix(db_path: str | None) -> str:
+    resolved = _resolve_db_path(db_path)
+    digest = hashlib.sha256(resolved.encode("utf-8")).hexdigest()
+    return digest[:12]
+
+
+def ipc_endpoint(db_path: str | None, *, os_name: str | None = None) -> IPCEndpoint:
+    resolved_os = os_name or os.name
+    if resolved_os == "nt":
+        suffix = _ipc_pipe_suffix(db_path)
+        return IPCEndpoint(rf"\\.\pipe\gismo-{suffix}", "AF_PIPE")
     return IPCEndpoint("/tmp/gismo-ipc.sock", "AF_UNIX")
 
 
@@ -237,7 +255,7 @@ def _log_request(request_id: str, action: str | None, caller: str | None) -> Non
 
 
 def serve_ipc(db_path: str, token: str) -> None:
-    endpoint = default_ipc_endpoint()
+    endpoint = ipc_endpoint(db_path)
     socket_path = Path(endpoint.address) if endpoint.family == "AF_UNIX" else None
     if socket_path is not None:
         if socket_path.exists():
@@ -248,7 +266,16 @@ def serve_ipc(db_path: str, token: str) -> None:
         socket_path.parent.mkdir(parents=True, exist_ok=True)
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    listener = Listener(endpoint.address, family=endpoint.family)
+    try:
+        listener = Listener(endpoint.address, family=endpoint.family)
+    except OSError:
+        print(
+            "IPC listener failed to bind. "
+            f"Address={endpoint.address}. "
+            "If a stale IPC server or pipe collision exists, run "
+            "`python -m gismo.cli.main supervise down` and retry."
+        )
+        raise SystemExit(1) from None
     state_store = StateStore(db_path)
 
     try:
@@ -279,8 +306,13 @@ def serve_ipc(db_path: str, token: str) -> None:
             socket_path.unlink()
 
 
-def ipc_request(action: str, args: Dict[str, Any], token: str) -> Dict[str, Any]:
-    endpoint = default_ipc_endpoint()
+def ipc_request(
+    action: str,
+    args: Dict[str, Any],
+    token: str,
+    db_path: str | None = None,
+) -> Dict[str, Any]:
+    endpoint = ipc_endpoint(db_path)
     request_id = str(uuid.uuid4())
     request = {
         "request_id": request_id,

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -716,7 +716,8 @@ def _handle_ipc_serve(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(str(exc))
         raise SystemExit(2) from exc
-    ipc_cli.serve_ipc(args.db_path, token)
+    db_path = getattr(args, "db_path", None) or str(ipc_cli.DEFAULT_DB_PATH)
+    ipc_cli.serve_ipc(db_path, token)
 
 
 def _print_ipc_connection_error() -> None:
@@ -743,6 +744,7 @@ def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
                     "max_attempts": args.max_attempts,
                 },
                 token,
+                getattr(args, "db_path", None),
             )
         )
     except ipc_cli.IPCConnectionError:
@@ -764,7 +766,9 @@ def _handle_ipc_ping(args: argparse.Namespace) -> None:
         print(str(exc))
         raise SystemExit(2) from exc
     try:
-        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("ping", {}, token))
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("ping", {}, token, getattr(args, "db_path", None))
+        )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
         raise SystemExit(2)
@@ -784,7 +788,9 @@ def _handle_ipc_queue_stats(args: argparse.Namespace) -> None:
         print(str(exc))
         raise SystemExit(2) from exc
     try:
-        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("queue_stats", {}, token))
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("queue_stats", {}, token, getattr(args, "db_path", None))
+        )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
         raise SystemExit(2)
@@ -805,7 +811,12 @@ def _handle_ipc_run_show(args: argparse.Namespace) -> None:
         raise SystemExit(2) from exc
     try:
         response = ipc_cli.parse_ipc_response(
-            ipc_cli.ipc_request("run_show", {"run_id": args.run_id}, token)
+            ipc_cli.ipc_request(
+                "run_show",
+                {"run_id": args.run_id},
+                token,
+                getattr(args, "db_path", None),
+            )
         )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
@@ -828,7 +839,9 @@ def _handle_ipc_daemon_status(args: argparse.Namespace) -> None:
         print(str(exc))
         raise SystemExit(2) from exc
     try:
-        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("daemon_status", {}, token))
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("daemon_status", {}, token, getattr(args, "db_path", None))
+        )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
         raise SystemExit(2)
@@ -848,7 +861,9 @@ def _handle_ipc_daemon_pause(args: argparse.Namespace) -> None:
         print(str(exc))
         raise SystemExit(2) from exc
     try:
-        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("daemon_pause", {}, token))
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("daemon_pause", {}, token, getattr(args, "db_path", None))
+        )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
         raise SystemExit(2)
@@ -868,7 +883,9 @@ def _handle_ipc_daemon_resume(args: argparse.Namespace) -> None:
         print(str(exc))
         raise SystemExit(2) from exc
     try:
-        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("daemon_resume", {}, token))
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("daemon_resume", {}, token, getattr(args, "db_path", None))
+        )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
         raise SystemExit(2)
@@ -889,7 +906,12 @@ def _handle_ipc_purge_failed(args: argparse.Namespace) -> None:
         raise SystemExit(2) from exc
     try:
         response = ipc_cli.parse_ipc_response(
-            ipc_cli.ipc_request("queue_purge_failed", {}, token)
+            ipc_cli.ipc_request(
+                "queue_purge_failed",
+                {},
+                token,
+                getattr(args, "db_path", None),
+            )
         )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
@@ -912,7 +934,12 @@ def _handle_ipc_requeue_stale(args: argparse.Namespace) -> None:
     payload = {"older_than_minutes": args.older_than_minutes, "limit": args.limit}
     try:
         response = ipc_cli.parse_ipc_response(
-            ipc_cli.ipc_request("queue_requeue_stale", payload, token)
+            ipc_cli.ipc_request(
+                "queue_requeue_stale",
+                payload,
+                token,
+                getattr(args, "db_path", None),
+            )
         )
     except ipc_cli.IPCConnectionError:
         _print_ipc_connection_error()
@@ -932,7 +959,8 @@ def _handle_supervise_up(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(str(exc))
         raise SystemExit(2) from exc
-    supervise_cli.run_supervise_up(args.db_path, token)
+    db_path = getattr(args, "db_path", None) or str(ipc_cli.DEFAULT_DB_PATH)
+    supervise_cli.run_supervise_up(db_path, token)
 
 
 def _handle_supervise_status(args: argparse.Namespace) -> None:
@@ -941,7 +969,8 @@ def _handle_supervise_status(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(str(exc))
         raise SystemExit(2) from exc
-    supervise_cli.run_supervise_status(token, db_path=args.db_path)
+    db_path = getattr(args, "db_path", None)
+    supervise_cli.run_supervise_status(token, db_path=db_path)
 
 
 def _handle_supervise_down(_args: argparse.Namespace) -> None:

--- a/gismo/cli/supervise.py
+++ b/gismo/cli/supervise.py
@@ -160,7 +160,7 @@ def run_supervise_up(
             return
         pid_path.unlink(missing_ok=True)
 
-    ipc_reachable, ipc_authorized = _probe_ipc_server(token)
+    ipc_reachable, ipc_authorized = _probe_ipc_server(token, db_path)
     if ipc_reachable and not ipc_authorized:
         print("IPC authorization failed. Ensure the supervisor token matches the running IPC server.")
         raise SystemExit(1)
@@ -267,8 +267,11 @@ def run_supervise_status(
         lines.append(f"db_path_mismatch: requested={db_path}")
     ipc_reachable = False
     ipc_error = None
+    db_path_for_ipc = record.db_path if record is not None else db_path
     try:
-        ping = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("ping", {}, token))
+        ping = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("ping", {}, token, db_path_for_ipc)
+        )
         ipc_reachable = ping.ok
         if not ping.ok:
             ipc_error = ping.error or "unknown"
@@ -278,7 +281,7 @@ def run_supervise_status(
     lines.append(_fmt_ipc_status(ipc_reachable, status.ipc_running))
     if ipc_reachable:
         daemon_status = ipc_cli.parse_ipc_response(
-            ipc_cli.ipc_request("daemon_status", {}, token)
+            ipc_cli.ipc_request("daemon_status", {}, token, db_path_for_ipc)
         )
         if daemon_status.ok:
             paused = bool(daemon_status.data and daemon_status.data.get("paused"))
@@ -357,9 +360,11 @@ def _fmt_ping(ok: bool, error: str | None) -> str:
     return "error"
 
 
-def _probe_ipc_server(token: str) -> tuple[bool, bool]:
+def _probe_ipc_server(token: str, db_path: str) -> tuple[bool, bool]:
     try:
-        response = ipc_cli.parse_ipc_response(ipc_cli.ipc_request("ping", {}, token))
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request("ping", {}, token, db_path)
+        )
     except ipc_cli.IPCConnectionError:
         return False, False
     if response.ok:
@@ -367,14 +372,14 @@ def _probe_ipc_server(token: str) -> tuple[bool, bool]:
     if response.error == "unauthorized":
         return True, False
     if response.error == "unsupported_action":
-        return _probe_ipc_fallback(token)
+        return _probe_ipc_fallback(token, db_path)
     return False, False
 
 
-def _probe_ipc_fallback(token: str) -> tuple[bool, bool]:
+def _probe_ipc_fallback(token: str, db_path: str) -> tuple[bool, bool]:
     try:
         response = ipc_cli.parse_ipc_response(
-            ipc_cli.ipc_request("daemon_status", {}, token)
+            ipc_cli.ipc_request("daemon_status", {}, token, db_path)
         )
     except ipc_cli.IPCConnectionError:
         return False, False

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import unittest
 from unittest import mock
@@ -148,6 +149,19 @@ class IpcHandlerTest(unittest.TestCase):
         data = response["data"]
         assert data is not None
         self.assertEqual(data["status"], "ok")
+
+
+class IpcEndpointTest(unittest.TestCase):
+    def test_windows_ipc_endpoint_is_stable_and_sanitized(self) -> None:
+        db_path = r"C:\Users\gismo\state.db"
+        endpoint_one = ipc_cli.ipc_endpoint(db_path, os_name="nt")
+        endpoint_two = ipc_cli.ipc_endpoint(db_path, os_name="nt")
+        self.assertEqual(endpoint_one.address, endpoint_two.address)
+        self.assertEqual(endpoint_one.family, "AF_PIPE")
+        self.assertRegex(
+            endpoint_one.address,
+            re.compile(r"^\\\\\.\\pipe\\gismo-[0-9a-f]{12}$"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_supervise.py
+++ b/tests/test_supervise.py
@@ -118,6 +118,28 @@ class SuperviseUpTest(unittest.TestCase):
         self.assertTrue(saved_record.ipc_reused)
         self.assertTrue(saved_record.daemon_started)
 
+    def test_supervise_up_passes_db_path_to_ipc_probe(self) -> None:
+        process_ops = FakeProcessOps(spawn_processes=[FakeProcess(3101)])
+        ping_response = {
+            "ok": True,
+            "request_id": "ping-3",
+            "data": {"status": "ok"},
+            "error": None,
+        }
+        with tempfile.TemporaryDirectory() as tempdir:
+            pid_path = Path(tempdir) / "supervise.json"
+            with mock.patch(
+                "gismo.cli.supervise.ipc_cli.ipc_request",
+                return_value=ping_response,
+            ) as ipc_request_mock:
+                supervise_cli.run_supervise_up(
+                    "state.db",
+                    "token",
+                    pid_path=pid_path,
+                    process_ops=process_ops,
+                )
+        ipc_request_mock.assert_called_once_with("ping", {}, "token", "state.db")
+
     def test_ipc_unauthorized_fails_cleanly(self) -> None:
         process_ops = FakeProcessOps()
         unauthorized_response = {


### PR DESCRIPTION
### Motivation
- On Windows the fixed/global named pipe could collide or be in an admin-only namespace causing WinError 5 when `supervise up` tried to start IPC. 
- IPC client and server needed a deterministic, user-writable address so `supervise`-spawned servers are discoverable by client commands. 
- Bind failures should present a concise, actionable message instead of spamming long tracebacks for an expected collision/stale-pipe case. 
- Supervisor shutdown must remain reliable and continue to stop any children it started on Ctrl+C or `supervise down`.

### Description
- Replace the fixed pipe name with a deterministic per-repo/user suffix derived from the normalized `--db` path using a SHA256 digest and expose `ipc_endpoint(db_path)` for clients and server. 
- Thread `db_path` through IPC client calls (`ipc_request`) and CLI handlers so `ipc serve`, `ipc ...` clients and `supervise` compute the identical endpoint. 
- Catch binding `OSError` when creating the `Listener` and print a concise actionable message that includes the attempted address and suggests running `python -m gismo.cli.main supervise down` before exiting. 
- Add unit tests for the Windows endpoint computation and for supervise probing using the db-path, and update `README.md` and `Handoff.md` to document the db-path requirement for Windows pipes.

### Testing
- Ran the repository verification: `python scripts/verify.py` and the test suite completed successfully (all tests passed). 
- Added and executed `tests/test_ipc.py::IpcEndpointTest::test_windows_ipc_endpoint_is_stable_and_sanitized`, which passed. 
- Added and executed `tests/test_supervise.py::SuperviseUpTest::test_supervise_up_passes_db_path_to_ipc_probe`, which passed. 
- Existing IPC and supervise unit tests were re-run as part of verification and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dbea3b4608330b033c22d1107bfc5)