### PR TITLE
Add ask plan assessment and confirmation gating

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -33,7 +33,7 @@ Completed:
 - Phase 1 (Local LLM Planner): DONE
 
 In progress:
-- Phase 2 (Control & Guardrails): ~65%
+- Phase 2 (Control & Guardrails): ~75%
 
 Planned:
 - Phase 3 (Memory & Context)
@@ -55,7 +55,7 @@ CLI and operator UX:
 - Queue introspection complete:
   - queue stats
   - queue list
-  - queue show <id_or_prefix>
+  - queue show ID_OR_PREFIX
   - short-id prefix resolution with ambiguity detection
 
 Policy & safety:
@@ -163,6 +163,21 @@ DB-anchored exports:
 - Coverage added: CLI export defaults tested from non-repo working directory.
 
 This is a structural improvement and should be treated as stable behavior.
+
+Plan assessment gate:
+- ask now prints confidence, risk flags, and an explanation for each plan.
+- High-risk plans require confirmation before enqueueing unless overridden with --yes.
+
+LATEST UPDATE (OPERATOR NOTES)
+
+Status:
+- Phase 2 now includes confidence scoring, risk flags, and confirmation gating for ask.
+
+Next steps:
+- Make planner prompts policy-aware (still pending).
+
+Tests run:
+- python scripts/verify.py
 
 -------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Queue introspection:
 
   gismo queue stats
   gismo queue list
-  gismo queue show <ID_OR_PREFIX>
+  gismo queue show ID_OR_PREFIX
 
 Notes:
 - queue show supports short-id prefix resolution (with ambiguity detection).
@@ -103,7 +103,7 @@ Notes:
 Export audit logs:
 
   gismo export --latest
-  gismo export --run <RUN_ID>
+  gismo export --run RUN_ID
   gismo export --all
 
 Planner (local LLM via Ollama):
@@ -116,6 +116,9 @@ Planner behavior:
 - Actions are bounded (hard limit on action count).
 - Normalization/coercion exists so malformed model output does not break the system.
 - Full audit trail is recorded for planner outputs and execution.
+- Every plan includes a confidence assessment, risk flags, and a short explanation.
+- Higher-risk plans require confirmation before enqueueing unless --yes is used.
+- --explain prints additional assessment details.
 
 -------------------------------------------------------------------------------
 

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -111,7 +111,7 @@ QUEUE LIST:
 
 QUEUE SHOW:
 
-  gismo queue show <ID_OR_PREFIX>
+  gismo queue show ID_OR_PREFIX
 
 Notes:
 - Short ID prefixes are supported
@@ -128,7 +128,7 @@ LATEST RUN:
 
 SPECIFIC RUN:
 
-  gismo export --run <RUN_ID>
+  gismo export --run RUN_ID
 
 ALL RUNS:
 
@@ -157,6 +157,9 @@ Planner rules:
 - Output is normalized
 - Policy is still enforced at execution time
 - Planner cannot execute directly
+- Confidence assessment and risk flags are printed with every plan
+- Higher-risk plans require confirmation before enqueueing unless --yes is used
+- Use --explain to print expanded assessment details
 
 Always prefer:
 - --dry-run first

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -29,6 +29,7 @@ from gismo.core.models import EVENT_TYPE_ASK_FAILED, EVENT_TYPE_LLM_PLAN, QueueS
 from gismo.core.maintenance import run_maintenance_iteration
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy, load_policy
+from gismo.core.plan_assess import PlanAssessment, assess_plan, expanded_explanation
 from gismo.core.state import StateStore
 from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
 from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFileTool, WriteFileTool
@@ -233,6 +234,53 @@ def _print_llm_plan(plan: dict) -> None:
         print("Notes:")
         for note in notes:
             print(f"- {note}")
+
+
+def _print_plan_assessment(assessment: PlanAssessment, *, explain: bool) -> None:
+    confidence_label = assessment.confidence.upper()
+    print(f"Confidence: {confidence_label}")
+    if assessment.risk_flags:
+        print(f"Risk flags: {', '.join(assessment.risk_flags)}")
+    else:
+        print("Risk flags: none")
+    print(f"Explanation: {assessment.explanation}")
+    if explain:
+        details = expanded_explanation(assessment)
+        if details:
+            print("Explanation details:")
+            for detail in details:
+                print(f"- {detail}")
+
+
+def _is_interactive_tty() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _confirm_assessment(assessment: PlanAssessment, *, yes: bool) -> None:
+    if not assessment.requires_confirmation or yes:
+        return
+    if _is_interactive_tty():
+        response = input("This plan requires confirmation. Proceed? [y/N]:")
+        if response.strip().lower() not in {"y", "yes"}:
+            print("Confirmation declined; plan not enqueued.", file=sys.stderr)
+            raise SystemExit(2)
+        return
+    print(
+        "Refusing to enqueue without confirmation in non-interactive mode. Use --yes to override.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _load_assessment_policy() -> PermissionPolicy | None:
+    repo_root = Path(__file__).resolve().parents[2]
+    policy_path, _ = _resolve_default_policy_path(None, repo_root)
+    if policy_path is None:
+        return None
+    try:
+        return load_policy(policy_path, repo_root=repo_root)
+    except (OSError, ValueError, PermissionError):
+        return None
 
 
 def _run_status(tasks: list) -> str:
@@ -544,6 +592,8 @@ def run_ask(
     enqueue: bool,
     dry_run: bool,
     max_actions: int,
+    yes: bool,
+    explain: bool,
 ) -> None:
     if not user_text or not user_text.strip():
         raise ValueError("ask requires a natural language request.")
@@ -645,12 +695,16 @@ def run_ask(
         )
         raise
     _print_llm_plan(plan)
+    policy = _load_assessment_policy()
+    assessment = assess_plan(plan.get("actions", []), policy=policy)
+    _print_plan_assessment(assessment, explain=explain)
     payload = {
         "model": config.model,
         "host": config.url,
         "timeout_s": config.timeout_s,
         "user_text": user_text,
         "plan": plan,
+        "assessment": assessment.to_dict(),
         "enqueue": enqueue,
         "dry_run": dry_run,
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -667,6 +721,7 @@ def run_ask(
     if dry_run:
         print("Dry run: enqueue requested but no items were enqueued.")
         return
+    _confirm_assessment(assessment, yes=yes)
 
     enqueued_ids = []
     skipped = []
@@ -907,6 +962,8 @@ def _handle_ask(args: argparse.Namespace) -> None:
         enqueue=args.enqueue,
         dry_run=dry_run,
         max_actions=args.max_actions,
+        yes=args.yes,
+        explain=args.explain,
     )
 
 
@@ -1648,6 +1705,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--enqueue",
         action="store_true",
         help="Enqueue validated actions for the daemon to execute",
+    )
+    ask_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for enqueue actions",
+    )
+    ask_parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="Print expanded assessment explanation details",
     )
     ask_parser.add_argument(
         "--dry-run",

--- a/gismo/core/plan_assess.py
+++ b/gismo/core/plan_assess.py
@@ -1,0 +1,221 @@
+"""Plan assessment heuristics for GISMO ask plans."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, Literal
+
+from gismo.core.permissions import PermissionPolicy
+
+
+ConfidenceLevel = Literal["low", "medium", "high"]
+
+
+@dataclass(frozen=True)
+class PlanAssessment:
+    confidence: ConfidenceLevel
+    risk_flags: list[str]
+    explanation: str
+    requires_confirmation: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "confidence": self.confidence,
+            "risk_flags": list(self.risk_flags),
+            "explanation": self.explanation,
+            "requires_confirmation": self.requires_confirmation,
+        }
+
+
+_DESTRUCTIVE_TOKENS = (
+    "rm ",
+    "del ",
+    "rmdir",
+    "format",
+    "shutdown",
+    "reboot",
+    "reg delete",
+    "diskpart",
+)
+_WRITE_PREFIXES = ("write:", "file_write:", "append:", "note:")
+_SHELL_PREFIX = "shell:"
+_FLAG_ORDER = [
+    "shell",
+    "writes",
+    "many_steps",
+    "too_many_steps",
+    "destructive_intent",
+    "policy_denied_in_plan",
+]
+_FLAG_DETAILS = {
+    "shell": "Includes shell commands.",
+    "writes": "Includes write actions.",
+    "many_steps": "Plan has more than 5 actions.",
+    "too_many_steps": "Plan has more than 12 actions.",
+    "destructive_intent": "Command text contains destructive keywords.",
+    "policy_denied_in_plan": "Policy would deny one or more tools.",
+}
+_WRITE_TOOLS = {"write_note"}
+
+
+def assess_plan(
+    actions: Iterable[dict[str, object]],
+    *,
+    policy: PermissionPolicy | None = None,
+) -> PlanAssessment:
+    actions_list = list(actions)
+    risk_flags: set[str] = set()
+    confidence: ConfidenceLevel = "high"
+
+    action_count = len(actions_list)
+    if action_count > 12:
+        risk_flags.add("too_many_steps")
+        confidence = "low"
+    elif action_count > 5:
+        risk_flags.add("many_steps")
+        confidence = _cap_confidence(confidence, "medium")
+
+    for action in actions_list:
+        command = action.get("command")
+        command_text = command if isinstance(command, str) else str(command) if command else ""
+        command_lower = command_text.strip().lower()
+        if command_lower.startswith(_SHELL_PREFIX):
+            risk_flags.add("shell")
+            confidence = _cap_confidence(confidence, "medium")
+        if command_lower.startswith(_WRITE_PREFIXES):
+            risk_flags.add("writes")
+            confidence = _cap_confidence(confidence, "medium")
+        if any(token in command_lower for token in _DESTRUCTIVE_TOKENS):
+            risk_flags.add("destructive_intent")
+            confidence = "low"
+        tool_names = _infer_tools_from_command(command_text)
+        if _contains_write_tool(tool_names):
+            risk_flags.add("writes")
+            confidence = _cap_confidence(confidence, "medium")
+        if policy is not None and tool_names:
+            for tool_name in tool_names:
+                if _tool_denied(policy, tool_name):
+                    risk_flags.add("policy_denied_in_plan")
+                    confidence = "low"
+                    break
+
+    ordered_flags = _order_flags(risk_flags)
+    requires_confirmation = _requires_confirmation(confidence, ordered_flags)
+    explanation = _build_explanation(confidence, ordered_flags, action_count)
+    return PlanAssessment(
+        confidence=confidence,
+        risk_flags=ordered_flags,
+        explanation=explanation,
+        requires_confirmation=requires_confirmation,
+    )
+
+
+def expanded_explanation(assessment: PlanAssessment) -> list[str]:
+    if not assessment.risk_flags:
+        return ["No additional risk flags detected."]
+    details: list[str] = []
+    for flag in assessment.risk_flags:
+        detail = _FLAG_DETAILS.get(flag)
+        if detail:
+            details.append(detail)
+    return details
+
+
+def _cap_confidence(current: ConfidenceLevel, cap: ConfidenceLevel) -> ConfidenceLevel:
+    if current == "low":
+        return "low"
+    if cap == "medium" and current == "high":
+        return "medium"
+    return current
+
+
+def _order_flags(flags: Iterable[str]) -> list[str]:
+    ordered: list[str] = []
+    remaining = set(flags)
+    for flag in _FLAG_ORDER:
+        if flag in remaining:
+            ordered.append(flag)
+            remaining.remove(flag)
+    for flag in sorted(remaining):
+        ordered.append(flag)
+    return ordered
+
+
+def _requires_confirmation(confidence: ConfidenceLevel, flags: list[str]) -> bool:
+    if confidence == "low":
+        return True
+    return any(
+        flag in flags
+        for flag in ("destructive_intent", "policy_denied_in_plan", "too_many_steps")
+    )
+
+
+def _build_explanation(confidence: ConfidenceLevel, flags: list[str], action_count: int) -> str:
+    if not flags:
+        return (
+            f"Plan has {action_count} action(s) with no flagged risks; "
+            f"confidence is {confidence}."
+        )
+    phrases = []
+    for flag in flags:
+        phrase = _flag_phrase(flag)
+        if phrase:
+            phrases.append(phrase)
+    reasons = ", ".join(phrases)
+    return (
+        f"Plan has {action_count} action(s) and {reasons}, "
+        f"so confidence is {confidence}."
+    )
+
+
+def _flag_phrase(flag: str) -> str | None:
+    mapping = {
+        "shell": "includes shell commands",
+        "writes": "includes write actions",
+        "many_steps": "has more than 5 actions",
+        "too_many_steps": "has more than 12 actions",
+        "destructive_intent": "contains destructive keywords",
+        "policy_denied_in_plan": "appears to violate policy",
+    }
+    return mapping.get(flag)
+
+
+def _infer_tools_from_command(command: str) -> list[str]:
+    if not isinstance(command, str):
+        return []
+    trimmed = command.strip()
+    if not trimmed:
+        return []
+    lower = trimmed.lower()
+    if lower.startswith("echo:"):
+        return ["echo"]
+    if lower.startswith("note:"):
+        return ["write_note"]
+    if lower.startswith("graph:"):
+        remainder = trimmed.split(":", 1)[1].strip()
+        if not remainder:
+            return []
+        steps = [part.strip() for part in remainder.split("->")]
+        tools: list[str] = []
+        for step in steps:
+            match = re.match(r"(?i)^(echo|note)\s+(.+)$", step)
+            if not match:
+                return []
+            verb = match.group(1).lower()
+            tools.append("echo" if verb == "echo" else "write_note")
+        return tools
+    return []
+
+
+def _contains_write_tool(tool_names: Iterable[str]) -> bool:
+    return any(tool in _WRITE_TOOLS for tool in tool_names)
+
+
+def _tool_denied(policy: PermissionPolicy, tool_name: str) -> bool:
+    try:
+        policy.check_tool_allowed(tool_name)
+    except PermissionError:
+        return True
+    except Exception:
+        return False
+    return False

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -56,6 +56,8 @@ class AskCliTest(unittest.TestCase):
                             enqueue=False,
                             dry_run=True,
                             max_actions=10,
+                            yes=False,
+                            explain=False,
                         )
             output = buffer.getvalue()
             self.assertIn("LLM: phi3:mini url=http://127.0.0.1:11434 timeout=120s", output)
@@ -80,7 +82,7 @@ class AskCliTest(unittest.TestCase):
                 "actions": [
                     {
                         "type": "enqueue",
-                        "command": "note: queued",
+                        "command": "echo: queued",
                         "timeout_seconds": 15,
                         "retries": 1,
                         "why": "record",
@@ -115,6 +117,8 @@ class AskCliTest(unittest.TestCase):
                             enqueue=True,
                             dry_run=False,
                             max_actions=10,
+                            yes=False,
+                            explain=False,
                         )
             output = buffer.getvalue()
             self.assertIn("Enqueued items:", output)
@@ -122,7 +126,7 @@ class AskCliTest(unittest.TestCase):
             state_store = StateStore(db_path)
             items = state_store.list_queue_items(limit=10)
             self.assertEqual(len(items), 1)
-            self.assertEqual(items[0].command_text, "note: queued")
+            self.assertEqual(items[0].command_text, "echo: queued")
             self.assertEqual(items[0].max_retries, 1)
             self.assertEqual(items[0].timeout_seconds, 15)
 
@@ -158,6 +162,8 @@ class AskCliTest(unittest.TestCase):
                                 enqueue=False,
                                 dry_run=True,
                                 max_actions=10,
+                                yes=False,
+                                explain=False,
                             )
             self.assertIn("not json", buffer.getvalue())
 
@@ -190,6 +196,8 @@ class AskCliTest(unittest.TestCase):
                         enqueue=False,
                         dry_run=True,
                         max_actions=5,
+                        yes=False,
+                        explain=False,
                     )
                     _, kwargs = ollama_mock.call_args
                     self.assertEqual(kwargs["model"], "custom-model")
@@ -214,6 +222,8 @@ class AskCliTest(unittest.TestCase):
                         enqueue=False,
                         dry_run=True,
                         max_actions=5,
+                        yes=False,
+                        explain=False,
                     )
                     _, kwargs = ollama_mock.call_args
                     self.assertEqual(kwargs["timeout_s"], 5)
@@ -259,6 +269,8 @@ class AskCliTest(unittest.TestCase):
                         enqueue=False,
                         dry_run=True,
                         max_actions=10,
+                        yes=False,
+                        explain=False,
                     )
             state_store = StateStore(db_path)
             event = state_store.list_events()[0]
@@ -312,6 +324,8 @@ class AskCliTest(unittest.TestCase):
                         enqueue=False,
                         dry_run=True,
                         max_actions=10,
+                        yes=False,
+                        explain=False,
                     )
             state_store = StateStore(db_path)
             event = state_store.list_events()[0]
@@ -352,6 +366,8 @@ class AskCliTest(unittest.TestCase):
                             enqueue=False,
                             dry_run=True,
                             max_actions=5,
+                            yes=False,
+                            explain=False,
                         )
             state_store = StateStore(db_path)
             events = state_store.list_events()
@@ -377,6 +393,205 @@ class AskCliTest(unittest.TestCase):
         normalized = cli_main._normalize_llm_plan(plan, max_actions=5)
         self.assertEqual(normalized["assumptions"], [])
         self.assertEqual(normalized["actions"][0]["command"], "echo: hello")
+
+    def test_ask_enqueue_requires_confirmation_interactive_decline(self) -> None:
+        actions = [
+            {
+                "type": "enqueue",
+                "command": f"note: step {index}",
+                "timeout_seconds": 30,
+                "retries": 0,
+                "why": "test",
+                "risk": "low",
+            }
+            for index in range(13)
+        ]
+        response = json.dumps(
+            {"intent": "queue notes", "assumptions": [], "actions": actions, "notes": []}
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch("sys.stdin.isatty", return_value=True), mock.patch(
+                        "sys.stdout.isatty", return_value=True
+                    ), mock.patch("builtins.input", return_value="n"):
+                        with self.assertRaises(SystemExit) as exc:
+                            cli_main.run_ask(
+                                db_path,
+                                "enqueue notes",
+                                model=None,
+                                host=None,
+                                timeout_s=None,
+                                enqueue=True,
+                                dry_run=False,
+                                max_actions=20,
+                                yes=False,
+                                explain=False,
+                            )
+                        self.assertEqual(exc.exception.code, 2)
+            state_store = StateStore(db_path)
+            items = state_store.list_queue_items(limit=20)
+            self.assertEqual(len(items), 0)
+
+    def test_ask_enqueue_requires_confirmation_interactive_accept(self) -> None:
+        actions = [
+            {
+                "type": "enqueue",
+                "command": f"note: step {index}",
+                "timeout_seconds": 30,
+                "retries": 0,
+                "why": "test",
+                "risk": "low",
+            }
+            for index in range(13)
+        ]
+        response = json.dumps(
+            {"intent": "queue notes", "assumptions": [], "actions": actions, "notes": []}
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch("sys.stdin.isatty", return_value=True), mock.patch(
+                        "sys.stdout.isatty", return_value=True
+                    ), mock.patch("builtins.input", return_value="y"):
+                        cli_main.run_ask(
+                            db_path,
+                            "enqueue notes",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=True,
+                            dry_run=False,
+                            max_actions=20,
+                            yes=False,
+                            explain=False,
+                        )
+            state_store = StateStore(db_path)
+            items = state_store.list_queue_items(limit=20)
+            self.assertEqual(len(items), 13)
+
+    def test_ask_enqueue_requires_confirmation_non_interactive(self) -> None:
+        actions = [
+            {
+                "type": "enqueue",
+                "command": f"note: step {index}",
+                "timeout_seconds": 30,
+                "retries": 0,
+                "why": "test",
+                "risk": "low",
+            }
+            for index in range(13)
+        ]
+        response = json.dumps(
+            {"intent": "queue notes", "assumptions": [], "actions": actions, "notes": []}
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    buffer = io.StringIO()
+                    with contextlib.redirect_stderr(buffer):
+                        with mock.patch("sys.stdin.isatty", return_value=False), mock.patch(
+                            "sys.stdout.isatty", return_value=False
+                        ):
+                            with self.assertRaises(SystemExit) as exc:
+                                cli_main.run_ask(
+                                    db_path,
+                                    "enqueue notes",
+                                    model=None,
+                                    host=None,
+                                    timeout_s=None,
+                                    enqueue=True,
+                                    dry_run=False,
+                                    max_actions=20,
+                                    yes=False,
+                                    explain=False,
+                                )
+                            self.assertEqual(exc.exception.code, 2)
+                    self.assertIn("--yes", buffer.getvalue())
+            state_store = StateStore(db_path)
+            items = state_store.list_queue_items(limit=20)
+            self.assertEqual(len(items), 0)
+
+    def test_ask_enqueue_requires_confirmation_yes_override(self) -> None:
+        actions = [
+            {
+                "type": "enqueue",
+                "command": f"note: step {index}",
+                "timeout_seconds": 30,
+                "retries": 0,
+                "why": "test",
+                "risk": "low",
+            }
+            for index in range(13)
+        ]
+        response = json.dumps(
+            {"intent": "queue notes", "assumptions": [], "actions": actions, "notes": []}
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch("sys.stdin.isatty", return_value=False), mock.patch(
+                        "sys.stdout.isatty", return_value=False
+                    ):
+                        cli_main.run_ask(
+                            db_path,
+                            "enqueue notes",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=True,
+                            dry_run=False,
+                            max_actions=20,
+                            yes=True,
+                            explain=False,
+                        )
+            state_store = StateStore(db_path)
+            items = state_store.list_queue_items(limit=20)
+            self.assertEqual(len(items), 13)
 
 
 if __name__ == "__main__":

--- a/tests/test_plan_assess.py
+++ b/tests/test_plan_assess.py
@@ -1,0 +1,21 @@
+import unittest
+
+from gismo.core.plan_assess import assess_plan
+
+
+class PlanAssessTest(unittest.TestCase):
+    def test_shell_action_sets_flag_and_lowers_confidence(self) -> None:
+        actions = [{"type": "enqueue", "command": "shell: dir"}]
+        assessment = assess_plan(actions)
+        self.assertIn("shell", assessment.risk_flags)
+        self.assertNotEqual(assessment.confidence, "high")
+
+    def test_destructive_token_requires_confirmation(self) -> None:
+        actions = [{"type": "enqueue", "command": "shell: rm -rf /"}]
+        assessment = assess_plan(actions)
+        self.assertEqual(assessment.confidence, "low")
+        self.assertTrue(assessment.requires_confirmation)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Implement Phase 2 guardrails by adding a deterministic plan assessment that assigns confidence, emits risk flags, and provides a short explanation for `gismo ask` plans.
- Prevent high-risk or low-confidence plans from being enqueued without explicit operator confirmation.
- Provide an explain-before-execute path and a non-interactive safety behavior with an explicit override.
- Keep heuristics deterministic and best-effort policy-aware while avoiding any LLM or network dependencies.

### Description
- Add a new pure module `gismo/core/plan_assess.py` exposing a `PlanAssessment` dataclass and `assess_plan`/`expanded_explanation` functions implementing the required heuristics and best-effort policy checks.
- Integrate assessment into the planner flow in `gismo/cli/main.py` so every printed plan includes `Confidence`, `Risk flags`, and `Explanation`, and the assessment is recorded in the ask event payload.
- Add a confirmation gate enforced before enqueueing: interactive TTY prompts default to NO, non-interactive runs abort with a non-zero exit (code 2) unless `--yes` is supplied, and add `--explain` to show expanded explanation details.
- Add/modify tests (`tests/test_plan_assess.py`, updated `tests/test_ask_cli.py`) and update operator-facing docs (`README.md`, `docs/OPERATOR.md`) and `Handoff.md` to document flags and behavior.

### Testing
- Run the full project verification with `python scripts/verify.py` which executes the test suite and completed successfully.
- Added unit tests `tests/test_plan_assess.py` and extended `tests/test_ask_cli.py` to cover assessment heuristics, interactive accept/decline, non-interactive abort, and `--yes` override, all of which passed under verification.
- As an alternate local check, `python -m unittest discover -s tests -p "test*.py" -v` was used and passed without regressions.
- No automated tests failed and the change preserved existing behavior except for the documented confirmation gating and assessment outputs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69529aca3d708330b7f235a7c6b49194)