### PR TITLE
Add local Ollama LLM planner and `ask` CLI command

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,13 +1,13 @@
 # Handoff
 
 ## Status
-- Added recovery command plus top-level aliases for supervise up/down/status.
-- Updated IPC bind failure guidance to recommend recovery and added operator-facing docs.
-- Added minimal tests for recover and alias routing.
+- Added local LLM planner support via the new `ask` CLI command with Ollama HTTP calls, dry-run output, and optional enqueueing.
+- Logged `llm_plan` audit events for planner runs (including parse failures).
+- Added tests and docs for the new planner flow.
 
 ## Next Steps
-- Validate recovery flow on Windows named pipes after abrupt termination.
-- Validate recovery messaging in long-running supervisor deployments.
+- Validate the `ask` command with a running Ollama instance and confirm model availability.
+- Consider expanding planner validation rules if new operator commands are added.
 
 ## Tests
 - `python scripts/verify.py`

--- a/README.md
+++ b/README.md
@@ -164,6 +164,26 @@ python -m gismo.cli.main run show RUN_ID
 
 ---
 
+## LLM Planner (Local Only)
+
+GISMO can ask a local Ollama model to propose a JSON plan. The planner is **dry-run by default** and never executes commands directly.
+Use `--enqueue` to submit validated operator commands to the queue for daemon execution.
+
+```bash
+python -m gismo.cli.main ask --db .gismo/state.db "Create a quick echo and note plan"
+python -m gismo.cli.main ask --db .gismo/state.db --enqueue "Queue an echo and a note"
+python -m gismo.cli.main ask --db .gismo/state.db --enqueue --dry-run "Show what would be enqueued"
+```
+
+Defaults:
+
+* Model: `phi3:mini` (override with `--model` or `GISMO_LLM_MODEL`)
+* Host: `http://127.0.0.1:11434` (override with `--host` or `OLLAMA_HOST`)
+
+Every `ask` call writes an audit event (`llm_plan`) to the state database.
+
+---
+
 ## Operator Lifecycle
 
 Each operator command has one responsibility:

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -15,6 +15,25 @@ Each operator command has a single responsibility:
 - `supervise down`: stops only the IPC/daemon processes launched by `supervise up`.
 - `up`, `status`, `down`: aliases for the matching `supervise` subcommands.
 - `maintain`: requeues stale `IN_PROGRESS` queue items; safe to run alongside a daemon.
+- `ask`: calls a local Ollama model to propose a JSON plan (dry-run by default).
+
+## LLM planner (local)
+
+The `ask` command calls a local Ollama instance on 127.0.0.1:11434 by default and never executes commands directly.
+It returns a plan and, when `--enqueue` is set, validates each `enqueue` action and submits it to the queue.
+
+PowerShell-safe examples:
+
+```bash
+python -m gismo.cli.main ask --db .gismo/state.db "Draft a quick plan"
+python -m gismo.cli.main ask --db .gismo/state.db --enqueue "Queue a note and an echo"
+python -m gismo.cli.main ask --db .gismo/state.db --enqueue --dry-run "Show what would be enqueued"
+```
+
+Defaults:
+
+- Model: `phi3:mini` (override with `--model` or `GISMO_LLM_MODEL`)
+- Host: `http://127.0.0.1:11434` (override with `--host` or `OLLAMA_HOST`)
 
 ## Recovery
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from gismo.cli.operator import (
@@ -25,7 +25,7 @@ from gismo.cli.windows_utils import quote_windows_arg
 from gismo.core.agent import SimpleAgent
 from gismo.core.daemon import run_daemon_loop
 from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
-from gismo.core.models import QueueStatus, TaskStatus
+from gismo.core.models import EVENT_TYPE_LLM_PLAN, QueueStatus, TaskStatus
 from gismo.core.maintenance import run_maintenance_iteration
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy, load_policy
@@ -33,6 +33,8 @@ from gismo.core.state import StateStore
 from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
 from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFileTool, WriteFileTool
 from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
+from gismo.llm.ollama import ollama_chat, resolve_ollama_host, resolve_ollama_model
+from gismo.llm.prompts import build_system_prompt, build_user_prompt
 
 
 def _fmt_dt(dt) -> str:
@@ -53,6 +55,123 @@ def _summarize_value(value: object, max_len: int) -> str:
     else:
         text = json.dumps(value, ensure_ascii=False, sort_keys=True)
     return _truncate(text, max_len)
+
+
+def _coerce_str_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item is not None]
+    return [str(value)]
+
+
+def _coerce_int(value: object, default: int, minimum: int = 0) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        return default
+    if coerced < minimum:
+        return default
+    return coerced
+
+
+def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
+    intent = plan.get("intent")
+    intent_text = intent if isinstance(intent, str) else str(intent) if intent is not None else ""
+    assumptions = _coerce_str_list(plan.get("assumptions"))
+    notes = _coerce_str_list(plan.get("notes"))
+    raw_actions = plan.get("actions")
+    actions: list[dict[str, object]] = []
+    if isinstance(raw_actions, list):
+        for action in raw_actions:
+            if not isinstance(action, dict):
+                continue
+            action_type = action.get("type")
+            action_type_text = (
+                action_type.strip()
+                if isinstance(action_type, str)
+                else str(action_type).strip()
+                if action_type is not None
+                else ""
+            )
+            command = action.get("command")
+            command_text = (
+                command.strip()
+                if isinstance(command, str)
+                else str(command).strip()
+                if command is not None
+                else ""
+            )
+            timeout_seconds = _coerce_int(action.get("timeout_seconds"), 30, minimum=1)
+            retries = _coerce_int(action.get("retries"), 0, minimum=0)
+            why = action.get("why")
+            why_text = why if isinstance(why, str) else str(why) if why is not None else ""
+            risk = action.get("risk")
+            risk_text = risk.strip().lower() if isinstance(risk, str) else ""
+            if risk_text not in {"low", "medium", "high"}:
+                risk_text = "medium"
+            actions.append(
+                {
+                    "type": action_type_text,
+                    "command": command_text,
+                    "timeout_seconds": timeout_seconds,
+                    "retries": retries,
+                    "why": why_text,
+                    "risk": risk_text,
+                }
+            )
+    if max_actions <= 0:
+        raise ValueError("max_actions must be > 0")
+    if len(actions) > max_actions:
+        notes.append(
+            f"Truncated actions from {len(actions)} to {max_actions} based on --max-actions."
+        )
+        actions = actions[:max_actions]
+    unknown_types = sorted({a["type"] for a in actions if a["type"] and a["type"] != "enqueue"})
+    if unknown_types:
+        notes.append(f"Ignored unsupported action types: {', '.join(unknown_types)}.")
+    return {
+        "intent": intent_text,
+        "assumptions": assumptions,
+        "actions": actions,
+        "notes": notes,
+    }
+
+
+def _print_llm_plan(plan: dict) -> None:
+    print("=== GISMO LLM Plan ===")
+    intent = plan.get("intent") or "unspecified"
+    print(f"Intent: {intent}")
+    assumptions = plan.get("assumptions") or []
+    if assumptions:
+        print("Assumptions:")
+        for item in assumptions:
+            print(f"- {item}")
+    else:
+        print("Assumptions: none")
+    actions = plan.get("actions") or []
+    print("Actions:")
+    if not actions:
+        print("  (none)")
+    else:
+        for index, action in enumerate(actions, start=1):
+            action_type = action.get("type") or "unknown"
+            command = action.get("command") or "-"
+            print(f"{index}. {action_type}: {command}")
+            print(
+                "   "
+                f"timeout_seconds={action.get('timeout_seconds')} "
+                f"retries={action.get('retries')} "
+                f"risk={action.get('risk')}"
+            )
+            why = action.get("why")
+            if why:
+                print(f"   why: {why}")
+    notes = plan.get("notes") or []
+    if notes:
+        print("Notes:")
+        for note in notes:
+            print(f"- {note}")
 
 
 def _run_status(tasks: list) -> str:
@@ -357,6 +476,149 @@ def run_enqueue(
     print(f"Enqueued {item.id} status={item.status.value}")
 
 
+def run_ask(
+    db_path: str,
+    user_text: str,
+    *,
+    model: str | None,
+    host: str | None,
+    timeout_s: int,
+    enqueue: bool,
+    dry_run: bool,
+    max_actions: int,
+) -> None:
+    if not user_text or not user_text.strip():
+        raise ValueError("ask requires a natural language request.")
+    resolved_host = resolve_ollama_host(host)
+    resolved_model = resolve_ollama_model(model)
+    state_store = StateStore(db_path)
+    system_prompt = build_system_prompt()
+    user_prompt = build_user_prompt(user_text)
+    raw_response = ollama_chat(
+        user_prompt,
+        system_prompt,
+        model=resolved_model,
+        host=resolved_host,
+        timeout_s=timeout_s,
+    )
+    try:
+        parsed = json.loads(raw_response)
+    except json.JSONDecodeError as exc:
+        print(raw_response, file=sys.stderr)
+        payload = {
+            "model": resolved_model,
+            "host": resolved_host,
+            "user_text": user_text,
+            "plan": None,
+            "raw_response": raw_response,
+            "parse_error": str(exc),
+            "enqueue": enqueue,
+            "dry_run": dry_run,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        state_store.record_event(
+            actor="ask",
+            event_type=EVENT_TYPE_LLM_PLAN,
+            message="LLM plan parsing failed.",
+            json_payload=payload,
+        )
+        raise ValueError("LLM response was not valid JSON.") from exc
+
+    if not isinstance(parsed, dict):
+        payload = {
+            "model": resolved_model,
+            "host": resolved_host,
+            "user_text": user_text,
+            "plan": None,
+            "raw_response": raw_response,
+            "parse_error": "Response JSON was not an object.",
+            "enqueue": enqueue,
+            "dry_run": dry_run,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        state_store.record_event(
+            actor="ask",
+            event_type=EVENT_TYPE_LLM_PLAN,
+            message="LLM plan parsing failed.",
+            json_payload=payload,
+        )
+        raise ValueError("LLM response must be a JSON object.")
+    try:
+        plan = _normalize_llm_plan(parsed, max_actions=max_actions)
+    except ValueError as exc:
+        payload = {
+            "model": resolved_model,
+            "host": resolved_host,
+            "user_text": user_text,
+            "plan": None,
+            "raw_response": raw_response,
+            "parse_error": str(exc),
+            "enqueue": enqueue,
+            "dry_run": dry_run,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        state_store.record_event(
+            actor="ask",
+            event_type=EVENT_TYPE_LLM_PLAN,
+            message="LLM plan parsing failed.",
+            json_payload=payload,
+        )
+        raise
+    _print_llm_plan(plan)
+    payload = {
+        "model": resolved_model,
+        "host": resolved_host,
+        "user_text": user_text,
+        "plan": plan,
+        "enqueue": enqueue,
+        "dry_run": dry_run,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    state_store.record_event(
+        actor="ask",
+        event_type=EVENT_TYPE_LLM_PLAN,
+        message="LLM plan generated.",
+        json_payload=payload,
+    )
+
+    if not enqueue:
+        return
+    if dry_run:
+        print("Dry run: enqueue requested but no items were enqueued.")
+        return
+
+    enqueued_ids = []
+    skipped = []
+    for action in plan.get("actions", []):
+        if action.get("type") != "enqueue":
+            continue
+        command_text = action.get("command") or ""
+        if not command_text.strip():
+            skipped.append("Skipped enqueue action with empty command.")
+            continue
+        try:
+            parse_command(command_text)
+        except ValueError as exc:
+            skipped.append(f"Skipped invalid command '{command_text}': {exc}")
+            continue
+        item = state_store.enqueue_command(
+            command_text=command_text,
+            max_retries=int(action.get("retries") or 0),
+            timeout_seconds=int(action.get("timeout_seconds") or 30),
+        )
+        enqueued_ids.append(item.id)
+    if skipped:
+        print("Enqueue notes:")
+        for note in skipped:
+            print(f"- {note}")
+    if enqueued_ids:
+        print("Enqueued items:")
+        for item_id in enqueued_ids:
+            print(f"- {item_id}")
+    else:
+        print("No items enqueued.")
+
+
 def run_daemon(
     db_path: str,
     policy_path: str | None,
@@ -547,6 +809,23 @@ def _handle_enqueue(args: argparse.Namespace) -> None:
         run_id=args.run_id,
         max_retries=args.max_retries,
         timeout_seconds=args.timeout_seconds,
+    )
+
+
+def _handle_ask(args: argparse.Namespace) -> None:
+    user_text = " ".join(args.text).strip()
+    dry_run = True if args.dry_run is None else args.dry_run
+    if args.enqueue and args.dry_run is None:
+        dry_run = False
+    run_ask(
+        args.db_path,
+        user_text,
+        model=args.model,
+        host=args.host,
+        timeout_s=args.timeout,
+        enqueue=args.enqueue,
+        dry_run=dry_run,
+        max_actions=args.max_actions,
     )
 
 
@@ -1242,6 +1521,51 @@ def build_parser() -> argparse.ArgumentParser:
         help="Operator command string to enqueue",
     )
     enqueue_parser.set_defaults(handler=_handle_enqueue)
+
+    ask_parser = subparsers.add_parser(
+        "ask",
+        help="Request an LLM plan (local Ollama only)",
+        parents=[db_parent_optional],
+    )
+    ask_parser.add_argument(
+        "--model",
+        default=None,
+        help="Override the local LLM model (default: phi3:mini or GISMO_LLM_MODEL)",
+    )
+    ask_parser.add_argument(
+        "--host",
+        default=None,
+        help="Override the Ollama host URL (default: http://127.0.0.1:11434 or OLLAMA_HOST)",
+    )
+    ask_parser.add_argument(
+        "--timeout",
+        type=int,
+        default=60,
+        help="Timeout in seconds for the LLM call (default: 60)",
+    )
+    ask_parser.add_argument(
+        "--enqueue",
+        action="store_true",
+        help="Enqueue validated actions for the daemon to execute",
+    )
+    ask_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=None,
+        help="Show the plan without enqueueing (default unless --enqueue is set)",
+    )
+    ask_parser.add_argument(
+        "--max-actions",
+        type=int,
+        default=10,
+        help="Maximum number of actions to accept from the LLM (default: 10)",
+    )
+    ask_parser.add_argument(
+        "text",
+        nargs=argparse.REMAINDER,
+        help="Natural language request for the planner",
+    )
+    ask_parser.set_defaults(handler=_handle_ask)
 
     daemon_parser = subparsers.add_parser(
         "daemon",

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -42,6 +42,9 @@ class QueueStatus(str, Enum):
     CANCELLED = "CANCELLED"
 
 
+EVENT_TYPE_LLM_PLAN = "llm_plan"
+
+
 @dataclass
 class Run:
     id: str = field(default_factory=lambda: str(uuid4()))

--- a/gismo/llm/__init__.py
+++ b/gismo/llm/__init__.py
@@ -1,0 +1,11 @@
+"""LLM planner helpers."""
+from gismo.llm.ollama import ollama_chat, resolve_ollama_host, resolve_ollama_model
+from gismo.llm.prompts import build_system_prompt, build_user_prompt
+
+__all__ = [
+    "ollama_chat",
+    "resolve_ollama_host",
+    "resolve_ollama_model",
+    "build_system_prompt",
+    "build_user_prompt",
+]

--- a/gismo/llm/ollama.py
+++ b/gismo/llm/ollama.py
@@ -1,0 +1,70 @@
+"""Minimal Ollama HTTP client for local planning."""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+DEFAULT_HOST = "http://127.0.0.1:11434"
+DEFAULT_MODEL = "phi3:mini"
+
+
+def resolve_ollama_host(host: str | None = None) -> str:
+    return (host or os.getenv("OLLAMA_HOST") or DEFAULT_HOST).rstrip("/")
+
+
+def resolve_ollama_model(model: str | None = None) -> str:
+    return model or os.getenv("GISMO_LLM_MODEL") or DEFAULT_MODEL
+
+
+def ollama_chat(
+    prompt: str,
+    system: str,
+    model: str | None = None,
+    host: str | None = None,
+    timeout_s: int = 60,
+) -> str:
+    """Call Ollama chat API and return assistant content."""
+    resolved_host = resolve_ollama_host(host)
+    resolved_model = resolve_ollama_model(model)
+    url = f"{resolved_host}/api/chat"
+    payload = {
+        "model": resolved_model,
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ],
+    }
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8") if exc.fp else ""
+        message = f"Ollama error {exc.code} from {resolved_host}. {detail}".strip()
+        raise RuntimeError(message) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Ollama not running or unreachable at {resolved_host}. "
+            "Start Ollama and ensure the model is pulled."
+        ) from exc
+
+    try:
+        payload_json: dict[str, Any] = json.loads(body)
+        message = payload_json.get("message") or {}
+        content = message.get("content")
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise RuntimeError("Invalid JSON response from Ollama.") from exc
+    if not isinstance(content, str):
+        raise RuntimeError("Ollama response missing assistant content.")
+    return content

--- a/gismo/llm/prompts.py
+++ b/gismo/llm/prompts.py
@@ -1,0 +1,34 @@
+"""Prompt helpers for LLM planning."""
+from __future__ import annotations
+
+
+def build_system_prompt() -> str:
+    return (
+        "You are a planning assistant for GISMO. "
+        "You must output a single JSON object and nothing else. "
+        "Do not include markdown or extra text. "
+        "The JSON schema is: "
+        "{\n"
+        "  \"intent\": \"string\",\n"
+        "  \"assumptions\": [\"string\"],\n"
+        "  \"actions\": [\n"
+        "    {\n"
+        "      \"type\": \"enqueue\",\n"
+        "      \"command\": \"string\",\n"
+        "      \"timeout_seconds\": 30,\n"
+        "      \"retries\": 0,\n"
+        "      \"why\": \"string\",\n"
+        "      \"risk\": \"low|medium|high\"\n"
+        "    }\n"
+        "  ],\n"
+        "  \"notes\": [\"string\"]\n"
+        "}\n"
+        "Rules: command must be a GISMO operator command string (echo:, note:, or graph:). "
+        "Keep actions small and sequenced. "
+        "If the user request is unsafe or unsupported, return actions as an empty array "
+        "and explain why in notes."
+    )
+
+
+def build_user_prompt(user_text: str) -> str:
+    return f"User request: {user_text}".strip()

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -1,0 +1,136 @@
+import contextlib
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gismo.cli import main as cli_main
+from gismo.core.models import EVENT_TYPE_LLM_PLAN
+from gismo.core.state import StateStore
+
+
+class AskCliTest(unittest.TestCase):
+    def test_ask_dry_run_writes_event_and_prints_plan(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "greet",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "echo: hello",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "acknowledge",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    cli_main.run_ask(
+                        db_path,
+                        "say hello",
+                        model=None,
+                        host=None,
+                        timeout_s=1,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=10,
+                    )
+            output = buffer.getvalue()
+            self.assertIn("=== GISMO LLM Plan ===", output)
+            self.assertIn("Intent: greet", output)
+
+            state_store = StateStore(db_path)
+            events = state_store.list_events()
+            self.assertTrue(events)
+            event = events[0]
+            self.assertEqual(event.event_type, EVENT_TYPE_LLM_PLAN)
+            payload = event.json_payload
+            assert payload is not None
+            self.assertTrue(payload["dry_run"])
+            self.assertFalse(payload["enqueue"])
+
+    def test_ask_enqueue_enqueues_items_and_writes_event(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "queue",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "note: queued",
+                        "timeout_seconds": 15,
+                        "retries": 1,
+                        "why": "record",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    cli_main.run_ask(
+                        db_path,
+                        "enqueue a note",
+                        model=None,
+                        host=None,
+                        timeout_s=1,
+                        enqueue=True,
+                        dry_run=False,
+                        max_actions=10,
+                    )
+            output = buffer.getvalue()
+            self.assertIn("Enqueued items:", output)
+
+            state_store = StateStore(db_path)
+            items = state_store.list_queue_items(limit=10)
+            self.assertEqual(len(items), 1)
+            self.assertEqual(items[0].command_text, "note: queued")
+            self.assertEqual(items[0].max_retries, 1)
+            self.assertEqual(items[0].timeout_seconds, 15)
+
+            events = state_store.list_events()
+            self.assertTrue(events)
+            self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
+
+    def test_ask_invalid_json_fails_cleanly(self) -> None:
+        response = "not json"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                buffer = io.StringIO()
+                with contextlib.redirect_stderr(buffer):
+                    with self.assertRaises(ValueError):
+                        cli_main.run_ask(
+                            db_path,
+                            "bad",
+                            model=None,
+                            host=None,
+                            timeout_s=1,
+                            enqueue=False,
+                            dry_run=True,
+                            max_actions=10,
+                        )
+            self.assertIn("not json", buffer.getvalue())
+
+            state_store = StateStore(db_path)
+            events = state_store.list_events()
+            self.assertTrue(events)
+            self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -45,6 +45,14 @@ class CliMainParserTest(unittest.TestCase):
         self.assertIs(args.handler, cli_main._handle_enqueue)
         self.assertEqual(args.operator_command, ["echo:", "hello"])
 
+    def test_ask_subcommand_routes_to_ask(self) -> None:
+        parser = cli_main.build_parser()
+        args = parser.parse_args(["ask", "draft", "plan"])
+
+        self.assertEqual(args.command, "ask")
+        self.assertIs(args.handler, cli_main._handle_ask)
+        self.assertEqual(args.text, ["draft", "plan"])
+
     def test_daemon_subcommand_routes_to_daemon(self) -> None:
         parser = cli_main.build_parser()
         args = parser.parse_args(["daemon", "--once"])


### PR DESCRIPTION
### Motivation

- Provide a fully-local planning layer so operators can request structured plans from a local LLM (Ollama) while keeping GISMO in control of execution.
- Ensure planner suggestions are validated, policy-checked, and auditable before any execution to preserve deny-by-default and auditability guarantees.
- Keep the implementation small and dependency-free using only the standard library and existing state/queue APIs.

### Description

- Added a minimal Ollama HTTP client and prompts in `gismo/llm/ollama.py`, `gismo/llm/prompts.py`, and `gismo/llm/__init__.py` with `OLLAMA_HOST` and `GISMO_LLM_MODEL` overrides and `ollama_chat(...)` API.
- Introduced CLI `ask` command in `gismo/cli/main.py` (handler `run_ask`) that calls the local Ollama model, strictly parses JSON plans, prints a readable plan, records an audit event `llm_plan`, and optionally enqueues validated `enqueue` actions using existing `parse_command` + `StateStore.enqueue_command` paths. Examples: `python -m gismo.cli.main ask --db .gismo/state.db "Draft a quick plan"` and `python -m gismo.cli.main ask --db .gismo/state.db --enqueue "Queue an echo"`.
- Added `EVENT_TYPE_LLM_PLAN = "llm_plan"` to `gismo/core/models.py` and reused `StateStore.record_event(...)` to persist planner runs and parse failures, preserving timestamped auditability.
- Updated docs and quickstart in `README.md` and `docs/OPERATOR.md`, added a Handoff note, and added tests (`tests/test_ask_cli.py` and updated `tests/test_cli_main.py`) that mock the Ollama call to avoid network dependency.

### Testing

- Ran full verification: `python scripts/verify.py` and all tests passed (`OK`).
- Added unit tests `tests/test_ask_cli.py` covering dry-run plan output, enqueue behavior, and invalid JSON parsing, which mock `ollama_chat` so no real Ollama instance is required.
- Existing CLI/parser tests were updated (`tests/test_cli_main.py`) to include `ask` routing and passed under the verification run.
- Tests exercise state changes via the SQLite test DB and assert that `llm_plan` events are recorded; tests succeeded in CI-local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695265e93c808330bf715942279fa952)