### PR TITLE
Docs: make PowerShell-safe placeholders (no angle brackets)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -44,6 +44,7 @@
 - Added daemon heartbeat persistence, IPC status enrichment, and supervise health interpretation.
 - Documented heartbeat status semantics and operator guidance.
 - Hardened queue reliability with SQLite WAL/busy_timeout, per-item timeouts, retries with backoff, and cancellation support (CLI + IPC) plus new coverage tests.
+- Hardened docs and CLI messaging to use PowerShell-safe placeholders and added Windows guidance.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
@@ -67,6 +68,7 @@
 
 ## Tests
 - `python scripts/verify.py`
+- `rg -n "<[A-Za-z0-9_-]+>" README.md docs Handoff.md`
 
 ## Notes
 - Validation is Python-only; do not run cargo/npm checks.

--- a/README.md
+++ b/README.md
@@ -156,8 +156,10 @@ python -m gismo.cli.main run "graph: echo A -> note B -> echo C"
 
 Show a run summary:
 
+PowerShell note: `<` and `>` are redirection operators. Replace placeholders without angle brackets (e.g., use `RUN_ID`).
+
 ```bash
-python -m gismo.cli.main run show <RUN_ID>
+python -m gismo.cli.main run show RUN_ID
 ```
 
 ---
@@ -182,8 +184,8 @@ Inspect the queue:
 ```bash
 python -m gismo.cli.main queue stats --db .gismo/state.db
 python -m gismo.cli.main queue list --db .gismo/state.db
-python -m gismo.cli.main queue show <QUEUE_ITEM_ID> --db .gismo/state.db
-python -m gismo.cli.main queue cancel <QUEUE_ITEM_ID> --db .gismo/state.db
+python -m gismo.cli.main queue show QUEUE_ITEM_ID --db .gismo/state.db
+python -m gismo.cli.main queue cancel QUEUE_ITEM_ID --db .gismo/state.db
 ```
 
 Cancellation requests for in-progress items are best-effort; the daemon checks between steps.
@@ -213,7 +215,7 @@ python -m gismo.cli.main ipc daemon-pause --db .gismo/state.db
 python -m gismo.cli.main ipc daemon-resume --db .gismo/state.db
 python -m gismo.cli.main ipc enqueue "echo: hello" --db .gismo/state.db
 python -m gismo.cli.main ipc enqueue --timeout 30 --retries 2 "echo: hello" --db .gismo/state.db
-python -m gismo.cli.main ipc queue-cancel <QUEUE_ITEM_ID> --db .gismo/state.db
+python -m gismo.cli.main ipc queue-cancel QUEUE_ITEM_ID --db .gismo/state.db
 ```
 
 ### Windows Note

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -1,5 +1,9 @@
 # Operator Guide
 
+## PowerShell placeholder note
+
+PowerShell treats `<` and `>` as redirection operators. When copying commands, replace placeholders without angle brackets (e.g., use `RUN_ID`).
+
 ## How status works
 
 GISMO records a daemon heartbeat in SQLite while the daemon is running.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -1128,7 +1128,7 @@ def build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument(
         "--out",
         default=None,
-        help="Output file path (defaults to exports/<run_id>.jsonl)",
+        help="Output file path (defaults to exports/RUN_ID.jsonl)",
     )
     export_parser.add_argument(
         "--redact",

--- a/gismo/cli/operator.py
+++ b/gismo/cli/operator.py
@@ -54,7 +54,7 @@ def parse_command(command: str) -> Dict[str, Any]:
             step_match = re.match(r"(?i)^(echo|note)\s+(.+)$", raw_step)
             if not step_match:
                 raise ValueError(
-                    f"Invalid graph step '{raw_step}'. Expected 'echo <text>' or 'note <text>'."
+                    f"Invalid graph step '{raw_step}'. Expected 'echo TEXT' or 'note TEXT'."
                 )
             verb = step_match.group(1).lower()
             payload = step_match.group(2).strip()


### PR DESCRIPTION
### Motivation

- PowerShell treats `<` and `>` as redirection operators so angle-bracket placeholders in docs are not copy/paste-safe on Windows.
- Make CLI examples and operator-facing messages safe for users who paste commands into PowerShell without changing semantics.

### Description

- Replaced angle-bracket placeholders in README command examples (e.g., `<RUN_ID>`, `<QUEUE_ITEM_ID>`) with PowerShell-safe identifiers (`RUN_ID`, `QUEUE_ITEM_ID`) and updated IPC cancel examples.  
- Added a concise PowerShell placeholder note to `README.md` and `docs/OPERATOR.md` explaining that users should omit angle brackets when substituting placeholders.  
- Updated CLI/help/error wording to remove angle-bracket placeholder examples in `gismo/cli/main.py` and `gismo/cli/operator.py`.  
- Recorded the documentation hardening in `Handoff.md` and added a grep check command to the Tests section.

### Testing

- Ran `python scripts/verify.py` which executes the test suite and it completed successfully (all tests passed).  
- Ran a repo grep check `rg -n "<[A-Za-z0-9_-]+>" README.md docs Handoff.md` to confirm no remaining angle-bracket placeholders in targeted docs and it returned no matches.  
- The changes are documentation and messaging only and did not alter runtime behavior according to the verification run.  
- No additional unit tests were added because the change is doc-only; existing tests passed as part of `scripts/verify.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69513b76ecd083308b5a808bdec2742e)