### PR TITLE
Add `maintain` CLI loop to requeue stale IN_PROGRESS items and record audit events

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -45,6 +45,7 @@
 - Documented heartbeat status semantics and operator guidance.
 - Hardened queue reliability with SQLite WAL/busy_timeout, per-item timeouts, retries with backoff, and cancellation support (CLI + IPC) plus new coverage tests.
 - Hardened docs and CLI messaging to use PowerShell-safe placeholders and added Windows guidance.
+- Added a maintenance CLI loop to requeue stale in-progress items, with SQLite audit events and operator docs.
 
 ## Next Steps
 - Validate IPC CLI db flag usage on Windows.
@@ -65,6 +66,7 @@
 - Consider IPC integration tests over the real transport layer.
 - Validate heartbeat freshness thresholds on long-running daemons.
 - Validate queue timeouts, retries, and cancellation flows on Windows PowerShell.
+- Validate maintain loop behavior on Windows scheduled runs and verify audit event retention.
 
 ## Tests
 - `python scripts/verify.py`

--- a/README.md
+++ b/README.md
@@ -190,6 +190,15 @@ python -m gismo.cli.main queue cancel QUEUE_ITEM_ID --db .gismo/state.db
 
 Cancellation requests for in-progress items are best-effort; the daemon checks between steps.
 
+### Maintenance loop
+
+Requeue stale in-progress queue items with the local maintenance loop:
+
+```bash
+python -m gismo.cli.main maintain --db .gismo/state.db --once
+python -m gismo.cli.main maintain --db .gismo/state.db --interval-seconds 30 --stale-minutes 10
+```
+
 ---
 
 ## IPC Control Plane (Local Only)

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -9,3 +9,25 @@ PowerShell treats `<` and `>` as redirection operators. When copying commands, r
 GISMO records a daemon heartbeat in SQLite while the daemon is running.
 Status commands use the heartbeat freshness as the **source of truth** for daemon health.
 PID files are best-effort metadata and may go stale without a matching heartbeat.
+
+## Maintenance loop
+
+Use `maintain` to periodically requeue stale `IN_PROGRESS` queue items.
+It is a local-only loop that never contacts the network or invokes an LLM.
+
+PowerShell-safe examples:
+
+```bash
+python -m gismo.cli.main maintain --db .gismo/state.db --once
+python -m gismo.cli.main maintain --db .gismo/state.db --interval-seconds 30 --stale-minutes 10
+```
+
+Each iteration prints a single-line summary:
+
+```
+maintain: requeued 3 stale items (stale_minutes=10)
+maintain: no stale items (stale_minutes=10)
+```
+
+The maintenance loop records an audit event only when it requeues stale items, keeping the
+events table focused on actionable changes instead of per-interval noise.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from gismo.core.agent import SimpleAgent
 from gismo.core.daemon import run_daemon_loop
 from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
 from gismo.core.models import QueueStatus, TaskStatus
+from gismo.core.maintenance import run_maintenance_iteration
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy, load_policy
 from gismo.core.state import StateStore
@@ -373,6 +375,41 @@ def run_daemon(
     )
 
 
+def run_maintain(
+    db_path: str,
+    *,
+    interval_seconds: float,
+    stale_minutes: int,
+    once: bool,
+) -> None:
+    if stale_minutes <= 0:
+        raise ValueError("stale_minutes must be > 0")
+    if interval_seconds <= 0 and not once:
+        raise ValueError("interval_seconds must be > 0")
+    state_store = StateStore(db_path)
+
+    def _run_iteration() -> None:
+        summary = run_maintenance_iteration(state_store, stale_minutes=stale_minutes)
+        if summary.requeued_count:
+            print(
+                "maintain: requeued "
+                f"{summary.requeued_count} stale items (stale_minutes={stale_minutes})"
+            )
+        else:
+            print(f"maintain: no stale items (stale_minutes={stale_minutes})")
+
+    if once:
+        _run_iteration()
+        return
+
+    try:
+        while True:
+            _run_iteration()
+            time.sleep(interval_seconds)
+    except KeyboardInterrupt:
+        print("maintain: stopped")
+
+
 def run_daemon_install_windows_task(
     name: str,
     db_path: str,
@@ -507,6 +544,15 @@ def _handle_daemon(args: argparse.Namespace) -> None:
         sleep_seconds=args.sleep,
         once=args.once,
         requeue_stale_seconds=args.requeue_stale_seconds,
+    )
+
+
+def _handle_maintain(args: argparse.Namespace) -> None:
+    run_maintain(
+        args.db_path,
+        interval_seconds=args.interval_seconds,
+        stale_minutes=args.stale_minutes,
+        once=args.once,
     )
 
 
@@ -1286,6 +1332,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Confirm removal (required to delete the launcher)",
     )
     daemon_uninstall_startup_parser.set_defaults(handler=_handle_daemon_uninstall_windows_startup)
+
+    maintain_parser = subparsers.add_parser(
+        "maintain",
+        help="Run the queue maintenance loop",
+        parents=[db_parent_optional],
+    )
+    maintain_parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Run a single maintenance iteration and exit",
+    )
+    maintain_parser.add_argument(
+        "--interval-seconds",
+        type=float,
+        default=30.0,
+        help="Sleep interval between maintenance iterations",
+    )
+    maintain_parser.add_argument(
+        "--stale-minutes",
+        type=int,
+        default=10,
+        help="Requeue IN_PROGRESS items older than this many minutes",
+    )
+    maintain_parser.set_defaults(handler=_handle_maintain)
 
     supervise_parser = subparsers.add_parser(
         "supervise",

--- a/gismo/core/maintenance.py
+++ b/gismo/core/maintenance.py
@@ -1,0 +1,51 @@
+"""Maintenance helpers for queue hygiene."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from gismo.core.state import StateStore
+
+
+@dataclass
+class MaintenanceSummary:
+    stale_minutes: int
+    requeued_ids: list[str]
+    timestamp: datetime
+
+    @property
+    def requeued_count(self) -> int:
+        return len(self.requeued_ids)
+
+
+def run_maintenance_iteration(state_store: StateStore, stale_minutes: int) -> MaintenanceSummary:
+    if stale_minutes <= 0:
+        raise ValueError("stale_minutes must be > 0")
+    now = datetime.now(timezone.utc)
+    older_than_seconds = stale_minutes * 60
+    stale_ids = state_store.list_stale_in_progress_queue_ids(
+        older_than_seconds=older_than_seconds,
+        now=now,
+    )
+    updated = state_store.requeue_stale_in_progress_queue(
+        older_than_seconds=older_than_seconds,
+        now=now,
+    )
+    requeued_ids = stale_ids[:updated] if updated < len(stale_ids) else stale_ids
+    if updated:
+        payload = {
+            "stale_minutes": stale_minutes,
+            "requeued_count": updated,
+            "requeued_ids": requeued_ids,
+        }
+        state_store.record_event(
+            actor="maintain",
+            event_type="queue_requeue_stale",
+            message=f"Requeued {updated} stale queue item(s).",
+            json_payload=payload,
+        )
+    return MaintenanceSummary(
+        stale_minutes=stale_minutes,
+        requeued_ids=requeued_ids,
+        timestamp=now,
+    )

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -143,6 +143,16 @@ class QueueItem:
 
 
 @dataclass
+class Event:
+    actor: str
+    event_type: str
+    message: str
+    json_payload: Optional[Dict[str, Any]] = None
+    id: str = field(default_factory=lambda: str(uuid4()))
+    ts: datetime = field(default_factory=_utc_now)
+
+
+@dataclass
 class DaemonHeartbeat:
     pid: int
     started_at: datetime

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Iterable, Optional
 
 from gismo.core.models import (
     DaemonHeartbeat,
+    Event,
     FailureType,
     QueueItem,
     QueueStatus,
@@ -147,6 +148,18 @@ class StateStore:
                 )
                 """
             )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    id TEXT PRIMARY KEY,
+                    ts TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    json_payload TEXT
+                )
+                """
+            )
             self._ensure_columns(connection)
             cursor.execute(
                 """
@@ -225,6 +238,60 @@ class StateStore:
         self._ensure_column(connection, "queue_items", "created_at", "TEXT NOT NULL")
         self._ensure_column(connection, "queue_items", "updated_at", "TEXT NOT NULL")
         self._sync_queue_retry_columns(connection)
+
+    def record_event(
+        self,
+        actor: str,
+        event_type: str,
+        message: str,
+        json_payload: Optional[Dict[str, Any]] = None,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> Event:
+        if connection is None:
+            with self._connection() as connection:
+                event = self.record_event(
+                    actor,
+                    event_type,
+                    message,
+                    json_payload,
+                    connection=connection,
+                )
+                connection.commit()
+                return event
+
+        event = Event(
+            actor=actor,
+            event_type=event_type,
+            message=message,
+            json_payload=json_payload,
+        )
+        connection.execute(
+            """
+            INSERT INTO events (id, ts, actor, event_type, message, json_payload)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.id,
+                event.ts.isoformat(),
+                event.actor,
+                event.event_type,
+                event.message,
+                json.dumps(event.json_payload)
+                if event.json_payload is not None
+                else None,
+            ),
+        )
+        return event
+
+    def list_events(self, limit: int = 100) -> list[Event]:
+        if limit <= 0:
+            raise ValueError("limit must be > 0")
+        with self._connection() as connection:
+            rows = connection.execute(
+                "SELECT * FROM events ORDER BY ts DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [self._row_to_event(row) for row in rows]
 
     def _sync_queue_retry_columns(self, connection: sqlite3.Connection) -> None:
         columns = {
@@ -789,6 +856,39 @@ class StateStore:
             connection.commit()
         return updated
 
+    def list_stale_in_progress_queue_ids(
+        self,
+        older_than_seconds: int,
+        limit: int | None = None,
+        *,
+        now: datetime | None = None,
+    ) -> list[str]:
+        if older_than_seconds <= 0:
+            raise ValueError("older_than_seconds must be > 0")
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be > 0")
+        current_time = now or _utc_now()
+        threshold = current_time.timestamp() - older_than_seconds
+        stale_ids: list[str] = []
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT id, started_at
+                FROM queue_items
+                WHERE status = ? AND started_at IS NOT NULL
+                ORDER BY started_at ASC
+                """,
+                (QueueStatus.IN_PROGRESS.value,),
+            ).fetchall()
+        for row in rows:
+            if limit is not None and len(stale_ids) >= limit:
+                break
+            started_at = _parse_dt(row["started_at"]).timestamp()
+            if started_at >= threshold:
+                continue
+            stale_ids.append(row["id"])
+        return stale_ids
+
     def get_daemon_paused(self) -> bool:
         with self._connection() as connection:
             row = connection.execute(
@@ -1117,6 +1217,16 @@ class StateStore:
             if "cancel_requested" in row.keys()
             else False,
             last_error=row["last_error"],
+        )
+
+    def _row_to_event(self, row: sqlite3.Row) -> Event:
+        return Event(
+            id=row["id"],
+            ts=_parse_dt(row["ts"]),
+            actor=row["actor"],
+            event_type=row["event_type"],
+            message=row["message"],
+            json_payload=json.loads(row["json_payload"]) if row["json_payload"] else None,
         )
 
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -53,6 +53,14 @@ class CliMainParserTest(unittest.TestCase):
         self.assertIs(args.handler, cli_main._handle_daemon)
         self.assertTrue(args.once)
 
+    def test_maintain_subcommand_routes_to_maintain(self) -> None:
+        parser = cli_main.build_parser()
+        args = parser.parse_args(["maintain", "--once"])
+
+        self.assertEqual(args.command, "maintain")
+        self.assertIs(args.handler, cli_main._handle_maintain)
+        self.assertTrue(args.once)
+
     def test_ipc_db_path_before_command(self) -> None:
         parser = cli_main.build_parser()
         db_path = "custom.db"

--- a/tests/test_maintain_cli.py
+++ b/tests/test_maintain_cli.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from gismo.core.models import QueueStatus
+from gismo.core.state import StateStore
+
+
+def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture()
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "state.db"
+
+
+def _event_table_exists(db_path: Path) -> bool:
+    with sqlite3.connect(str(db_path)) as connection:
+        row = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='events'"
+        ).fetchone()
+    return row is not None
+
+
+def test_maintain_once_no_stale_items(repo_root: Path, db_path: Path) -> None:
+    proc = _run_cli(
+        ["maintain", "--db", str(db_path), "--once", "--stale-minutes", "10"],
+        cwd=repo_root,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "maintain: no stale items (stale_minutes=10)" in proc.stdout
+    assert _event_table_exists(db_path)
+
+    state_store = StateStore(str(db_path))
+    events = state_store.list_events()
+    assert events == []
+
+
+def test_maintain_once_requeues_stale_items(repo_root: Path, db_path: Path) -> None:
+    state_store = StateStore(str(db_path))
+    item = state_store.enqueue_command("echo: stale")
+    stale_start = datetime.now(timezone.utc) - timedelta(minutes=20)
+    with state_store._connection() as connection:  # pylint: disable=protected-access
+        connection.execute(
+            """
+            UPDATE queue_items
+            SET status = ?, started_at = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (
+                QueueStatus.IN_PROGRESS.value,
+                stale_start.isoformat(),
+                stale_start.isoformat(),
+                item.id,
+            ),
+        )
+        connection.commit()
+
+    proc = _run_cli(
+        ["maintain", "--db", str(db_path), "--once", "--stale-minutes", "10"],
+        cwd=repo_root,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "maintain: requeued 1 stale items (stale_minutes=10)" in proc.stdout
+
+    updated = state_store.get_queue_item(item.id)
+    assert updated is not None
+    assert updated.status == QueueStatus.QUEUED
+    assert updated.attempt_count == 1
+
+    events = state_store.list_events()
+    assert len(events) == 1
+    event = events[0]
+    assert event.actor == "maintain"
+    assert event.event_type == "queue_requeue_stale"
+    assert event.json_payload is not None
+    assert item.id in event.json_payload["requeued_ids"]


### PR DESCRIPTION
### Motivation
- Provide a small, local-only maintenance loop to automatically requeue stale `IN_PROGRESS` queue items and avoid stuck work.
- Ensure every automated maintenance action is auditable in SQLite so operators have a durable trail of recovery actions.
- Offer a clean operator UX (single-line summaries per iteration, PowerShell-safe examples) and a `--once` mode for safe Windows-friendly testing.
- Keep the implementation policy-safe, deterministic, and without any network or LLM dependencies.

### Description
- Add a new `maintain` CLI subcommand (`gismo.cli.main`) with `--once`, `--interval-seconds`, and `--stale-minutes` options for running a single iteration or a repeating loop.
- Implement `gismo/core/maintenance.py` with `run_maintenance_iteration` to find stale IN_PROGRESS items (via a new `list_stale_in_progress_queue_ids`) and reuse `requeue_stale_in_progress_queue` to requeue them and produce a short summary.
- Extend `StateStore` to create an `events` table and add `record_event`/`list_events` helpers plus a `_row_to_event` mapper, and ensure the schema migration runs automatically on DB init.
- Add model `Event` in `gismo/core/models.py`, tests (`tests/test_maintain_cli.py`) covering `maintain --once` with and without stale items, parser coverage in `tests/test_cli_main.py`, and update `README.md`, `docs/OPERATOR.md`, and `Handoff.md` with usage and operator guidance.

### Testing
- Ran `python scripts/verify.py` which executes the full test suite and verification steps, and it completed successfully (all tests passed).
- New tests include `tests/test_maintain_cli.py` which validate `maintain --once` with no stale items and with a stale IN_PROGRESS item and assert the event row is written, and these passed under verification.
- Existing unit and integration tests were re-run as part of verify and remained green, demonstrating no regressions in queue, IPC, or daemon behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951437289308330af39bd654ae72b1b)