### PR TITLE
Harden ask JSON handling and Ollama request settings

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -171,7 +171,9 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Ask CLI now accepts options after the prompt so `--timeout-s` drives the LLM banner and request timeout.
+- Ask now uses Ollama JSON mode with keep_alive and best-effort JSON extraction.
+- Plans with more than 12 actions are explicitly flagged in notes.
+- Ollama-related tests are hermetic by default with an optional integration gate.
 
 Next steps:
 - Make planner prompts policy-aware (still pending).

--- a/README.md
+++ b/README.md
@@ -115,11 +115,20 @@ Planner behavior:
 - Produces enqueue-only plans under strict schema.
 - Actions are bounded (hard limit on action count).
 - Normalization/coercion exists so malformed model output does not break the system.
+- Ollama is called in JSON mode and uses keep_alive to avoid repeated model reloads.
 - Full audit trail is recorded for planner outputs and execution.
 - Every plan includes a confidence assessment, risk flags, and a short explanation.
 - Higher-risk plans require confirmation before enqueueing unless --yes is used.
 - --explain prints additional assessment details.
 - Use --debug to print tracebacks for ask failures.
+
+Planner configuration:
+- Increase --timeout-s on CPU machines (60s baseline) if prompts time out.
+- Environment overrides:
+  - GISMO_LLM_MODEL or GISMO_OLLAMA_MODEL (model name)
+  - GISMO_LLM_TIMEOUT_S or GISMO_OLLAMA_TIMEOUT_S (LLM timeout)
+  - GISMO_OLLAMA_URL or OLLAMA_HOST (Ollama endpoint)
+- keep_alive defaults to 10m so models stay loaded for smoother repeated calls.
 
 -------------------------------------------------------------------------------
 

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -155,12 +155,21 @@ Planner rules:
 - Produces enqueue-only plans
 - Action count is bounded
 - Output is normalized
+- Uses Ollama JSON mode with keep_alive to reduce reload latency
 - Policy is still enforced at execution time
 - Planner cannot execute directly
 - Confidence assessment and risk flags are printed with every plan
 - Higher-risk plans require confirmation before enqueueing unless --yes is used
 - Use --explain to print expanded assessment details
 - Use --debug to print tracebacks for ask failures
+
+Planner configuration:
+- Increase --timeout-s on CPU machines (60s baseline) if Ollama is slow.
+- Environment overrides:
+  - GISMO_LLM_MODEL or GISMO_OLLAMA_MODEL
+  - GISMO_LLM_TIMEOUT_S or GISMO_OLLAMA_TIMEOUT_S
+  - GISMO_OLLAMA_URL or OLLAMA_HOST
+- keep_alive defaults to 10m so models remain loaded for repeated calls.
 
 Always prefer:
 - --dry-run first

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 import time
 from datetime import datetime, timezone
@@ -106,6 +107,48 @@ def _coerce_action_type_to_command(action_type_text: str) -> str | None:
     return candidate
 
 
+def _strip_code_fences(text: str) -> str:
+    cleaned = text.strip()
+    if "```" not in cleaned:
+        return cleaned
+    cleaned = re.sub(r"```[a-zA-Z0-9_-]*", "", cleaned)
+    return cleaned.strip()
+
+
+def extract_json_object(text: str) -> str | None:
+    cleaned = _strip_code_fences(text).strip()
+    if not cleaned:
+        return None
+    for start, ch in enumerate(cleaned):
+        if ch in "{[":
+            open_ch = ch
+            close_ch = "}" if ch == "{" else "]"
+            depth = 0
+            in_string = False
+            escape = False
+            for index in range(start, len(cleaned)):
+                current = cleaned[index]
+                if in_string:
+                    if escape:
+                        escape = False
+                    elif current == "\\":
+                        escape = True
+                    elif current == '"':
+                        in_string = False
+                    continue
+                if current == '"':
+                    in_string = True
+                    continue
+                if current == open_ch:
+                    depth += 1
+                elif current == close_ch:
+                    depth -= 1
+                    if depth == 0:
+                        return cleaned[start : index + 1]
+            return None
+    return None
+
+
 def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
     allowed_fields = {"intent", "assumptions", "actions", "notes"}
     unknown_fields = set(plan.keys()) - allowed_fields
@@ -184,9 +227,15 @@ def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
             )
     if max_actions <= 0:
         raise ValueError("max_actions must be > 0")
-    if len(actions) > max_actions:
+    original_action_count = len(actions)
+    if original_action_count > 12:
         notes.append(
-            f"Truncated actions from {len(actions)} to {max_actions} based on --max-actions."
+            "Too many actions "
+            f"({original_action_count}). Please ask for 12 or fewer, or request batching."
+        )
+    if original_action_count > max_actions:
+        notes.append(
+            f"Truncated actions from {original_action_count} to {max_actions} based on --max-actions."
         )
         actions = actions[:max_actions]
     unknown_types = sorted({a["type"] for a in actions if a["type"] and a["type"] != "enqueue"})
@@ -632,29 +681,46 @@ def run_ask(
         if debug:
             raise
         raise SystemExit(1)
+    parsed: dict | None = None
+    parse_error: str | None = None
     try:
         parsed = json.loads(raw_response)
     except json.JSONDecodeError as exc:
-        print(raw_response, file=sys.stderr)
-        payload = {
-            "model": config.model,
-            "host": config.url,
-            "timeout_s": config.timeout_s,
-            "user_text": user_text,
-            "plan": None,
-            "raw_response": raw_response,
-            "parse_error": str(exc),
-            "enqueue": enqueue,
-            "dry_run": dry_run,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        state_store.record_event(
-            actor="ask",
-            event_type=EVENT_TYPE_LLM_PLAN,
-            message="LLM plan parsing failed.",
-            json_payload=payload,
-        )
-        raise ValueError("LLM response was not valid JSON.") from exc
+        parse_error = str(exc)
+        extracted = extract_json_object(raw_response)
+        if extracted:
+            try:
+                parsed = json.loads(extracted)
+            except json.JSONDecodeError as exc_extracted:
+                parse_error = str(exc_extracted)
+        if parsed is None:
+            payload = {
+                "model": config.model,
+                "host": config.url,
+                "timeout_s": config.timeout_s,
+                "user_text": user_text,
+                "plan": None,
+                "raw_response": raw_response,
+                "parse_error": parse_error,
+                "enqueue": enqueue,
+                "dry_run": dry_run,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+            state_store.record_event(
+                actor="ask",
+                event_type=EVENT_TYPE_LLM_PLAN,
+                message="LLM plan parsing failed.",
+                json_payload=payload,
+            )
+            message = (
+                "LLM response was not valid JSON. "
+                f"model={config.model} endpoint={config.url} timeout={config.timeout_s}s. "
+                "Try --timeout-s 60+ and/or switch models."
+            )
+            print(f"ERROR: {message}", file=sys.stderr)
+            if debug:
+                raise ValueError(message) from exc
+            raise SystemExit(1)
 
     if not isinstance(parsed, dict):
         payload = {
@@ -675,7 +741,14 @@ def run_ask(
             message="LLM plan parsing failed.",
             json_payload=payload,
         )
-        raise ValueError("LLM response must be a JSON object.")
+        message = (
+            "LLM response was not a JSON object. "
+            f"model={config.model} endpoint={config.url} timeout={config.timeout_s}s."
+        )
+        print(f"ERROR: {message}", file=sys.stderr)
+        if debug:
+            raise ValueError(message)
+        raise SystemExit(1)
     try:
         plan = _normalize_llm_plan(parsed, max_actions=max_actions)
     except ValueError as exc:

--- a/gismo/llm/ollama.py
+++ b/gismo/llm/ollama.py
@@ -13,6 +13,7 @@ from typing import Any
 DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434"
 DEFAULT_OLLAMA_MODEL = "phi3:mini"
 DEFAULT_OLLAMA_TIMEOUT_S = 120
+DEFAULT_OLLAMA_KEEP_ALIVE = "10m"
 
 
 @dataclass(frozen=True)
@@ -72,7 +73,7 @@ def resolve_ollama_model(model: str | None = None) -> str:
 def resolve_ollama_timeout(timeout_s: int | None = None) -> int:
     if timeout_s is not None and timeout_s > 0:
         return timeout_s
-    env_value = os.getenv("GISMO_OLLAMA_TIMEOUT_S")
+    env_value = os.getenv("GISMO_OLLAMA_TIMEOUT_S") or os.getenv("GISMO_LLM_TIMEOUT_S")
     return _coerce_timeout(env_value, DEFAULT_OLLAMA_TIMEOUT_S)
 
 
@@ -89,6 +90,27 @@ def resolve_ollama_config(
     )
 
 
+def build_ollama_chat_payload(
+    prompt: str,
+    system: str,
+    *,
+    model: str,
+    keep_alive: str = DEFAULT_OLLAMA_KEEP_ALIVE,
+    temperature: float = 0,
+) -> dict[str, Any]:
+    return {
+        "model": model,
+        "stream": False,
+        "format": "json",
+        "keep_alive": keep_alive,
+        "options": {"temperature": temperature},
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ],
+    }
+
+
 def ollama_chat(
     prompt: str,
     system: str,
@@ -99,14 +121,11 @@ def ollama_chat(
     """Call Ollama chat API and return assistant content."""
     config = resolve_ollama_config(url=host, model=model, timeout_s=timeout_s)
     url = f"{config.url}/api/chat"
-    payload = {
-        "model": config.model,
-        "stream": False,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": prompt},
-        ],
-    }
+    payload = build_ollama_chat_payload(
+        prompt,
+        system,
+        model=config.model,
+    )
     data = json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(
         url,

--- a/gismo/llm/prompts.py
+++ b/gismo/llm/prompts.py
@@ -34,6 +34,8 @@ def build_system_prompt() -> str:
         "command must be a GISMO operator command string (echo:, note:, or graph:), "
         "for example \"echo: hello\". "
         "Keep actions small and sequenced. "
+        "If the operator requests more than 12 items, produce ONE enqueue action "
+        "that describes the batch instead of listing each item. "
         "If the user request is unsafe or unsupported, return actions as an empty array "
         "and explain why in notes. "
         "Examples:\n"

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -152,7 +152,7 @@ class AskCliTest(unittest.TestCase):
                 with mock.patch.object(cli_main, "ollama_chat", return_value=response):
                     buffer = io.StringIO()
                     with contextlib.redirect_stderr(buffer):
-                        with self.assertRaises(ValueError):
+                        with self.assertRaises(SystemExit) as exc:
                             cli_main.run_ask(
                                 db_path,
                                 "bad",
@@ -165,12 +165,100 @@ class AskCliTest(unittest.TestCase):
                                 yes=False,
                                 explain=False,
                             )
-            self.assertIn("not json", buffer.getvalue())
+                        self.assertNotEqual(exc.exception.code, 0)
+            self.assertIn("LLM response was not valid JSON", buffer.getvalue())
 
             state_store = StateStore(db_path)
             events = state_store.list_events()
             self.assertTrue(events)
             self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
+    
+    def test_ask_best_effort_json_extraction_succeeds(self) -> None:
+        response = (
+            "Here is the plan:\n"
+            "```json\n"
+            "{\"intent\":\"queue\",\"assumptions\":[],\"actions\":["
+            "{\"type\":\"enqueue\",\"command\":\"echo: hello\","
+            "\"timeout_seconds\":30,\"retries\":0,\"why\":\"test\",\"risk\":\"low\"}"
+            "],\"notes\":[]}\n"
+            "```\n"
+            "Thanks."
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    cli_main.run_ask(
+                        db_path,
+                        "enqueue hello",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=10,
+                        yes=False,
+                        explain=False,
+                    )
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            plan = payload["plan"]
+            self.assertEqual(plan["intent"], "queue")
+            self.assertEqual(plan["actions"][0]["command"], "echo: hello")
+
+    def test_ask_best_effort_json_extraction_fails_on_comments(self) -> None:
+        response = (
+            "{"
+            "\"intent\": \"bad\","
+            "\"assumptions\": [],"
+            "\"actions\": [],"
+            "\"notes\": []"
+            "// trailing comment"
+            "}"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    buffer = io.StringIO()
+                    with contextlib.redirect_stderr(buffer):
+                        with self.assertRaises(SystemExit) as exc:
+                            cli_main.run_ask(
+                                db_path,
+                                "bad plan",
+                                model=None,
+                                host=None,
+                                timeout_s=None,
+                                enqueue=False,
+                                dry_run=True,
+                                max_actions=10,
+                                yes=False,
+                                explain=False,
+                            )
+                        self.assertNotEqual(exc.exception.code, 0)
+            self.assertIn("LLM response was not valid JSON", buffer.getvalue())
 
     def test_ask_env_defaults_used_for_model_and_timeout(self) -> None:
         response = json.dumps(
@@ -202,6 +290,36 @@ class AskCliTest(unittest.TestCase):
                     _, kwargs = ollama_mock.call_args
                     self.assertEqual(kwargs["model"], "custom-model")
                     self.assertEqual(kwargs["timeout_s"], 42)
+
+    def test_ask_env_defaults_used_for_llm_timeout(self) -> None:
+        response = json.dumps(
+            {"intent": "ping", "assumptions": [], "actions": [], "notes": []}
+        )
+        env = {
+            "GISMO_LLM_TIMEOUT_S": "33",
+            "GISMO_OLLAMA_TIMEOUT_S": "",
+            "GISMO_OLLAMA_URL": "http://127.0.0.1:11434",
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(os.environ, env, clear=False):
+                with mock.patch.object(
+                    cli_main, "ollama_chat", return_value=response
+                ) as ollama_mock:
+                    cli_main.run_ask(
+                        db_path,
+                        "ping",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=5,
+                        yes=False,
+                        explain=False,
+                    )
+                    _, kwargs = ollama_mock.call_args
+                    self.assertEqual(kwargs["timeout_s"], 33)
 
     def test_ask_timeout_override_beats_env(self) -> None:
         response = json.dumps(
@@ -425,6 +543,29 @@ class AskCliTest(unittest.TestCase):
         normalized = cli_main._normalize_llm_plan(plan, max_actions=5)
         self.assertEqual(normalized["assumptions"], [])
         self.assertEqual(normalized["actions"][0]["command"], "echo: hello")
+
+    def test_normalize_plan_flags_too_many_actions(self) -> None:
+        actions = [
+            {
+                "type": "enqueue",
+                "command": f"note: step {index}",
+                "timeout_seconds": 30,
+                "retries": 0,
+                "why": "test",
+                "risk": "low",
+            }
+            for index in range(13)
+        ]
+        plan = {
+            "intent": "enqueue notes",
+            "assumptions": [],
+            "actions": actions,
+            "notes": [],
+        }
+        normalized = cli_main._normalize_llm_plan(plan, max_actions=20)
+        self.assertTrue(
+            any("Too many actions (13)" in note for note in normalized["notes"])
+        )
 
     def test_ask_enqueue_requires_confirmation_interactive_decline(self) -> None:
         actions = [

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,0 +1,41 @@
+import json
+import unittest
+from unittest import mock
+
+from gismo.llm import ollama
+
+
+class DummyResponse:
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+class OllamaClientPayloadTest(unittest.TestCase):
+    def test_chat_payload_includes_json_format_and_keep_alive(self) -> None:
+        captured = {}
+
+        def fake_urlopen(request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return DummyResponse('{"message":{"content":"{}"}}')
+
+        with mock.patch.object(ollama.urllib.request, "urlopen", side_effect=fake_urlopen):
+            response = ollama.ollama_chat("ping", "return JSON")
+        self.assertEqual(response, "{}")
+        body = json.loads(captured["request"].data.decode("utf-8"))
+        self.assertEqual(body["format"], "json")
+        self.assertEqual(body["keep_alive"], ollama.DEFAULT_OLLAMA_KEEP_ALIVE)
+        self.assertEqual(body["options"]["temperature"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -1,0 +1,29 @@
+import json
+import os
+import unittest
+
+from gismo.llm.ollama import ollama_chat, resolve_ollama_config
+from gismo.llm.prompts import build_system_prompt, build_user_prompt
+
+
+@unittest.skipUnless(
+    os.getenv("GISMO_TEST_INTEGRATION_OLLAMA") == "1",
+    "Set GISMO_TEST_INTEGRATION_OLLAMA=1 to run Ollama integration tests.",
+)
+class OllamaIntegrationTest(unittest.TestCase):
+    def test_ollama_chat_round_trip(self) -> None:
+        config = resolve_ollama_config()
+        response = ollama_chat(
+            build_user_prompt("ping"),
+            build_system_prompt(),
+            model=config.model,
+            host=config.url,
+            timeout_s=config.timeout_s,
+        )
+        parsed = json.loads(response)
+        self.assertIsInstance(parsed, dict)
+        self.assertIn("intent", parsed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Make `gismo ask` robust to non-JSON or noisy model output and avoid tracebacks for typical failures. 
- Use Ollama JSON mode and set deterministic planning options to reduce creative drift and parsing problems. 
- Reduce Ollama reload latency between calls by using `keep_alive` so CPU laptops are less likely to hit timeouts. 
- Make tests hermetic so CI/local runs do not require a live Ollama server by default.

### Description
- Added `build_ollama_chat_payload` and updated `ollama_chat` to send `"format":"json"`, `keep_alive` (default `10m`), and `options.temperature=0`, and made timeout resolution respect `GISMO_LLM_TIMEOUT_S` as fallback.
- Hardened `run_ask` JSON parsing with `extract_json_object` (and `_strip_code_fences`) to attempt best-effort extraction of a balanced JSON object from noisy model text, and emit a clean user-facing error with model/endpoint/timeout guidance when parsing ultimately fails.
- Added an explicit plan note when more than 12 actions are returned: `Too many actions (N). Please ask for 12 or fewer, or request batching.` and added a batching hint to the planner system prompt to encourage producing a single enqueue for large batches.
- Made ask/Ollama tests hermetic: added `tests/test_ollama_client.py` (asserts payload contains `format`, `keep_alive`, and `temperature`) and a gated integration `tests/test_ollama_integration.py` skipped unless `GISMO_TEST_INTEGRATION_OLLAMA=1`; updated `tests/test_ask_cli.py` to cover extraction success/failure and the >12 action note.
- Updated `README.md`, `docs/OPERATOR.md`, and `Handoff.md` to document JSON mode, `keep_alive`, and `GISMO_LLM_TIMEOUT_S` / `GISMO_LLM_MODEL` guidance.

### Testing
- Ran full verification: `python scripts/verify.py` — passed (unit test suite succeeded and Ollama integration test was skipped by default).
- Unit tests covering `ask` updated and executed as part of `verify.py` and succeeded; new client payload test passed.
- Integration test is available but skipped unless enabled with `GISMO_TEST_INTEGRATION_OLLAMA=1` and can be run with `GISMO_TEST_INTEGRATION_OLLAMA=1 python -m unittest tests.test_ollama_integration`.
- To reproduce basic flows locally: run `gismo ask "ping" --dry-run --timeout-s 20` (with Ollama running) and `gismo ask "create 13 notes" --enqueue --timeout-s 60` to observe the too-many-actions note/confirmation behavior.

Risks / limitations: models that ignore Ollama JSON mode or return malformed JSON comments will still fail parsing (the extractor will not attempt to repair JSON comments), and operator guidance suggests increasing `--timeout-s` or switching models when needed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cb9e850083309bbbe5c4c9cc6a34)