### PR TITLE
Add daemon heartbeat persistence and status freshness reporting

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -41,6 +41,8 @@
 - Derived Windows IPC pipe names from the database path and aligned supervise/IPC client discovery.
 - Added Windows IPC endpoint unit coverage and supervise db-path probe validation.
 - Hardened IPC accept shutdown handling with Windows-specific error guards and coverage tests.
+- Added daemon heartbeat persistence, IPC status enrichment, and supervise health interpretation.
+- Documented heartbeat status semantics and operator guidance.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
@@ -59,6 +61,7 @@
 - Add Windows-specific operational playbooks for Task Scheduler maintenance.
 - Document Windows Startup launcher maintenance steps.
 - Consider IPC integration tests over the real transport layer.
+- Validate heartbeat freshness thresholds on long-running daemons.
 
 ## Tests
 - `python scripts/verify.py`

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ The supervisor reconciles:
 * IPC reachability
 * Daemon state
 * PID metadata (best-effort)
+* Heartbeat freshness (source of truth)
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -151,6 +151,16 @@ State is **explicit and authoritative**.
 
 ---
 
+### Daemon Heartbeat
+
+The daemon persists a **heartbeat** row in SQLite at a fixed interval.
+
+* Captures the daemon PID, start time, and last-seen timestamp
+* Serves as the authoritative health signal for status checks
+* Complements PID files, which are best-effort metadata
+
+---
+
 ## Execution Model
 
 ### Task Graph Scheduling Rules

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -1,0 +1,7 @@
+# Operator Guide
+
+## How status works
+
+GISMO records a daemon heartbeat in SQLite while the daemon is running.
+Status commands use the heartbeat freshness as the **source of truth** for daemon health.
+PID files are best-effort metadata and may go stale without a matching heartbeat.

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Dict
 
 from gismo.cli.operator import parse_command
-from gismo.core.models import QueueStatus, TaskStatus
+from gismo.core.models import DaemonHeartbeat, QueueStatus, TaskStatus
 from gismo.core.state import StateStore
 
 
@@ -37,6 +37,13 @@ class IPCResponse:
             "data": self.data,
             "error": self.error,
         }
+
+
+@dataclass(frozen=True)
+class DaemonHeartbeatStatus:
+    daemon_running: bool
+    heartbeat_age_seconds: int | None
+    stale_heartbeat: bool
 
 
 LOGGER = logging.getLogger(__name__)
@@ -151,6 +158,30 @@ def _serialize_run_show(state_store: StateStore, run_id: str) -> Dict[str, Any] 
     }
 
 
+def interpret_daemon_heartbeat(
+    heartbeat: DaemonHeartbeat | None,
+    *,
+    now: datetime | None = None,
+    stale_seconds: int = 30,
+) -> DaemonHeartbeatStatus:
+    if heartbeat is None:
+        return DaemonHeartbeatStatus(
+            daemon_running=False,
+            heartbeat_age_seconds=None,
+            stale_heartbeat=False,
+        )
+    current_time = now or datetime.now(timezone.utc)
+    age_seconds = int((current_time - heartbeat.last_seen).total_seconds())
+    if age_seconds < 0:
+        age_seconds = 0
+    stale = age_seconds > stale_seconds
+    return DaemonHeartbeatStatus(
+        daemon_running=not stale,
+        heartbeat_age_seconds=age_seconds,
+        stale_heartbeat=stale,
+    )
+
+
 def handle_ipc_request(
     request: Dict[str, Any],
     expected_token: str,
@@ -188,7 +219,14 @@ def handle_ipc_request(
             data = {"status": "ok"}
             return IPCResponse(True, request_id, data, None).to_dict()
         if action == "daemon_status":
-            data = {"paused": state_store.get_daemon_paused()}
+            heartbeat = state_store.get_daemon_heartbeat()
+            status = interpret_daemon_heartbeat(heartbeat)
+            data = {
+                "paused": state_store.get_daemon_paused(),
+                "daemon_running": status.daemon_running,
+                "heartbeat_age_seconds": status.heartbeat_age_seconds,
+                "stale_heartbeat": status.stale_heartbeat,
+            }
             return IPCResponse(True, request_id, data, None).to_dict()
         if action == "daemon_pause":
             state_store.set_daemon_paused(True)
@@ -451,9 +489,19 @@ def format_enqueue_output(data: Dict[str, Any]) -> str:
 
 
 def format_daemon_status_output(data: Dict[str, Any]) -> str:
-    paused = data.get("paused", False)
-    state = "paused" if paused else "running"
-    return f"Daemon status: {state}"
+    paused = bool(data.get("paused", False))
+    daemon_running = bool(data.get("daemon_running", False))
+    heartbeat_age = data.get("heartbeat_age_seconds")
+    stale = bool(data.get("stale_heartbeat", False))
+    if paused:
+        state = "paused"
+    elif daemon_running:
+        state = "running"
+    else:
+        state = "stopped"
+    heartbeat = f"{heartbeat_age}s" if heartbeat_age is not None else "unknown"
+    stale_note = " (stale)" if stale else ""
+    return f"Daemon status: {state} (heartbeat_age={heartbeat}{stale_note})"
 
 
 def format_daemon_pause_output(data: Dict[str, Any]) -> str:

--- a/gismo/cli/supervise.py
+++ b/gismo/cli/supervise.py
@@ -284,9 +284,25 @@ def run_supervise_status(
             ipc_cli.ipc_request("daemon_status", {}, token, db_path_for_ipc)
         )
         if daemon_status.ok:
-            paused = bool(daemon_status.data and daemon_status.data.get("paused"))
+            data = daemon_status.data or {}
+            paused = bool(data.get("paused"))
+            daemon_running = bool(data.get("daemon_running", False))
+            heartbeat_age = data.get("heartbeat_age_seconds")
+            stale_heartbeat = bool(data.get("stale_heartbeat", False))
             lines.append(f"daemon_paused: {paused}")
-            lines.append(_fmt_daemon_status(paused))
+            lines.append(f"daemon_running: {daemon_running}")
+            lines.append(
+                f"heartbeat_age_seconds: {heartbeat_age if heartbeat_age is not None else 'unknown'}"
+            )
+            lines.append(f"stale_heartbeat: {stale_heartbeat}")
+            lines.append(
+                _fmt_daemon_status(
+                    paused,
+                    daemon_running=daemon_running,
+                    stale_heartbeat=stale_heartbeat,
+                    pid_running=status.daemon_running,
+                )
+            )
         else:
             lines.append(f"daemon_paused: error ({daemon_status.error})")
             lines.append(f"daemon_status: error ({daemon_status.error})")
@@ -408,10 +424,22 @@ def _fmt_ipc_status(ipc_reachable: bool, pid_running: bool) -> str:
     return f"ipc_status: unknown (unreachable; pid_file_running={pid_running})"
 
 
-def _fmt_daemon_status(paused: bool | None) -> str:
+def _fmt_daemon_status(
+    paused: bool | None,
+    *,
+    daemon_running: bool = False,
+    stale_heartbeat: bool = False,
+    pid_running: bool = False,
+) -> str:
     if paused is None:
         return "daemon_status: unknown (ipc_unreachable)"
-    return "daemon_status: paused" if paused else "daemon_status: running"
+    if stale_heartbeat and pid_running:
+        return "daemon_status: possibly stale/hung"
+    if paused:
+        return "daemon_status: paused"
+    if daemon_running:
+        return "daemon_status: running"
+    return "daemon_status: stopped"
 
 
 def _windows_is_running(pid: int) -> bool:

--- a/gismo/core/daemon.py
+++ b/gismo/core/daemon.py
@@ -5,6 +5,8 @@ import signal
 import sqlite3
 import time
 import threading
+import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -20,6 +22,7 @@ from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
 
 
 RegistryFactory = Callable[[StateStore, PermissionPolicy], ToolRegistry]
+HEARTBEAT_INTERVAL_SECONDS = 10.0
 
 
 def run_daemon_loop(
@@ -31,17 +34,31 @@ def run_daemon_loop(
     repo_root = Path(__file__).resolve().parents[2]
     stop_event = threading.Event()
     _register_shutdown_handlers(stop_event)
-    while not stop_event.is_set():
-        if state.get_daemon_paused():
-            stop_event.wait(sleep_seconds)
-            continue
-        item = state.claim_next_queue_item()
-        if item is None:
-            if once:
-                return
-            stop_event.wait(sleep_seconds)
-            continue
-        _execute_queue_item(state, item, policy_path, repo_root)
+    pid = os.getpid()
+    started_at = datetime.now(timezone.utc)
+    state.set_daemon_heartbeat(pid, started_at, started_at, version=None)
+    heartbeat_thread = _start_heartbeat_thread(
+        state,
+        pid=pid,
+        started_at=started_at,
+        stop_event=stop_event,
+        interval_seconds=HEARTBEAT_INTERVAL_SECONDS,
+    )
+    try:
+        while not stop_event.is_set():
+            if state.get_daemon_paused():
+                stop_event.wait(sleep_seconds)
+                continue
+            item = state.claim_next_queue_item()
+            if item is None:
+                if once:
+                    break
+                stop_event.wait(sleep_seconds)
+                continue
+            _execute_queue_item(state, item, policy_path, repo_root)
+    finally:
+        stop_event.set()
+        heartbeat_thread.join(timeout=1.0)
 
 
 def _execute_queue_item(
@@ -207,3 +224,21 @@ def _register_shutdown_handlers(stop_event: threading.Event) -> None:
         if sig is None:
             continue
         signal.signal(sig, _handle_signal)
+
+
+def _start_heartbeat_thread(
+    state: StateStore,
+    *,
+    pid: int,
+    started_at: datetime,
+    stop_event: threading.Event,
+    interval_seconds: float,
+) -> threading.Thread:
+    def _runner() -> None:
+        while not stop_event.wait(interval_seconds):
+            now = datetime.now(timezone.utc)
+            state.set_daemon_heartbeat(pid, started_at, now, version=None)
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    return thread

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -136,3 +136,11 @@ class QueueItem:
     attempt_count: int = 0
     max_attempts: int = 3
     last_error: Optional[str] = None
+
+
+@dataclass
+class DaemonHeartbeat:
+    pid: int
+    started_at: datetime
+    last_seen: datetime
+    version: Optional[str] = None

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
 from gismo.core.models import (
+    DaemonHeartbeat,
     FailureType,
     QueueItem,
     QueueStatus,
@@ -117,6 +118,17 @@ class StateStore:
                     id INTEGER PRIMARY KEY CHECK (id = 1),
                     paused INTEGER NOT NULL DEFAULT 0,
                     updated_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS daemon_heartbeat (
+                    id INTEGER PRIMARY KEY CHECK (id = 1),
+                    pid INTEGER NOT NULL,
+                    started_at TEXT NOT NULL,
+                    last_seen TEXT NOT NULL,
+                    version TEXT
                 )
                 """
             )
@@ -672,6 +684,50 @@ class StateStore:
                     VALUES (1, ?, ?)
                     """,
                     (1 if paused else 0, now),
+                )
+            connection.commit()
+
+    def get_daemon_heartbeat(self) -> Optional[DaemonHeartbeat]:
+        with self._connection() as connection:
+            row = connection.execute(
+                """
+                SELECT pid, started_at, last_seen, version
+                FROM daemon_heartbeat
+                WHERE id = 1
+                """
+            ).fetchone()
+        if row is None:
+            return None
+        return DaemonHeartbeat(
+            pid=int(row["pid"]),
+            started_at=_parse_dt(row["started_at"]),
+            last_seen=_parse_dt(row["last_seen"]),
+            version=row["version"],
+        )
+
+    def set_daemon_heartbeat(
+        self,
+        pid: int,
+        started_at: datetime,
+        last_seen: datetime,
+        version: str | None,
+    ) -> None:
+        with self._connection() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE daemon_heartbeat
+                SET pid = ?, started_at = ?, last_seen = ?, version = ?
+                WHERE id = 1
+                """,
+                (pid, started_at.isoformat(), last_seen.isoformat(), version),
+            )
+            if cursor.rowcount == 0:
+                connection.execute(
+                    """
+                    INSERT INTO daemon_heartbeat (id, pid, started_at, last_seen, version)
+                    VALUES (1, ?, ?, ?, ?)
+                    """,
+                    (pid, started_at.isoformat(), last_seen.isoformat(), version),
                 )
             connection.commit()
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,9 +1,11 @@
 import re
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest import mock
 
 from gismo.cli import ipc as ipc_cli
+from gismo.core.models import DaemonHeartbeat
 from gismo.core.state import StateStore
 
 
@@ -149,6 +151,19 @@ class IpcHandlerTest(unittest.TestCase):
         data = response["data"]
         assert data is not None
         self.assertEqual(data["status"], "ok")
+
+    def test_daemon_heartbeat_marks_stale_when_old(self) -> None:
+        now = datetime.now(timezone.utc)
+        heartbeat = DaemonHeartbeat(
+            pid=999,
+            started_at=now - timedelta(minutes=5),
+            last_seen=now - timedelta(seconds=45),
+            version=None,
+        )
+        status = ipc_cli.interpret_daemon_heartbeat(heartbeat, now=now, stale_seconds=30)
+        self.assertFalse(status.daemon_running)
+        self.assertEqual(status.heartbeat_age_seconds, 45)
+        self.assertTrue(status.stale_heartbeat)
 
 
 class IpcEndpointTest(unittest.TestCase):

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -77,6 +77,36 @@ class StateStoreTest(unittest.TestCase):
             self.assertEqual(stale.attempt_count, 1)
             self.assertEqual(recent.status, QueueStatus.IN_PROGRESS)
 
+    def test_daemon_heartbeat_persists_and_updates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            started_at = datetime.now(timezone.utc)
+            first_seen = started_at + timedelta(seconds=1)
+            state_store.set_daemon_heartbeat(
+                pid=1234,
+                started_at=started_at,
+                last_seen=first_seen,
+                version="test",
+            )
+            heartbeat = state_store.get_daemon_heartbeat()
+            assert heartbeat is not None
+            self.assertEqual(heartbeat.pid, 1234)
+            self.assertEqual(heartbeat.started_at, started_at)
+            self.assertEqual(heartbeat.last_seen, first_seen)
+            self.assertEqual(heartbeat.version, "test")
+
+            second_seen = first_seen + timedelta(seconds=10)
+            state_store.set_daemon_heartbeat(
+                pid=1234,
+                started_at=started_at,
+                last_seen=second_seen,
+                version="test",
+            )
+            updated = state_store.get_daemon_heartbeat()
+            assert updated is not None
+            self.assertGreater(updated.last_seen, heartbeat.last_seen)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_supervise.py
+++ b/tests/test_supervise.py
@@ -207,7 +207,12 @@ class SuperviseStatusOutputTest(unittest.TestCase):
         daemon_response = {
             "ok": True,
             "request_id": "daemon-1",
-            "data": {"paused": False},
+            "data": {
+                "paused": False,
+                "daemon_running": True,
+                "heartbeat_age_seconds": 5,
+                "stale_heartbeat": False,
+            },
             "error": None,
         }
         with tempfile.TemporaryDirectory() as tempdir:
@@ -227,6 +232,9 @@ class SuperviseStatusOutputTest(unittest.TestCase):
                     )
         output = buffer.getvalue()
         self.assertIn("ipc_status: running (observed: ping)", output)
+        self.assertIn("daemon_running: True", output)
+        self.assertIn("heartbeat_age_seconds: 5", output)
+        self.assertIn("stale_heartbeat: False", output)
         self.assertIn("daemon_status: running", output)
 
     def test_status_reports_paused_from_ipc(self) -> None:
@@ -248,7 +256,12 @@ class SuperviseStatusOutputTest(unittest.TestCase):
         daemon_response = {
             "ok": True,
             "request_id": "daemon-2",
-            "data": {"paused": True},
+            "data": {
+                "paused": True,
+                "daemon_running": True,
+                "heartbeat_age_seconds": 4,
+                "stale_heartbeat": False,
+            },
             "error": None,
         }
         with tempfile.TemporaryDirectory() as tempdir:
@@ -267,6 +280,9 @@ class SuperviseStatusOutputTest(unittest.TestCase):
                         process_ops=FakeProcessOps(),
                     )
         output = buffer.getvalue()
+        self.assertIn("daemon_running: True", output)
+        self.assertIn("heartbeat_age_seconds: 4", output)
+        self.assertIn("stale_heartbeat: False", output)
         self.assertIn("daemon_status: paused", output)
 
 


### PR DESCRIPTION
### Motivation
- PID files are best-effort and can go stale (especially on Windows), so a durable health signal is required. 
- Provide a trustworthy, auditable indicator of daemon liveness by persisting a heartbeat into the SQLite StateStore. 
- Surface heartbeat freshness to CLI status commands so operators can detect stale/hung processes. 
- Note: heartbeat freshness may mark a live but blocked worker as stale if it is unresponsive longer than the threshold.

### Description
- Add a `daemon_heartbeat` SQLite table and a `DaemonHeartbeat` model, and implement `StateStore.set_daemon_heartbeat(...)` and `StateStore.get_daemon_heartbeat()` helpers. 
- Make the daemon write an initial heartbeat at startup and refresh it at least every 10 seconds via a background thread. 
- Enrich IPC `daemon_status` responses with `daemon_running`, `heartbeat_age_seconds`, and `stale_heartbeat`, and update `supervise status` formatting to consider heartbeat freshness and report `possibly stale/hung` when appropriate. 
- Add unit tests for heartbeat persistence and stale detection, and update docs (`README.md`, `docs/ARCHITECTURE.md`, `docs/OPERATOR.md`) and `Handoff.md` to document the new behavior.

### Testing
- Run the verification suite with `python scripts/verify.py` which executes the full test suite and smoke tests. 
- Fallback test commands: `python -m unittest -v tests.test_smoke` and `python -m unittest discover -s tests -p "test*.py" -v`. 
- All automated tests were executed and passed locally (`OK` reported by `python scripts/verify.py`). 
- New tests added: heartbeat persistence/update test in `tests/test_state_store.py` and stale-interpretation test in `tests/test_ipc.py`, and supervise status coverage in `tests/test_supervise.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694deb3955e8833098f0fd1d69227e04)