### PR TITLE
Fix ask timeout banner parsing

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -171,7 +171,7 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added a console script entrypoint (`gismo`) for CLI access via pip installs.
+- Ask CLI now accepts options after the prompt so `--timeout-s` drives the LLM banner and request timeout.
 
 Next steps:
 - Make planner prompts policy-aware (still pending).

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -1740,7 +1740,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     ask_parser.add_argument(
         "text",
-        nargs=argparse.REMAINDER,
+        nargs="+",
         help="Natural language request for the planner",
     )
     ask_parser.set_defaults(handler=_handle_ask)

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -236,20 +236,13 @@ class AskCliTest(unittest.TestCase):
             db_path = str(Path(tmpdir) / "state.db")
             with mock.patch.dict(os.environ, {"GISMO_OLLAMA_TIMEOUT_S": "120"}, clear=False):
                 with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    parser = cli_main.build_parser()
+                    args = parser.parse_args(
+                        ["ask", "--db", db_path, "ping", "--dry-run", "--timeout-s", "2"]
+                    )
                     buffer = io.StringIO()
                     with contextlib.redirect_stdout(buffer):
-                        cli_main.run_ask(
-                            db_path,
-                            "ping",
-                            model=None,
-                            host=None,
-                            timeout_s=2,
-                            enqueue=False,
-                            dry_run=True,
-                            max_actions=5,
-                            yes=False,
-                            explain=False,
-                        )
+                        args.handler(args)
             output = buffer.getvalue()
             self.assertIn("timeout=2s", output)
 


### PR DESCRIPTION
### Motivation
- The `ask` subcommand previously used `nargs=argparse.REMAINDER`, so CLI options provided after the prompt (e.g. `--timeout-s`) were treated as prompt text and the LLM banner showed the default timeout instead of the effective override.
- The effective timeout must be reflected in the printed `LLM:` banner and used for the actual `ollama_chat` request.

### Description
- Change `ask` positional `text` argument from `nargs=argparse.REMAINDER` to `nargs='+'` so options after the prompt are parsed as CLI flags instead of literal prompt text.
- Update `tests/test_ask_cli.py::test_ask_timeout_override_printed_in_llm_line` to invoke the CLI parser and handler with `--timeout-s 2` and assert the banner contains `timeout=2s`.
- Update `Handoff.md` to note the CLI behavior change regarding options after the prompt.

### Testing
- Ran `python scripts/verify.py`, which executes the unit test suite and verification steps, and it completed successfully (all tests passed).
- Adjusted unit test `test_ask_timeout_override_printed_in_llm_line` now asserts the banner prints `timeout=2s` and passes.
- Verified that existing `ask` behavior still passes the effective timeout through to `ollama_chat` by asserting call arguments in related tests.
- No other tests were modified and the full test suite ran cleanly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c612426c8330befdc97d2f88669e)