### PR TITLE
Support curl transport for Ollama on Windows and harden JSON parsing

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -171,8 +171,8 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Ask now uses Ollama JSON mode with keep_alive and best-effort JSON extraction.
-- Plans with more than 12 actions are explicitly flagged in notes.
+- Ask now supports curl transport selection for Ollama (Windows defaults to curl when available).
+- Ollama JSON parsing hardens against fenced output and reports richer errors.
 - Ollama-related tests are hermetic by default with an optional integration gate.
 
 Next steps:

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Planner configuration:
   - GISMO_LLM_MODEL or GISMO_OLLAMA_MODEL (model name)
   - GISMO_LLM_TIMEOUT_S or GISMO_OLLAMA_TIMEOUT_S (LLM timeout)
   - GISMO_OLLAMA_URL or OLLAMA_HOST (Ollama endpoint)
+  - GISMO_OLLAMA_TRANSPORT=python|curl (Windows defaults to curl when available because urllib can be slow)
 - keep_alive defaults to 10m so models stay loaded for smoother repeated calls.
 
 -------------------------------------------------------------------------------

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -169,6 +169,7 @@ Planner configuration:
   - GISMO_LLM_MODEL or GISMO_OLLAMA_MODEL
   - GISMO_LLM_TIMEOUT_S or GISMO_OLLAMA_TIMEOUT_S
   - GISMO_OLLAMA_URL or OLLAMA_HOST
+  - GISMO_OLLAMA_TRANSPORT=python|curl (Windows defaults to curl when available because urllib can be slow)
 - keep_alive defaults to 10m so models remain loaded for repeated calls.
 
 Always prefer:

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -119,34 +119,11 @@ def extract_json_object(text: str) -> str | None:
     cleaned = _strip_code_fences(text).strip()
     if not cleaned:
         return None
-    for start, ch in enumerate(cleaned):
-        if ch in "{[":
-            open_ch = ch
-            close_ch = "}" if ch == "{" else "]"
-            depth = 0
-            in_string = False
-            escape = False
-            for index in range(start, len(cleaned)):
-                current = cleaned[index]
-                if in_string:
-                    if escape:
-                        escape = False
-                    elif current == "\\":
-                        escape = True
-                    elif current == '"':
-                        in_string = False
-                    continue
-                if current == '"':
-                    in_string = True
-                    continue
-                if current == open_ch:
-                    depth += 1
-                elif current == close_ch:
-                    depth -= 1
-                    if depth == 0:
-                        return cleaned[start : index + 1]
-            return None
-    return None
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    return cleaned[start : end + 1]
 
 
 def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
@@ -712,15 +689,14 @@ def run_ask(
                 message="LLM plan parsing failed.",
                 json_payload=payload,
             )
+            raw_preview = raw_response[:200]
             message = (
                 "LLM response was not valid JSON. "
-                f"model={config.model} endpoint={config.url} timeout={config.timeout_s}s. "
-                "Try --timeout-s 60+ and/or switch models."
+                f"model={config.model} timeout={config.timeout_s}s "
+                f"raw_response={raw_preview} "
+                "Model violated JSON-only contract; try another model or transport=curl"
             )
-            print(f"ERROR: {message}", file=sys.stderr)
-            if debug:
-                raise ValueError(message) from exc
-            raise SystemExit(1)
+            raise ValueError(message) from exc
 
     if not isinstance(parsed, dict):
         payload = {

--- a/gismo/llm/ollama.py
+++ b/gismo/llm/ollama.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import socket
+import subprocess
+import sys
+import tempfile
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -21,6 +25,7 @@ class OllamaConfig:
     url: str
     model: str
     timeout_s: int
+    transport: str
 
 
 class OllamaError(RuntimeError):
@@ -87,6 +92,7 @@ def resolve_ollama_config(
         url=resolve_ollama_url(url),
         model=resolve_ollama_model(model),
         timeout_s=resolve_ollama_timeout(timeout_s),
+        transport=resolve_ollama_transport(),
     )
 
 
@@ -111,6 +117,56 @@ def build_ollama_chat_payload(
     }
 
 
+def resolve_ollama_transport() -> str:
+    env_value = os.getenv("GISMO_OLLAMA_TRANSPORT")
+    if env_value:
+        normalized = env_value.strip().lower()
+        if normalized in {"python", "curl"}:
+            return normalized
+        return "python"
+    if _is_windows() and _curl_available_windows():
+        return "curl"
+    return "python"
+
+
+def _is_windows() -> bool:
+    return sys.platform.startswith("win")
+
+
+def _curl_available_windows() -> bool:
+    try:
+        result = subprocess.run(
+            ["where.exe", "curl"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
+def _resolve_curl_executable() -> str | None:
+    if _is_windows():
+        try:
+            result = subprocess.run(
+                ["where.exe", "curl"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=2,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip().splitlines()[0]
+    return shutil.which("curl")
+
+
 def ollama_chat(
     prompt: str,
     system: str,
@@ -126,7 +182,36 @@ def ollama_chat(
         system,
         model=config.model,
     )
-    data = json.dumps(payload).encode("utf-8")
+    payload_json = json.dumps(payload)
+    if config.transport == "curl":
+        curl_executable = _resolve_curl_executable()
+        if curl_executable:
+            try:
+                return _ollama_chat_via_curl(
+                    url,
+                    payload_json,
+                    timeout_s=config.timeout_s,
+                    config=config,
+                    curl_executable=curl_executable,
+                )
+            except OllamaError:
+                pass
+    return _ollama_chat_via_urllib(
+        url,
+        payload_json,
+        timeout_s=config.timeout_s,
+        config=config,
+    )
+
+
+def _ollama_chat_via_urllib(
+    url: str,
+    payload_json: str,
+    *,
+    timeout_s: int,
+    config: OllamaConfig,
+) -> str:
+    data = payload_json.encode("utf-8")
     request = urllib.request.Request(
         url,
         data=data,
@@ -134,26 +219,88 @@ def ollama_chat(
         method="POST",
     )
     try:
-        with urllib.request.urlopen(request, timeout=config.timeout_s) as response:
+        with urllib.request.urlopen(request, timeout=timeout_s) as response:
             body = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         detail = exc.read().decode("utf-8") if exc.fp else ""
         message = f"Ollama error {exc.code} from {config.url}. {detail}".strip()
         raise OllamaError(
             message,
-            timeout_s=config.timeout_s,
+            timeout_s=timeout_s,
             url=config.url,
             status_code=exc.code,
         ) from exc
     except (urllib.error.URLError, socket.timeout, TimeoutError) as exc:
         raise OllamaError(
             "Ollama request failed (timeout/connection) after "
-            f"{config.timeout_s}s. Verify `ollama ps` and that {config.url} is "
+            f"{timeout_s}s. Verify `ollama ps` and that {config.url} is "
             "reachable. Consider a smaller model or increase --timeout-s.",
-            timeout_s=config.timeout_s,
+            timeout_s=timeout_s,
             url=config.url,
         ) from exc
+    return _extract_message_content(body, timeout_s=timeout_s, config=config)
 
+
+def _ollama_chat_via_curl(
+    url: str,
+    payload_json: str,
+    *,
+    timeout_s: int,
+    config: OllamaConfig,
+    curl_executable: str,
+) -> str:
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            delete=False,
+        ) as temp_file:
+            temp_file.write(payload_json)
+            temp_path = temp_file.name
+        command = [
+            curl_executable,
+            "-sS",
+            url,
+            "-H",
+            "Content-Type: application/json",
+            "--data-binary",
+            f"@{temp_path}",
+        ]
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_s,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise OllamaError(
+            f"curl failed after {timeout_s}s.",
+            timeout_s=timeout_s,
+            url=config.url,
+        ) from exc
+    finally:
+        if temp_path:
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        message = (
+            f"curl failed with exit code {result.returncode} "
+            f"after {timeout_s}s. {stderr}"
+        ).strip()
+        raise OllamaError(
+            message,
+            timeout_s=timeout_s,
+            url=config.url,
+        )
+    return _extract_message_content(result.stdout, timeout_s=timeout_s, config=config)
+
+
+def _extract_message_content(body: str, *, timeout_s: int, config: OllamaConfig) -> str:
     try:
         payload_json: dict[str, Any] = json.loads(body)
         message = payload_json.get("message") or {}
@@ -161,13 +308,13 @@ def ollama_chat(
     except (json.JSONDecodeError, TypeError) as exc:
         raise OllamaError(
             "Invalid JSON response from Ollama.",
-            timeout_s=config.timeout_s,
+            timeout_s=timeout_s,
             url=config.url,
         ) from exc
     if not isinstance(content, str):
         raise OllamaError(
             "Ollama response missing assistant content.",
-            timeout_s=config.timeout_s,
+            timeout_s=timeout_s,
             url=config.url,
         )
     return content

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -150,23 +150,21 @@ class AskCliTest(unittest.TestCase):
                 clear=False,
             ):
                 with mock.patch.object(cli_main, "ollama_chat", return_value=response):
-                    buffer = io.StringIO()
-                    with contextlib.redirect_stderr(buffer):
-                        with self.assertRaises(SystemExit) as exc:
-                            cli_main.run_ask(
-                                db_path,
-                                "bad",
-                                model=None,
-                                host=None,
-                                timeout_s=None,
-                                enqueue=False,
-                                dry_run=True,
-                                max_actions=10,
-                                yes=False,
-                                explain=False,
-                            )
-                        self.assertNotEqual(exc.exception.code, 0)
-            self.assertIn("LLM response was not valid JSON", buffer.getvalue())
+                    with self.assertRaises(ValueError) as exc:
+                        cli_main.run_ask(
+                            db_path,
+                            "bad",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=False,
+                            dry_run=True,
+                            max_actions=10,
+                            yes=False,
+                            explain=False,
+                        )
+            self.assertIn("LLM response was not valid JSON", str(exc.exception))
+            self.assertIn("Model violated JSON-only contract", str(exc.exception))
 
             state_store = StateStore(db_path)
             events = state_store.list_events()
@@ -242,23 +240,21 @@ class AskCliTest(unittest.TestCase):
                 clear=False,
             ):
                 with mock.patch.object(cli_main, "ollama_chat", return_value=response):
-                    buffer = io.StringIO()
-                    with contextlib.redirect_stderr(buffer):
-                        with self.assertRaises(SystemExit) as exc:
-                            cli_main.run_ask(
-                                db_path,
-                                "bad plan",
-                                model=None,
-                                host=None,
-                                timeout_s=None,
-                                enqueue=False,
-                                dry_run=True,
-                                max_actions=10,
-                                yes=False,
-                                explain=False,
-                            )
-                        self.assertNotEqual(exc.exception.code, 0)
-            self.assertIn("LLM response was not valid JSON", buffer.getvalue())
+                    with self.assertRaises(ValueError) as exc:
+                        cli_main.run_ask(
+                            db_path,
+                            "bad plan",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=False,
+                            dry_run=True,
+                            max_actions=10,
+                            yes=False,
+                            explain=False,
+                        )
+            self.assertIn("LLM response was not valid JSON", str(exc.exception))
+            self.assertIn("Model violated JSON-only contract", str(exc.exception))
 
     def test_ask_env_defaults_used_for_model_and_timeout(self) -> None:
         response = json.dumps(

--- a/tests/test_ollama_client.py
+++ b/tests/test_ollama_client.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import unittest
 from unittest import mock
 
@@ -35,6 +36,52 @@ class OllamaClientPayloadTest(unittest.TestCase):
         self.assertEqual(body["format"], "json")
         self.assertEqual(body["keep_alive"], ollama.DEFAULT_OLLAMA_KEEP_ALIVE)
         self.assertEqual(body["options"]["temperature"], 0)
+
+
+class OllamaCurlTransportTest(unittest.TestCase):
+    def test_curl_transport_writes_payload_and_invokes_curl(self) -> None:
+        captured = {}
+        payload = ollama.build_ollama_chat_payload(
+            "ping",
+            "return JSON",
+            model="phi3:mini",
+        )
+        payload_json = json.dumps(payload)
+        config = ollama.OllamaConfig(
+            url="http://127.0.0.1:11434",
+            model="phi3:mini",
+            timeout_s=5,
+            transport="curl",
+        )
+
+        def fake_run(command, capture_output, text, check, timeout):
+            captured["command"] = command
+            captured["timeout"] = timeout
+            data_arg = command[-1]
+            self.assertTrue(data_arg.startswith("@"))
+            with open(data_arg[1:], encoding="utf-8") as handle:
+                body = json.load(handle)
+            self.assertEqual(body["format"], "json")
+            self.assertEqual(body["options"]["temperature"], 0)
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout='{"message":{"content":"{}"}}',
+                stderr="",
+            )
+
+        with mock.patch.object(ollama.subprocess, "run", side_effect=fake_run):
+            response = ollama._ollama_chat_via_curl(
+                "http://127.0.0.1:11434/api/chat",
+                payload_json,
+                timeout_s=config.timeout_s,
+                config=config,
+                curl_executable="curl.exe",
+            )
+        self.assertEqual(response, "{}")
+        self.assertIn("curl.exe", captured["command"][0])
+        self.assertIn("--data-binary", captured["command"])
+        self.assertEqual(captured["timeout"], 5)
 
 
 if __name__ == "__main__":

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -7,8 +7,8 @@ from gismo.llm.prompts import build_system_prompt, build_user_prompt
 
 
 @unittest.skipUnless(
-    os.getenv("GISMO_TEST_INTEGRATION_OLLAMA") == "1",
-    "Set GISMO_TEST_INTEGRATION_OLLAMA=1 to run Ollama integration tests.",
+    os.getenv("GISMO_TEST_OLLAMA") == "1",
+    "Set GISMO_TEST_OLLAMA=1 to run Ollama integration tests.",
 )
 class OllamaIntegrationTest(unittest.TestCase):
     def test_ollama_chat_round_trip(self) -> None:


### PR DESCRIPTION
### Motivation
- Windows `urllib` POSTs to a local Ollama endpoint can be slow, while `curl` is significantly faster and more reliable for small payloads.  
- Some models return fenced or wrapped text (e.g. ```json``` blocks) which caused brittle JSON parsing.  
- Make planner behavior deterministic and operator-friendly by adding a fast transport and clearer/parsing errors.  
- Preserve backwards compatibility by falling back to the Python transport when `curl` is not available.

### Description
- Add `GISMO_OLLAMA_TRANSPORT` with values `python|curl` and auto-select `curl` on Windows when available (uses `where.exe curl`); selection surfaced in `OllamaConfig` via `resolve_ollama_transport`.  
- Implement a `curl` transport that writes the request JSON to a UTF-8 temp file and invokes `curl.exe -sS <url> -H "Content-Type: application/json" --data-binary "@<file>"` with `subprocess.run(..., timeout=...)`, and fall back to the existing `urllib` path if `curl` is unavailable or fails.  
- Ensure payload requests use `format: "json"`, `temperature=0`, and `keep_alive` in `build_ollama_chat_payload`.  
- Harden `ask` parsing in `gismo/cli/main.py` by first attempting `json.loads(raw_response)`, then extracting a JSON substring (first `{` .. last `}`) if needed, and on final failure raise a `ValueError` that includes the effective timeout, model name, a 200-char preview of the raw response, and the hint `Model violated JSON-only contract; try another model or transport=curl`.
- Add hermetic unit tests for the curl transport (mocking `subprocess.run`) and keep Ollama integration test gated by the env `GISMO_TEST_OLLAMA=1`; update tests to expect the new error behavior.  
- Update `README.md`, `docs/OPERATOR.md`, and `Handoff.md` to document `GISMO_OLLAMA_TRANSPORT` and the Windows default rationale.

### Testing
- Ran the repository verification suite with `python scripts/verify.py`, which completed successfully (`OK`, integration Ollama test skipped by default).  
- Added unit test `OllamaCurlTransportTest.test_curl_transport_writes_payload_and_invokes_curl` which was run as part of the verification and passed.  
- Existing `ask` CLI unit tests were updated to reflect the new JSON parsing behavior and all CLI-related tests passed under `verify.py`.  
- The optional integration test remains gated by `GISMO_TEST_OLLAMA=1` and was skipped during CI by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d30d08e88330abe00ff8921da652)