### PR TITLE
Anchor export outputs to DB path (repo-root exports)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -1,13 +1,12 @@
 # Handoff
 
 ## Status
-- Tightened LLM planner prompt with strict enqueue-only schema and examples.
-- Normalized ask plans now coerce echo/note/graph action type near-misses into enqueue commands while preserving safeguards.
-- Added ask CLI tests for action coercion and unsupported action reporting; updated README guidance.
+- Anchored export outputs to the repo root derived from the database path, with a shared helper and resolved paths.
+- Added CLI coverage for export defaults when running from an alternate working directory.
+- Documented export defaults in README and operator guide.
 
 ## Next Steps
-- Validate `ask` against a live Ollama instance with smaller models (phi3:mini) for plan compliance.
-- Extend operator command patterns if new verbs are added.
+- Consider extending db-anchored path defaults to other user-facing artifacts if new output types are added.
 
 ## Tests
 - `python scripts/verify.py`

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ PowerShell note: `<` and `>` are redirection operators. Replace placeholders wit
 python -m gismo.cli.main run show RUN_ID
 ```
 
+## Exporting Run Audits
+
+Exports default to the `exports/` folder next to `.gismo`, derived from `--db`, so the output location is stable across terminals.
+
+```bash
+python -m gismo.cli.main export --latest --db .gismo/state.db
+```
+
 ---
 
 ## LLM Planner (Local Only)

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -17,6 +17,14 @@ Each operator command has a single responsibility:
 - `maintain`: requeues stale `IN_PROGRESS` queue items; safe to run alongside a daemon.
 - `ask`: calls a local Ollama model to propose a JSON plan (dry-run by default).
 
+## Exports
+
+Exports default to the `exports/` folder next to `.gismo`, derived from `--db`, so the output location is stable across terminals.
+
+```bash
+python -m gismo.cli.main export --latest --db .gismo/state.db
+```
+
 ## LLM planner (local)
 
 The `ask` command calls a local Ollama instance on 127.0.0.1:11434 by default and never executes commands directly.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -499,14 +499,12 @@ def run_export(
     policy_path, warn = _resolve_default_policy_path(policy_path, repo_root)
     if warn:
         _warn_missing_default_policy()
-    policy = load_policy(policy_path, repo_root=repo_root)
-    base_dir = policy.fs.base_dir
+    load_policy(policy_path, repo_root=repo_root)
     if use_latest:
         export_path = export_latest_run_jsonl(
             state_store,
             out_path=out_path,
             redact=redact,
-            base_dir=base_dir,
         )
     else:
         export_path = export_run_jsonl(
@@ -514,7 +512,6 @@ def run_export(
             run_id,
             out_path=out_path,
             redact=redact,
-            base_dir=base_dir,
         )
     print(f"Exported run audit to {export_path}")
 
@@ -1564,7 +1561,7 @@ def build_parser() -> argparse.ArgumentParser:
     export_parser.add_argument(
         "--out",
         default=None,
-        help="Output file path (defaults to exports/RUN_ID.jsonl)",
+        help="Output file path (defaults to exports/RUN_ID.jsonl next to --db)",
     )
     export_parser.add_argument(
         "--redact",

--- a/gismo/core/export.py
+++ b/gismo/core/export.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from gismo.core.models import Run, Task, ToolCall
+from gismo.core.paths import resolve_exports_dir
 from gismo.core.state import StateStore
 
 
@@ -21,8 +22,12 @@ def export_run_jsonl(
     run = state_store.get_run(run_id)
     if run is None:
         raise ValueError(f"Run not found: {run_id}")
-    base_dir = base_dir or Path(".")
-    resolved_out = _resolve_output_path(run_id, out_path, base_dir)
+    if base_dir is None:
+        exports_dir = resolve_exports_dir(state_store.db_path)
+    else:
+        exports_dir = base_dir / "exports"
+        exports_dir.mkdir(parents=True, exist_ok=True)
+    resolved_out = _resolve_output_path(run_id, out_path, exports_dir)
     tasks = list(state_store.list_tasks(run_id))
     tool_calls = list(state_store.list_tool_calls(run_id))
     records = _build_records(run, tasks, tool_calls, redact=redact)
@@ -49,11 +54,12 @@ def export_latest_run_jsonl(
     )
 
 
-def _resolve_output_path(run_id: str, out_path: str | Path | None, base_dir: Path) -> Path:
+def _resolve_output_path(run_id: str, out_path: str | Path | None, exports_dir: Path) -> Path:
     if out_path is None:
-        resolved = base_dir / "exports" / f"{run_id}.jsonl"
+        resolved = exports_dir / f"{run_id}.jsonl"
     else:
-        resolved = Path(out_path)
+        resolved = Path(out_path).expanduser()
+    resolved = resolved.resolve()
     resolved.parent.mkdir(parents=True, exist_ok=True)
     return resolved
 

--- a/gismo/core/paths.py
+++ b/gismo/core/paths.py
@@ -1,0 +1,11 @@
+"""Path helpers derived from the database location."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_exports_dir(db_path: str | Path) -> Path:
+    base_dir = Path(db_path).resolve().parent.parent
+    exports_dir = base_dir / "exports"
+    exports_dir.mkdir(parents=True, exist_ok=True)
+    return exports_dir

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -166,6 +166,34 @@ class CliMainParserTest(unittest.TestCase):
             assert item is not None
             self.assertEqual(item.status, QueueStatus.SUCCEEDED)
 
+    def test_export_anchors_default_output_to_db_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir) / "repo"
+            db_path = repo_root / ".gismo" / "state.db"
+            state_store = StateStore(str(db_path))
+            run = state_store.create_run(label="export", metadata={})
+            other_cwd = Path(tmpdir) / "cwd"
+            other_cwd.mkdir(parents=True, exist_ok=True)
+
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(other_cwd)
+                cli_main.run_export(
+                    str(db_path),
+                    run_id=run.id,
+                    use_latest=False,
+                    export_format="jsonl",
+                    out_path=None,
+                    redact=False,
+                    policy_path=None,
+                )
+            finally:
+                os.chdir(original_cwd)
+
+            expected = repo_root / "exports" / f"{run.id}.jsonl"
+            self.assertTrue(expected.exists())
+            self.assertFalse((other_cwd / "exports" / f"{run.id}.jsonl").exists())
+
     def test_ipc_queue_stats_connection_error(self) -> None:
         args = argparse.Namespace(token="secret-token")
         with mock.patch.object(


### PR DESCRIPTION
### Motivation

- Exports were being written relative to the process CWD which is brittle when users run commands from arbitrary terminals (PowerShell, VS Code, external drives). 
- The database path (`--db`) is always provided and lives under `.gismo` in the repo, so it is a stable anchor for user-facing outputs. 
- Making exports derive from the DB location ensures consistent, cross-platform placement of artifacts regardless of current working directory. 

### Description

- Add a canonical helper `resolve_exports_dir` in `gismo/core/paths.py` to compute `<repo_root>/exports` from a `db_path`. 
- Update `gismo/core/export.py` to default export outputs to the DB-anchored `exports/` directory and to return fully resolved paths. 
- Change `gismo/cli/main.py` export handling to use the DB-anchored default (keeps CLI flags unchanged and still prints the resolved full path). 
- Add a cross-platform unit test `test_export_anchors_default_output_to_db_path` in `tests/test_cli_main.py` and document the behavior in `README.md`, `docs/OPERATOR.md`, and `Handoff.md`.

### Testing

- Run verification with `python scripts/verify.py`; the full test suite (including the new export test) passed. 
- The new unit test `tests.test_cli_main.CliMainParserTest.test_export_anchors_default_output_to_db_path` runs as part of the suite and succeeded. 
- No new dependencies were added and existing CLI behavior/flags remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528a72da748330813eb52a6c18b88d)