### PR TITLE
Harden queue reliability with SQLite WAL/busy_timeout, per-item timeouts, retries and cancellation

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -43,6 +43,7 @@
 - Hardened IPC accept shutdown handling with Windows-specific error guards and coverage tests.
 - Added daemon heartbeat persistence, IPC status enrichment, and supervise health interpretation.
 - Documented heartbeat status semantics and operator guidance.
+- Hardened queue reliability with SQLite WAL/busy_timeout, per-item timeouts, retries with backoff, and cancellation support (CLI + IPC) plus new coverage tests.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
@@ -62,6 +63,7 @@
 - Document Windows Startup launcher maintenance steps.
 - Consider IPC integration tests over the real transport layer.
 - Validate heartbeat freshness thresholds on long-running daemons.
+- Validate queue timeouts, retries, and cancellation flows on Windows PowerShell.
 
 ## Tests
 - `python scripts/verify.py`

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Enqueue work:
 
 ```bash
 python -m gismo.cli.main enqueue "echo: daemon hello" --db .gismo/state.db
+python -m gismo.cli.main enqueue --timeout 30 --retries 2 "echo: daemon hello" --db .gismo/state.db
 ```
 
 Run the daemon once:
@@ -182,7 +183,10 @@ Inspect the queue:
 python -m gismo.cli.main queue stats --db .gismo/state.db
 python -m gismo.cli.main queue list --db .gismo/state.db
 python -m gismo.cli.main queue show <QUEUE_ITEM_ID> --db .gismo/state.db
+python -m gismo.cli.main queue cancel <QUEUE_ITEM_ID> --db .gismo/state.db
 ```
+
+Cancellation requests for in-progress items are best-effort; the daemon checks between steps.
 
 ---
 
@@ -208,6 +212,8 @@ python -m gismo.cli.main ipc daemon-status --db .gismo/state.db
 python -m gismo.cli.main ipc daemon-pause --db .gismo/state.db
 python -m gismo.cli.main ipc daemon-resume --db .gismo/state.db
 python -m gismo.cli.main ipc enqueue "echo: hello" --db .gismo/state.db
+python -m gismo.cli.main ipc enqueue --timeout 30 --retries 2 "echo: hello" --db .gismo/state.db
+python -m gismo.cli.main ipc queue-cancel <QUEUE_ITEM_ID> --db .gismo/state.db
 ```
 
 ### Windows Note

--- a/gismo/cli/ipc.py
+++ b/gismo/cli/ipc.py
@@ -202,11 +202,14 @@ def handle_ipc_request(
                 raise ValueError("enqueue requires a command string")
             parse_command(command_text)
             run_id = args.get("run_id")
-            max_attempts = int(args.get("max_attempts", 3))
+            retries_value = args.get("max_retries", args.get("max_attempts", 3))
+            max_retries = int(retries_value)
+            timeout_seconds = int(args.get("timeout_seconds", 300))
             item = state_store.enqueue_command(
                 command_text=command_text,
                 run_id=run_id,
-                max_attempts=max_attempts,
+                max_retries=max_retries,
+                timeout_seconds=timeout_seconds,
             )
             data = {"queue_item_id": item.id, "status": item.status.value}
             return IPCResponse(True, request_id, data, None).to_dict()
@@ -255,6 +258,15 @@ def handle_ipc_request(
                 "older_than_minutes": older_than_minutes,
                 "limit": limit_value,
             }
+            return IPCResponse(True, request_id, data, None).to_dict()
+        if action == "queue_cancel":
+            queue_item_id = str(args.get("queue_item_id") or "").strip()
+            if not queue_item_id:
+                raise ValueError("queue_cancel requires a queue item id")
+            item = state_store.request_queue_item_cancel(queue_item_id)
+            if item is None:
+                return IPCResponse(False, request_id, None, "not_found").to_dict()
+            data = {"queue_item_id": item.id, "status": item.status.value}
             return IPCResponse(True, request_id, data, None).to_dict()
         if action == "run_show":
             run_id = str(args.get("run_id") or "").strip()
@@ -527,6 +539,10 @@ def format_queue_requeue_stale_output(data: Dict[str, Any]) -> str:
         f"Requeued {requeued} stale queue item(s) "
         f"(older_than_minutes={older_than_minutes}, limit={limit})."
     )
+
+
+def format_queue_cancel_output(data: Dict[str, Any]) -> str:
+    return f"Queue item {data['queue_item_id']} status={data['status']}"
 
 
 def format_run_show_output(payload: Dict[str, Any]) -> str:

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -342,13 +342,15 @@ def run_enqueue(
     command_text: str,
     *,
     run_id: str | None,
-    max_attempts: int,
+    max_retries: int,
+    timeout_seconds: int,
 ) -> None:
     state_store = StateStore(db_path)
     item = state_store.enqueue_command(
         command_text=command_text,
         run_id=run_id,
-        max_attempts=max_attempts,
+        max_retries=max_retries,
+        timeout_seconds=timeout_seconds,
     )
     print(f"Enqueued {item.id} status={item.status.value}")
 
@@ -493,7 +495,8 @@ def _handle_enqueue(args: argparse.Namespace) -> None:
         args.db_path,
         command_text,
         run_id=args.run_id,
-        max_attempts=args.max_attempts,
+        max_retries=args.max_retries,
+        timeout_seconds=args.timeout_seconds,
     )
 
 
@@ -600,7 +603,13 @@ def _handle_queue_list(args: argparse.Namespace) -> None:
                     "started_at": it.started_at.isoformat() if it.started_at else None,
                     "finished_at": it.finished_at.isoformat() if it.finished_at else None,
                     "attempt_count": it.attempt_count,
-                    "max_attempts": it.max_attempts,
+                    "max_attempts": it.max_retries,
+                    "max_retries": it.max_retries,
+                    "next_attempt_at": it.next_attempt_at.isoformat()
+                    if it.next_attempt_at
+                    else None,
+                    "timeout_seconds": it.timeout_seconds,
+                    "cancel_requested": it.cancel_requested,
                     "last_error": it.last_error,
                     "command_text": it.command_text,
                 }
@@ -619,7 +628,7 @@ def _handle_queue_list(args: argparse.Namespace) -> None:
     cmd_width = 200 if args.full else 60
     error_width = 80 if args.full else 30
     for it in items:
-        att = f"{it.attempt_count}/{it.max_attempts}"
+        att = f"{it.attempt_count}/{it.max_retries}"
         last_error = _summarize_value(it.last_error, error_width)
         cmd = it.command_text if args.full else _truncate(it.command_text, cmd_width)
         print(
@@ -662,7 +671,13 @@ def _handle_queue_show(args: argparse.Namespace) -> None:
             "started_at": item.started_at.isoformat() if item.started_at else None,
             "finished_at": item.finished_at.isoformat() if item.finished_at else None,
             "attempt_count": item.attempt_count,
-            "max_attempts": item.max_attempts,
+            "max_attempts": item.max_retries,
+            "max_retries": item.max_retries,
+            "next_attempt_at": item.next_attempt_at.isoformat()
+            if item.next_attempt_at
+            else None,
+            "timeout_seconds": item.timeout_seconds,
+            "cancel_requested": item.cancel_requested,
             "last_error": item.last_error,
             "command_text": item.command_text,
         }
@@ -677,7 +692,7 @@ def _handle_queue_show(args: argparse.Namespace) -> None:
     print(f"Updated:    {_fmt_dt(item.updated_at)}")
     print(f"Started:    {_fmt_dt(item.started_at)}")
     print(f"Finished:   {_fmt_dt(item.finished_at)}")
-    print(f"Attempts:   {item.attempt_count}/{item.max_attempts}")
+    print(f"Attempts:   {item.attempt_count}/{item.max_retries}")
     if item.last_error:
         print("Last error:")
         print(item.last_error)
@@ -701,7 +716,7 @@ def _handle_queue_purge_failed(args: argparse.Namespace) -> None:
     print("-" * len(header))
     cmd_width = 80
     for item in failed_items:
-        att = f"{item.attempt_count}/{item.max_attempts}"
+        att = f"{item.attempt_count}/{item.max_retries}"
         last_error = _summarize_value(item.last_error, 30)
         cmd = _truncate(item.command_text, cmd_width)
         print(
@@ -741,7 +756,8 @@ def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
                 {
                     "command": command_text,
                     "run_id": args.run_id,
-                    "max_attempts": args.max_attempts,
+                    "max_retries": args.max_retries,
+                    "timeout_seconds": args.timeout_seconds,
                 },
                 token,
                 getattr(args, "db_path", None),
@@ -757,6 +773,50 @@ def _handle_ipc_enqueue(args: argparse.Namespace) -> None:
             print(f"IPC error: {response.error or 'unknown error'}")
         raise SystemExit(2)
     print(ipc_cli.format_enqueue_output(response.data or {}))
+
+
+def _handle_queue_cancel(args: argparse.Namespace) -> None:
+    state_store = StateStore(args.db_path)
+    item = state_store.request_queue_item_cancel(args.id)
+    if item is None:
+        print(f"Queue item not found: {args.id}")
+        raise SystemExit(2)
+    if item.status == QueueStatus.CANCELLED:
+        print(f"Cancelled queue item {item.id}.")
+        return
+    if item.status == QueueStatus.IN_PROGRESS:
+        print(f"Cancel requested for in-progress queue item {item.id}.")
+        return
+    print(f"Queue item already completed: {item.id} status={item.status.value}.")
+
+
+def _handle_ipc_queue_cancel(args: argparse.Namespace) -> None:
+    try:
+        token = ipc_cli.load_ipc_token(args.token)
+    except ValueError as exc:
+        print(str(exc))
+        raise SystemExit(2) from exc
+    try:
+        response = ipc_cli.parse_ipc_response(
+            ipc_cli.ipc_request(
+                "queue_cancel",
+                {"queue_item_id": args.id},
+                token,
+                getattr(args, "db_path", None),
+            )
+        )
+    except ipc_cli.IPCConnectionError:
+        _print_ipc_connection_error()
+        raise SystemExit(2)
+    if not response.ok:
+        if response.error == "unauthorized":
+            print("IPC unauthorized")
+        elif response.error == "not_found":
+            print(f"Queue item not found: {args.id}")
+        else:
+            print(f"IPC error: {response.error or 'unknown error'}")
+        raise SystemExit(2)
+    print(ipc_cli.format_queue_cancel_output(response.data or {}))
 
 
 def _handle_ipc_ping(args: argparse.Namespace) -> None:
@@ -1089,10 +1149,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional existing run ID to attach tasks to",
     )
     enqueue_parser.add_argument(
-        "--max-attempts",
+        "--retries",
         type=int,
         default=3,
-        help="Maximum attempts for this queue item",
+        dest="max_retries",
+        help="Maximum retries for this queue item",
+    )
+    enqueue_parser.add_argument(
+        "--max-attempts",
+        type=int,
+        dest="max_retries",
+        help="Alias for --retries (maximum attempts for this queue item)",
+    )
+    enqueue_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        dest="timeout_seconds",
+        help="Timeout in seconds for this queue item (default: 300)",
     )
     enqueue_parser.add_argument(
         "operator_command",
@@ -1332,6 +1406,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     queue_purge_failed_parser.set_defaults(handler=_handle_queue_purge_failed)
 
+    queue_cancel_parser = queue_subparsers.add_parser(
+        "cancel",
+        help="Request cancellation for a queue item",
+        parents=[db_parent_optional],
+    )
+    queue_cancel_parser.add_argument("id", help="Queue item id")
+    queue_cancel_parser.set_defaults(handler=_handle_queue_cancel)
+
     ipc_parser = subparsers.add_parser(
         "ipc",
         help="Local IPC control plane",
@@ -1368,10 +1450,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional existing run ID to attach tasks to",
     )
     ipc_enqueue_parser.add_argument(
-        "--max-attempts",
+        "--retries",
         type=int,
         default=3,
-        help="Maximum attempts for this queue item",
+        dest="max_retries",
+        help="Maximum retries for this queue item",
+    )
+    ipc_enqueue_parser.add_argument(
+        "--max-attempts",
+        type=int,
+        dest="max_retries",
+        help="Alias for --retries (maximum attempts for this queue item)",
+    )
+    ipc_enqueue_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        dest="timeout_seconds",
+        help="Timeout in seconds for this queue item (default: 300)",
     )
     ipc_enqueue_parser.add_argument(
         "operator_command",
@@ -1475,6 +1571,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="IPC auth token (or set GISMO_IPC_TOKEN)",
     )
     ipc_requeue_stale_parser.set_defaults(handler=_handle_ipc_requeue_stale)
+
+    ipc_queue_cancel_parser = ipc_subparsers.add_parser(
+        "queue-cancel",
+        help="Request cancellation for a queue item via IPC",
+        parents=[db_parent_optional],
+    )
+    ipc_queue_cancel_parser.add_argument(
+        "--token",
+        default=None,
+        help="IPC auth token (or set GISMO_IPC_TOKEN)",
+    )
+    ipc_queue_cancel_parser.add_argument("id", help="Queue item id")
+    ipc_queue_cancel_parser.set_defaults(handler=_handle_ipc_queue_cancel)
 
     ipc_run_show_parser = ipc_subparsers.add_parser(
         "run-show",

--- a/gismo/core/daemon.py
+++ b/gismo/core/daemon.py
@@ -1,6 +1,7 @@
 """Daemon loop for executing queued operator commands."""
 from __future__ import annotations
 
+import concurrent.futures
 import signal
 import sqlite3
 import time
@@ -69,53 +70,119 @@ def _execute_queue_item(
     *,
     registry_factory: Optional[RegistryFactory] = None,
 ) -> None:
+    if _cancel_requested(state, item.id):
+        state.mark_queue_item_cancelled(item.id, "Cancellation requested before execution.")
+        return
+    timeout_seconds = max(1, int(item.timeout_seconds))
     try:
-        policy, plan, normalized = _load_policy_and_plan(policy_path, repo_root, item.command_text)
-        registry = (registry_factory or build_registry)(state, policy)
-        agent = SimpleAgent(registry=registry)
-        orchestrator = Orchestrator(
-            state_store=state,
-            registry=registry,
-            policy=policy,
-            agent=agent,
+        _run_queue_item_with_timeout(
+            state,
+            item,
+            policy_path,
+            repo_root,
+            timeout_seconds=timeout_seconds,
+            registry_factory=registry_factory,
         )
-
-        run_id = _resolve_run_id(state, item, normalized)
-        created_tasks = []
-        previous_task_id = None
-        for index, step in enumerate(plan["steps"]):
-            tool_name = step["tool_name"]
-            tool_input = step["input_json"]
-            idempotency_key = make_idempotency_key(step, normalized, index)
-            depends_on = [previous_task_id] if plan["mode"] == "graph" and previous_task_id else None
-            task = state.create_task(
-                run_id=run_id,
-                title=step["title"],
-                description="Daemon queue step",
-                input_json={"tool": tool_name, "payload": tool_input},
-                depends_on=depends_on,
-                idempotency_key=idempotency_key,
-            )
-            created_tasks.append(task)
-            previous_task_id = task.id
-
-        if plan["mode"] == "single":
-            task = created_tasks[0]
-            result = orchestrator.run_tool(
-                run_id,
-                task,
-                task.input_json["tool"],
-                task.input_json["payload"],
-            )
-            _raise_on_failed_tasks([result])
-        else:
-            results = orchestrator.run_task_graph(run_id)
-            _raise_on_failed_tasks(list(results.values()))
-
-        state.mark_queue_item_succeeded(item.id)
+    except concurrent.futures.TimeoutError:
+        message = f"Task timed out after {timeout_seconds}s"
+        state.mark_queue_item_failed(item.id, message, retryable=True)
     except Exception as exc:  # noqa: BLE001
         retryable = _is_retryable_queue_error(exc)
         state.mark_queue_item_failed(item.id, _safe_error_message(exc), retryable=retryable)
+    else:
+        if _cancel_requested(state, item.id):
+            state.mark_queue_item_cancelled(item.id, "Cancellation requested during execution.")
+            return
+        state.mark_queue_item_succeeded(item.id)
+
+
+def _run_queue_item_with_timeout(
+    state: StateStore,
+    item: QueueItem,
+    policy_path: str | None,
+    repo_root: Path,
+    *,
+    timeout_seconds: int,
+    registry_factory: Optional[RegistryFactory],
+) -> None:
+    errors: list[BaseException] = []
+
+    def _runner() -> None:
+        try:
+            _run_queue_item_plan(
+                state,
+                item,
+                policy_path,
+                repo_root,
+                registry_factory=registry_factory,
+            )
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    thread = threading.Thread(target=_runner, daemon=True)
+    thread.start()
+    thread.join(timeout=timeout_seconds)
+    if thread.is_alive():
+        raise concurrent.futures.TimeoutError()
+    if errors:
+        raise errors[0]
+
+
+def _run_queue_item_plan(
+    state: StateStore,
+    item: QueueItem,
+    policy_path: str | None,
+    repo_root: Path,
+    *,
+    registry_factory: Optional[RegistryFactory],
+) -> None:
+    policy, plan, normalized = _load_policy_and_plan(policy_path, repo_root, item.command_text)
+    registry = (registry_factory or build_registry)(state, policy)
+    agent = SimpleAgent(registry=registry)
+    orchestrator = Orchestrator(
+        state_store=state,
+        registry=registry,
+        policy=policy,
+        agent=agent,
+    )
+
+    run_id = _resolve_run_id(state, item, normalized)
+    created_tasks = []
+    previous_task_id = None
+    for index, step in enumerate(plan["steps"]):
+        tool_name = step["tool_name"]
+        tool_input = step["input_json"]
+        idempotency_key = make_idempotency_key(step, normalized, index)
+        depends_on = [previous_task_id] if plan["mode"] == "graph" and previous_task_id else None
+        task = state.create_task(
+            run_id=run_id,
+            title=step["title"],
+            description="Daemon queue step",
+            input_json={"tool": tool_name, "payload": tool_input},
+            depends_on=depends_on,
+            idempotency_key=idempotency_key,
+        )
+        created_tasks.append(task)
+        previous_task_id = task.id
+
+    cancel_check = lambda: _cancel_requested(state, item.id)
+
+    if plan["mode"] == "single":
+        if cancel_check():
+            return
+        task = created_tasks[0]
+        result = orchestrator.run_tool(
+            run_id,
+            task,
+            task.input_json["tool"],
+            task.input_json["payload"],
+        )
+        _raise_on_failed_tasks([result])
+    else:
+        results = orchestrator.run_task_graph(run_id, should_cancel=cancel_check)
+        if cancel_check():
+            return
+        _raise_on_failed_tasks(list(results.values()))
 
 
 def _resolve_run_id(state: StateStore, item: QueueItem, normalized_command: str) -> str:
@@ -174,6 +241,13 @@ def _is_retryable_queue_error(exc: BaseException) -> bool:
 def _safe_error_message(exc: BaseException) -> str:
     message = str(exc)
     return message or exc.__class__.__name__
+
+
+def _cancel_requested(state: StateStore, item_id: str) -> bool:
+    item = state.get_queue_item(item_id)
+    if item is None:
+        return False
+    return bool(item.cancel_requested)
 
 
 def _resolve_default_policy_path(policy_path: str | None, repo_root: Path) -> tuple[str | None, bool]:

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -39,6 +39,7 @@ class QueueStatus(str, Enum):
     IN_PROGRESS = "IN_PROGRESS"
     SUCCEEDED = "SUCCEEDED"
     FAILED = "FAILED"
+    CANCELLED = "CANCELLED"
 
 
 @dataclass
@@ -134,7 +135,10 @@ class QueueItem:
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
     attempt_count: int = 0
-    max_attempts: int = 3
+    max_retries: int = 3
+    next_attempt_at: Optional[datetime] = None
+    timeout_seconds: int = 300
+    cancel_requested: bool = False
     last_error: Optional[str] = None
 
 

--- a/gismo/core/orchestrator.py
+++ b/gismo/core/orchestrator.py
@@ -7,7 +7,7 @@ import sqlite3
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 from gismo.core.agent import Agent
 from gismo.core.models import FailureType, Task, TaskStatus, ToolCall, ToolCallStatus
@@ -115,7 +115,12 @@ class Orchestrator:
 
         return task
 
-    def run_task_graph(self, run_id: str) -> Dict[str, Task]:
+    def run_task_graph(
+        self,
+        run_id: str,
+        *,
+        should_cancel: Optional[Callable[[], bool]] = None,
+    ) -> Dict[str, Task]:
         tasks = {task.id: task for task in self.state_store.list_tasks(run_id)}
         if not tasks:
             return {}
@@ -123,6 +128,13 @@ class Orchestrator:
         while True:
             runnable: list[Task] = []
             pending = [task for task in tasks.values() if task.status == TaskStatus.PENDING]
+            if should_cancel and pending and should_cancel():
+                error = "Cancellation requested."
+                for task in pending:
+                    task.mark_failed(error, FailureType.SYSTEM_ERROR, status_reason=error)
+                    with self.state_store.transaction() as connection:
+                        self.state_store.update_task(task, connection=connection)
+                break
 
             for task in pending:
                 if not task.depends_on:

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
@@ -29,7 +29,18 @@ class StateStore:
     def _connect(self) -> sqlite3.Connection:
         connection = sqlite3.connect(self.db_path)
         connection.row_factory = sqlite3.Row
+        self._apply_pragmas(connection)
         return connection
+
+    def _apply_pragmas(self, connection: sqlite3.Connection) -> None:
+        try:
+            connection.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.Error:
+            pass
+        try:
+            connection.execute("PRAGMA busy_timeout = 5000")
+        except sqlite3.Error:
+            pass
 
     @contextmanager
     def _connection(self) -> Iterable[sqlite3.Connection]:
@@ -108,6 +119,10 @@ class StateStore:
                     finished_at TEXT,
                     attempt_count INTEGER NOT NULL DEFAULT 0,
                     max_attempts INTEGER NOT NULL DEFAULT 3,
+                    max_retries INTEGER NOT NULL DEFAULT 3,
+                    next_attempt_at TEXT,
+                    timeout_seconds INTEGER NOT NULL DEFAULT 300,
+                    cancel_requested INTEGER NOT NULL DEFAULT 0,
                     last_error TEXT
                 )
                 """
@@ -182,6 +197,25 @@ class StateStore:
             "max_attempts",
             "INTEGER NOT NULL DEFAULT 3",
         )
+        self._ensure_column(
+            connection,
+            "queue_items",
+            "max_retries",
+            "INTEGER NOT NULL DEFAULT 3",
+        )
+        self._ensure_column(connection, "queue_items", "next_attempt_at", "TEXT")
+        self._ensure_column(
+            connection,
+            "queue_items",
+            "timeout_seconds",
+            "INTEGER NOT NULL DEFAULT 300",
+        )
+        self._ensure_column(
+            connection,
+            "queue_items",
+            "cancel_requested",
+            "INTEGER NOT NULL DEFAULT 0",
+        )
         self._ensure_column(connection, "queue_items", "last_error", "TEXT")
         self._ensure_column(connection, "queue_items", "started_at", "TEXT")
         self._ensure_column(connection, "queue_items", "finished_at", "TEXT")
@@ -190,6 +224,21 @@ class StateStore:
         self._ensure_column(connection, "queue_items", "status", "TEXT NOT NULL")
         self._ensure_column(connection, "queue_items", "created_at", "TEXT NOT NULL")
         self._ensure_column(connection, "queue_items", "updated_at", "TEXT NOT NULL")
+        self._sync_queue_retry_columns(connection)
+
+    def _sync_queue_retry_columns(self, connection: sqlite3.Connection) -> None:
+        columns = {
+            row["name"]
+            for row in connection.execute("PRAGMA table_info(queue_items)").fetchall()
+        }
+        if "max_attempts" in columns and "max_retries" in columns:
+            connection.execute(
+                """
+                UPDATE queue_items
+                SET max_retries = max_attempts
+                WHERE max_attempts IS NOT NULL
+                """
+            )
 
     def _ensure_column(
         self,
@@ -419,22 +468,29 @@ class StateStore:
         self,
         command_text: str,
         run_id: Optional[str] = None,
-        max_attempts: int = 3,
+        max_retries: int = 3,
+        timeout_seconds: int = 300,
     ) -> QueueItem:
         if not command_text or not command_text.strip():
             raise ValueError("command_text must be a non-empty string")
+        if max_retries < 0:
+            raise ValueError("max_retries must be >= 0")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be > 0")
         item = QueueItem(
             command_text=command_text.strip(),
             run_id=run_id,
-            max_attempts=max_attempts,
+            max_retries=max_retries,
+            timeout_seconds=timeout_seconds,
         )
         with self._connection() as connection:
             connection.execute(
                 """
                 INSERT INTO queue_items (
                     id, run_id, command_text, status, created_at, updated_at,
-                    started_at, finished_at, attempt_count, max_attempts, last_error
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    started_at, finished_at, attempt_count, max_attempts, max_retries,
+                    next_attempt_at, timeout_seconds, cancel_requested, last_error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     item.id,
@@ -446,7 +502,11 @@ class StateStore:
                     item.started_at.isoformat() if item.started_at else None,
                     item.finished_at.isoformat() if item.finished_at else None,
                     item.attempt_count,
-                    item.max_attempts,
+                    item.max_retries,
+                    item.max_retries,
+                    item.next_attempt_at.isoformat() if item.next_attempt_at else None,
+                    item.timeout_seconds,
+                    1 if item.cancel_requested else 0,
                     item.last_error,
                 ),
             )
@@ -458,24 +518,26 @@ class StateStore:
         connection.row_factory = sqlite3.Row
         try:
             connection.execute("BEGIN IMMEDIATE")
+            now = _utc_now().isoformat()
             row = connection.execute(
                 """
                 SELECT * FROM queue_items
                 WHERE status = ?
+                  AND cancel_requested = 0
+                  AND (next_attempt_at IS NULL OR next_attempt_at <= ?)
                 ORDER BY created_at
                 LIMIT 1
                 """,
-                (QueueStatus.QUEUED.value,),
+                (QueueStatus.QUEUED.value, now),
             ).fetchone()
             if row is None:
                 connection.commit()
                 return None
-            now = _utc_now().isoformat()
             updated = connection.execute(
                 """
                 UPDATE queue_items
-                SET status = ?, started_at = ?, updated_at = ?
-                WHERE id = ? AND status = ?
+                SET status = ?, started_at = ?, updated_at = ?, finished_at = NULL
+                WHERE id = ? AND status = ? AND cancel_requested = 0
                 """,
                 (
                     QueueStatus.IN_PROGRESS.value,
@@ -506,7 +568,7 @@ class StateStore:
             connection.execute(
                 """
                 UPDATE queue_items
-                SET status = ?, updated_at = ?, finished_at = ?
+                SET status = ?, updated_at = ?, finished_at = ?, next_attempt_at = NULL
                 WHERE id = ?
                 """,
                 (QueueStatus.SUCCEEDED.value, now, now, item_id),
@@ -518,13 +580,14 @@ class StateStore:
         if item is None:
             return
         now = _utc_now().isoformat()
-        if retryable and item.attempt_count < item.max_attempts:
+        if retryable and item.attempt_count < item.max_retries:
+            next_attempt = _utc_now() + _retry_backoff(item.attempt_count + 1)
             with self._connection() as connection:
                 connection.execute(
                     """
                     UPDATE queue_items
                     SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
-                        started_at = NULL
+                        started_at = NULL, finished_at = ?, next_attempt_at = ?
                     WHERE id = ?
                     """,
                     (
@@ -532,6 +595,8 @@ class StateStore:
                         now,
                         item.attempt_count + 1,
                         error,
+                        now,
+                        next_attempt.isoformat(),
                         item_id,
                     ),
                 )
@@ -541,12 +606,65 @@ class StateStore:
             connection.execute(
                 """
                 UPDATE queue_items
-                SET status = ?, updated_at = ?, finished_at = ?, last_error = ?
+                SET status = ?, updated_at = ?, finished_at = ?, last_error = ?,
+                    next_attempt_at = NULL
                 WHERE id = ?
                 """,
                 (QueueStatus.FAILED.value, now, now, error, item_id),
             )
             connection.commit()
+
+    def mark_queue_item_cancelled(self, item_id: str, reason: str | None = None) -> None:
+        now = _utc_now().isoformat()
+        with self._connection() as connection:
+            connection.execute(
+                """
+                UPDATE queue_items
+                SET status = ?, updated_at = ?, finished_at = ?, last_error = ?,
+                    cancel_requested = 1, next_attempt_at = NULL
+                WHERE id = ?
+                """,
+                (QueueStatus.CANCELLED.value, now, now, reason, item_id),
+            )
+            connection.commit()
+
+    def request_queue_item_cancel(self, item_id: str) -> Optional[QueueItem]:
+        item = self.get_queue_item(item_id)
+        if item is None:
+            return None
+        now = _utc_now().isoformat()
+        if item.status in {QueueStatus.SUCCEEDED, QueueStatus.FAILED, QueueStatus.CANCELLED}:
+            return item
+        if item.status == QueueStatus.QUEUED:
+            with self._connection() as connection:
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET status = ?, updated_at = ?, finished_at = ?, last_error = ?,
+                        cancel_requested = 1, next_attempt_at = NULL
+                    WHERE id = ?
+                    """,
+                    (
+                        QueueStatus.CANCELLED.value,
+                        now,
+                        now,
+                        "Cancellation requested before execution.",
+                        item_id,
+                    ),
+                )
+                connection.commit()
+            return self.get_queue_item(item_id)
+        with self._connection() as connection:
+            connection.execute(
+                """
+                UPDATE queue_items
+                SET cancel_requested = 1, updated_at = ?
+                WHERE id = ?
+                """,
+                (now, item_id),
+            )
+            connection.commit()
+        return self.get_queue_item(item_id)
 
     def requeue_stale_in_progress(self, older_than_seconds: int = 600) -> int:
         threshold = _utc_now().timestamp() - older_than_seconds
@@ -565,13 +683,13 @@ class StateStore:
                 if started_at >= threshold:
                     continue
                 attempt_count = row["attempt_count"]
-                max_attempts = row["max_attempts"]
-                if attempt_count < max_attempts:
+                max_retries = row["max_retries"]
+                if attempt_count < max_retries:
                     connection.execute(
                         """
                         UPDATE queue_items
                         SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
-                            started_at = NULL
+                            started_at = NULL, next_attempt_at = ?
                         WHERE id = ?
                         """,
                         (
@@ -579,6 +697,7 @@ class StateStore:
                             now,
                             attempt_count + 1,
                             "Requeued stale in-progress item.",
+                            now,
                             row["id"],
                         ),
                     )
@@ -586,14 +705,15 @@ class StateStore:
                     connection.execute(
                         """
                         UPDATE queue_items
-                        SET status = ?, updated_at = ?, finished_at = ?, last_error = ?
+                        SET status = ?, updated_at = ?, finished_at = ?, last_error = ?,
+                            next_attempt_at = NULL
                         WHERE id = ?
                         """,
                         (
                             QueueStatus.FAILED.value,
                             now,
                             now,
-                            "Exceeded max attempts after stale in-progress.",
+                            "Exceeded max retries after stale in-progress.",
                             row["id"],
                         ),
                     )
@@ -630,21 +750,41 @@ class StateStore:
                 started_at = _parse_dt(row["started_at"]).timestamp()
                 if started_at >= threshold:
                     continue
-                connection.execute(
-                    """
-                    UPDATE queue_items
-                    SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
-                        started_at = NULL
-                    WHERE id = ?
-                    """,
-                    (
-                        QueueStatus.QUEUED.value,
-                        current_time.isoformat(),
-                        row["attempt_count"] + 1,
-                        "Requeued stale in-progress item.",
-                        row["id"],
-                    ),
-                )
+                attempt_count = row["attempt_count"]
+                max_retries = row["max_retries"]
+                if attempt_count < max_retries:
+                    connection.execute(
+                        """
+                        UPDATE queue_items
+                        SET status = ?, updated_at = ?, attempt_count = ?, last_error = ?,
+                            started_at = NULL, next_attempt_at = ?
+                        WHERE id = ?
+                        """,
+                        (
+                            QueueStatus.QUEUED.value,
+                            current_time.isoformat(),
+                            attempt_count + 1,
+                            "Requeued stale in-progress item.",
+                            current_time.isoformat(),
+                            row["id"],
+                        ),
+                    )
+                else:
+                    connection.execute(
+                        """
+                        UPDATE queue_items
+                        SET status = ?, updated_at = ?, finished_at = ?, last_error = ?,
+                            next_attempt_at = NULL
+                        WHERE id = ?
+                        """,
+                        (
+                            QueueStatus.FAILED.value,
+                            current_time.isoformat(),
+                            current_time.isoformat(),
+                            "Exceeded max retries after stale in-progress.",
+                            row["id"],
+                        ),
+                    )
                 updated += 1
             connection.commit()
         return updated
@@ -955,6 +1095,9 @@ class StateStore:
         return tool_call
 
     def _row_to_queue_item(self, row: sqlite3.Row) -> QueueItem:
+        max_retries = row["max_retries"] if "max_retries" in row.keys() else None
+        if max_retries is None:
+            max_retries = row["max_attempts"]
         return QueueItem(
             id=row["id"],
             run_id=row["run_id"],
@@ -965,7 +1108,14 @@ class StateStore:
             started_at=_parse_dt(row["started_at"]) if row["started_at"] else None,
             finished_at=_parse_dt(row["finished_at"]) if row["finished_at"] else None,
             attempt_count=row["attempt_count"],
-            max_attempts=row["max_attempts"],
+            max_retries=max_retries,
+            next_attempt_at=_parse_dt(row["next_attempt_at"])
+            if row["next_attempt_at"]
+            else None,
+            timeout_seconds=row["timeout_seconds"] if "timeout_seconds" in row.keys() else 300,
+            cancel_requested=bool(row["cancel_requested"])
+            if "cancel_requested" in row.keys()
+            else False,
             last_error=row["last_error"],
         )
 
@@ -976,3 +1126,10 @@ def _parse_dt(value: str) -> datetime:
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _retry_backoff(attempt_count: int) -> timedelta:
+    if attempt_count <= 0:
+        return timedelta(seconds=0)
+    backoff_seconds = min(60, 2 ** (attempt_count - 1))
+    return timedelta(seconds=backoff_seconds)

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -95,7 +95,13 @@ class CliMainParserTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")
 
-            cli_main.run_enqueue(db_path, "echo: systemd", run_id=None, max_attempts=1)
+            cli_main.run_enqueue(
+                db_path,
+                "echo: systemd",
+                run_id=None,
+                max_retries=1,
+                timeout_seconds=300,
+            )
             cli_main.run_daemon(
                 db_path,
                 policy_path,

--- a/tests/test_daemon_queue.py
+++ b/tests/test_daemon_queue.py
@@ -1,5 +1,7 @@
 import tempfile
+import time
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from gismo.core import daemon as daemon_module
@@ -17,6 +19,16 @@ class FlakyEchoTool(Tool):
         self.calls += 1
         if self.calls == 1:
             raise RuntimeError("flaky echo")
+        return {"echo": tool_input}
+
+
+class SlowEchoTool(Tool):
+    def __init__(self, sleep_seconds: float) -> None:
+        super().__init__(name="echo", description="Sleeps before returning")
+        self._sleep_seconds = sleep_seconds
+
+    def run(self, tool_input: dict) -> dict:
+        time.sleep(self._sleep_seconds)
         return {"echo": tool_input}
 
 
@@ -79,7 +91,36 @@ class DaemonQueueTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")
             state_store = StateStore(db_path)
-            item = state_store.enqueue_command("echo: retry", max_attempts=3)
+            item = state_store.enqueue_command("echo: retry", max_retries=3)
+
+            original_factory = daemon_module.build_registry
+            try:
+                daemon_module.build_registry = _build_flaky_registry
+                daemon_module.run_daemon_loop(
+                    state_store,
+                    policy_path=self._policy_path(),
+                    sleep_seconds=0.0,
+                    once=True,
+                )
+            finally:
+                daemon_module.build_registry = original_factory
+
+            updated = state_store.get_queue_item(item.id)
+            assert updated is not None
+            self.assertEqual(updated.attempt_count, 1)
+            self.assertEqual(updated.status, QueueStatus.QUEUED)
+            self.assertIsNotNone(updated.next_attempt_at)
+
+            with state_store._connection() as connection:  # pylint: disable=protected-access
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET next_attempt_at = ?
+                    WHERE id = ?
+                    """,
+                    ((datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(), item.id),
+                )
+                connection.commit()
 
             original_factory = daemon_module.build_registry
             try:
@@ -115,6 +156,53 @@ class DaemonQueueTest(unittest.TestCase):
             assert updated is not None
             self.assertEqual(updated.status, QueueStatus.FAILED)
             self.assertEqual(updated.attempt_count, 0)
+            self.assertIsNone(updated.next_attempt_at)
+
+    def test_timeout_marks_failed_when_no_retries(self) -> None:
+        slow_tool = SlowEchoTool(sleep_seconds=2.0)
+
+        def _build_slow_registry(state_store: StateStore, policy) -> ToolRegistry:
+            registry = ToolRegistry()
+            registry.register(slow_tool)
+            return registry
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            item = state_store.enqueue_command(
+                "echo: slow",
+                max_retries=0,
+                timeout_seconds=1,
+            )
+
+            original_factory = daemon_module.build_registry
+            try:
+                daemon_module.build_registry = _build_slow_registry
+                daemon_module.run_daemon_loop(
+                    state_store,
+                    policy_path=self._policy_path(),
+                    sleep_seconds=0.0,
+                    once=True,
+                )
+            finally:
+                daemon_module.build_registry = original_factory
+
+            updated = state_store.get_queue_item(item.id)
+            assert updated is not None
+            self.assertEqual(updated.status, QueueStatus.FAILED)
+            self.assertIn("Task timed out after 1s", updated.last_error or "")
+            self.assertIsNotNone(updated.finished_at)
+
+    def test_cancel_queued_item(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            item = state_store.enqueue_command("echo: cancel")
+
+            cancelled = state_store.request_queue_item_cancel(item.id)
+            assert cancelled is not None
+            self.assertEqual(cancelled.status, QueueStatus.CANCELLED)
+            self.assertTrue(cancelled.cancel_requested)
 
 
 if __name__ == "__main__":

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -110,6 +110,7 @@ class IpcHandlerTest(unittest.TestCase):
             "daemon_resume",
             "queue_purge_failed",
             "queue_requeue_stale",
+            "queue_cancel",
         ]
         for action in actions:
             with self.subTest(action=action):
@@ -164,6 +165,23 @@ class IpcHandlerTest(unittest.TestCase):
         self.assertFalse(status.daemon_running)
         self.assertEqual(status.heartbeat_age_seconds, 45)
         self.assertTrue(status.stale_heartbeat)
+
+    def test_queue_cancel_updates_status(self) -> None:
+        item = self.state_store.enqueue_command("echo: cancel")
+        response = ipc_cli.handle_ipc_request(
+            {
+                "action": "queue_cancel",
+                "token": self.token,
+                "args": {"queue_item_id": item.id},
+            },
+            expected_token=self.token,
+            state_store=self.state_store,
+        )
+        self.assertTrue(response["ok"])
+        data = response["data"]
+        assert data is not None
+        self.assertEqual(data["queue_item_id"], item.id)
+        self.assertEqual(data["status"], "CANCELLED")
 
 
 class IpcEndpointTest(unittest.TestCase):

--- a/tests/test_queue_cli.py
+++ b/tests/test_queue_cli.py
@@ -131,3 +131,19 @@ def test_queue_purge_failed_dry_run_and_confirm(repo_root: Path, db_path: Path) 
     assert state_store.get_queue_item(failed_item.id) is None
     assert state_store.get_queue_item(queued_item.id) is not None
     assert state_store.get_queue_item(succeeded_item.id) is not None
+
+
+def test_queue_cancel(repo_root: Path, db_path: Path) -> None:
+    state_store = StateStore(str(db_path))
+    item = state_store.enqueue_command("echo: cancel")
+
+    cancel = _run_cli(
+        ["queue", "cancel", "--db", str(db_path), item.id],
+        cwd=repo_root,
+    )
+    assert cancel.returncode == 0, cancel.stderr
+    assert "Cancelled queue item" in cancel.stdout
+
+    updated = state_store.get_queue_item(item.id)
+    assert updated is not None
+    assert updated.status.value == "CANCELLED"

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -107,6 +107,35 @@ class StateStoreTest(unittest.TestCase):
             assert updated is not None
             self.assertGreater(updated.last_seen, heartbeat.last_seen)
 
+    def test_sqlite_pragmas_are_applied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            with state_store._connection() as connection:  # pylint: disable=protected-access
+                journal = connection.execute("PRAGMA journal_mode").fetchone()[0]
+                busy_timeout = connection.execute("PRAGMA busy_timeout").fetchone()[0]
+            self.assertIn(str(journal).lower(), {"wal", "wal2"})
+            self.assertEqual(int(busy_timeout), 5000)
+
+    def test_next_attempt_at_blocks_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            item = state_store.enqueue_command("echo: later")
+            future_time = datetime.now(timezone.utc) + timedelta(minutes=5)
+            with state_store._connection() as connection:  # pylint: disable=protected-access
+                connection.execute(
+                    """
+                    UPDATE queue_items
+                    SET next_attempt_at = ?
+                    WHERE id = ?
+                    """,
+                    (future_time.isoformat(), item.id),
+                )
+                connection.commit()
+            claimed = state_store.claim_next_queue_item()
+            self.assertIsNone(claimed)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Improve unattended reliability by reducing SQLite contention and making the daemon resilient to hung or flaky work. 
- Provide per-item execution controls (timeouts) and automated retry with backoff so transient failures recover without operator intervention. 
- Allow operators to request cancellation of queued or in-progress items cooperatively to support safer maintenance and supervise flows.

### Description
- Apply `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout = 5000` centrally in `StateStore._connect` so every SQLite connection inherits these settings. 
- Extend `queue_items` schema (idempotent ALTERs) to add `max_retries`, `next_attempt_at`, `timeout_seconds`, and `cancel_requested`, plus a migration that syncs legacy `max_attempts` to the new `max_retries`. 
- Enforce per-item timeouts in the daemon by running item plans on a bounded thread join and marking timed-out items FAILED with a retryable error and scheduled `next_attempt_at` using exponential backoff (capped at 60s). 
- Add cooperative cancellation support (`cancel_requested`) with CLI `queue cancel` and IPC `queue-cancel`, plus `--retries`/`--timeout` flags on enqueue (CLI and IPC) and updated list/show outputs, while keeping Windows-safe behavior and minimal schema churn. 

### Testing
- Ran full verification: `python scripts/verify.py` and the test suite completed with all tests passing. 
- Added/updated unit tests covering pragmas and claim-blocking (`tests/test_state_store.py`), daemon timeouts/retries/cancel flows (`tests/test_daemon_queue.py`), IPC cancel handling (`tests/test_ipc.py`), and queue cancel CLI (`tests/test_queue_cli.py`), and parser/CLI wiring (`tests/test_cli_main.py`). 
- Manual validation examples (Windows PowerShell or POSIX): `python -m gismo.cli.main enqueue --timeout 30 --retries 2 --db .gismo/state.db "echo: hi"`, `python -m gismo.cli.main daemon --once --db .gismo/state.db`, and `python -m gismo.cli.main queue cancel --db .gismo/state.db <QUEUE_ITEM_ID>`. 
- Note risks: timeout enforcement is best-effort (worker thread may continue running) and cancellation is cooperative and checked between task/step boundaries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69512f0fa59883308c43452ed08ae7a3)