### PR TITLE
Harden IPC accept shutdown on Windows

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -40,6 +40,7 @@
 - Reconciled supervise status against IPC reachability and daemon status with Windows-safe PID checks.
 - Derived Windows IPC pipe names from the database path and aligned supervise/IPC client discovery.
 - Added Windows IPC endpoint unit coverage and supervise db-path probe validation.
+- Hardened IPC accept shutdown handling with Windows-specific error guards and coverage tests.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -254,6 +254,17 @@ def _log_request(request_id: str, action: str | None, caller: str | None) -> Non
     )
 
 
+def _should_exit_on_accept_error(exc: BaseException, os_name: str) -> bool:
+    if os_name != "nt":
+        return False
+    if isinstance(exc, AssertionError):
+        return True
+    if isinstance(exc, OSError):
+        winerror = getattr(exc, "winerror", None)
+        return winerror in {995, 10038}
+    return False
+
+
 def serve_ipc(db_path: str, token: str) -> None:
     endpoint = ipc_endpoint(db_path)
     socket_path = Path(endpoint.address) if endpoint.family == "AF_UNIX" else None
@@ -277,13 +288,20 @@ def serve_ipc(db_path: str, token: str) -> None:
         )
         raise SystemExit(1) from None
     state_store = StateStore(db_path)
+    stopped = False
 
     try:
         while True:
             try:
                 conn = listener.accept()
             except KeyboardInterrupt:
+                stopped = True
                 break
+            except (AssertionError, OSError) as exc:
+                if _should_exit_on_accept_error(exc, os.name):
+                    stopped = True
+                    break
+                raise
             with conn:
                 try:
                     raw = conn.recv_bytes()
@@ -304,6 +322,8 @@ def serve_ipc(db_path: str, token: str) -> None:
         listener.close()
         if socket_path is not None and socket_path.exists() and socket_path.is_socket():
             socket_path.unlink()
+        if stopped:
+            LOGGER.info("ipc_server_stopped")
 
 
 def ipc_request(

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -164,5 +164,82 @@ class IpcEndpointTest(unittest.TestCase):
         )
 
 
+class IpcServeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.db_path = f"{self.tempdir.name}/state.db"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_serve_ipc_stops_on_keyboard_interrupt(self) -> None:
+        listener = self._run_serve_with_listener([KeyboardInterrupt()])
+        self.assertTrue(listener.closed)
+
+    def test_serve_ipc_stops_on_assertion_error_when_allowed(self) -> None:
+        listener = self._run_serve_with_listener(
+            [AssertionError("boom")],
+            allow_accept_error=True,
+        )
+        self.assertTrue(listener.closed)
+
+    def test_serve_ipc_stops_on_oserror_when_allowed(self) -> None:
+        listener = self._run_serve_with_listener(
+            [OSError("operation aborted")],
+            allow_accept_error=True,
+        )
+        self.assertTrue(listener.closed)
+
+    def _run_serve_with_listener(
+        self,
+        exceptions: list[BaseException],
+        *,
+        allow_accept_error: bool = False,
+    ) -> "FakeListener":
+        listener = FakeListener(exceptions)
+        endpoint = ipc_cli.IPCEndpoint("ignored", "AF_PIPE")
+        with mock.patch.object(ipc_cli, "Listener", return_value=listener):
+            with mock.patch.object(ipc_cli, "ipc_endpoint", return_value=endpoint):
+                if allow_accept_error:
+                    with mock.patch.object(
+                        ipc_cli,
+                        "_should_exit_on_accept_error",
+                        return_value=True,
+                    ):
+                        ipc_cli.serve_ipc(self.db_path, "token")
+                else:
+                    ipc_cli.serve_ipc(self.db_path, "token")
+        return listener
+
+
+class FakeListener:
+    def __init__(self, exceptions: list[BaseException]):
+        self.exceptions = list(exceptions)
+        self.closed = False
+
+    def accept(self):
+        exc = self.exceptions.pop(0)
+        raise exc
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class IpcAcceptErrorTest(unittest.TestCase):
+    def test_should_exit_on_accept_error_windows_assertion(self) -> None:
+        self.assertTrue(
+            ipc_cli._should_exit_on_accept_error(AssertionError("boom"), "nt")
+        )
+        self.assertFalse(
+            ipc_cli._should_exit_on_accept_error(AssertionError("boom"), "posix")
+        )
+
+    def test_should_exit_on_accept_error_windows_oserror(self) -> None:
+        oserr = OSError("operation aborted")
+        oserr.winerror = 995
+        self.assertTrue(ipc_cli._should_exit_on_accept_error(oserr, "nt"))
+        self.assertFalse(ipc_cli._should_exit_on_accept_error(oserr, "posix"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- On Windows a Ctrl+C during `Listener.accept()` could raise `KeyboardInterrupt` followed by `AssertionError` or noisy `OSError` tracebacks from the multiprocessing listener, producing an unpleasant shutdown experience.
- The IPC server must shut down cleanly and deterministically without altering IPC protocol, pipe naming, DB logic, or CLI semantics.

### Description
- Added `_should_exit_on_accept_error(exc, os_name)` to detect Windows-specific accept errors (AssertionError and OSError with winerror 995/10038) that should be treated as shutdown conditions.
- Updated `serve_ipc` to catch `KeyboardInterrupt` and guarded `AssertionError`/`OSError` during `listener.accept()` to exit the accept loop cleanly, always close the listener in `finally`, and emit a single `ipc_server_stopped` log when stopped.
- Added unit tests exercising the accept-loop shutdown behavior and the new `_should_exit_on_accept_error` logic, and updated `Handoff.md` to record the change.

### Testing
- Ran the verification suite with `python scripts/verify.py`, which executes the unit test suite and completed successfully.
- New tests added in `tests/test_ipc.py` cover `IpcServeTest` (accept interrupt scenarios) and `IpcAcceptErrorTest` (Windows accept error detection), and all tests passed.
- No changes were made to IPC protocol, pipe naming, DB logic, or CLI semantics, and the full test run reported success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dc8edd088833080875ac65f78c660)