### PR TITLE
Add gismo console script entrypoint

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -50,7 +50,7 @@ Core persistence + execution:
 - Retained FAILED items for auditability (intentional)
 
 CLI and operator UX:
-- Canonical invocation: python -m gismo.cli.main ...
+- Canonical invocation: gismo ... (fallback: python -m gismo.cli.main ...)
 - CLI entrypoint supports: run, enqueue, daemon, export, queue introspection
 - Queue introspection complete:
   - queue stats
@@ -171,11 +171,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Ask now reports Ollama timeouts cleanly, with accurate timeout display and a --debug flag.
+- Added a console script entrypoint (`gismo`) for CLI access via pip installs.
 
 Next steps:
 - Make planner prompts policy-aware (still pending).
 - Monitor operator feedback on ask timeout UX.
+- Confirm Windows operator docs emphasize the console entrypoint when installed.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Install (from repo root):
 CANONICAL INVOCATION
 
 Prefer:
-  python -m gismo.cli.main ...
-
-If installed in editable mode, the `gismo` console entrypoint may also be available:
   gismo ...
+
+Fallback (no console script available):
+  python -m gismo.cli.main ...
 
 -------------------------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = {text = "UNLICENSED"}
 
+[project.scripts]
+gismo = "gismo.cli.main:main"
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["gismo*"]

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,19 @@
+import tomllib
+import unittest
+from pathlib import Path
+
+
+class PackageMetadataTest(unittest.TestCase):
+    def test_console_script_entrypoint_is_defined(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        pyproject_path = repo_root / "pyproject.toml"
+
+        with pyproject_path.open("rb") as handle:
+            pyproject = tomllib.load(handle)
+
+        scripts = pyproject.get("project", {}).get("scripts", {})
+        self.assertEqual(scripts.get("gismo"), "gismo.cli.main:main")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a proper console entrypoint so `pip install -e .` exposes a `gismo` CLI on Windows and other platforms.
- Prefer the installed console script as the canonical invocation for operator workflows.
- Make packaging metadata explicit and verifiable by tests.

### Description
- Add `[project.scripts]` entry to `pyproject.toml` with `gismo = "gismo.cli.main:main"`.
- Add `tests/test_package_metadata.py` which asserts the `gismo` console script is declared in `pyproject.toml`.
- Update `README.md` and `Handoff.md` to prefer `gismo ...` and note the fallback `python -m gismo.cli.main ...`.

### Testing
- Ran `python scripts/verify.py` which executed the full test suite and completed successfully (all tests passed).
- The new unit test `tests/test_package_metadata.py` was run as part of verification and passed.
- No additional manual verification was performed; the package metadata test checks declaration only and does not execute the console script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a7c2c35883309e59a4e60914f695)