### PR TITLE
Clarify ask CLI warning for plans with too many actions

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -174,6 +174,7 @@ Status:
 - Ollama payload unit test now isolates outgoing payload assertions with a stubbed response.
 - Ollama JSON parsing hardens against fenced output and reports richer errors.
 - Ollama-related tests are hermetic by default with an optional integration gate.
+- Ask CLI too-many-actions warning now clarifies confirmation-required behavior.
 
 Next steps:
 - Make planner prompts policy-aware (still pending).

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -208,7 +208,8 @@ def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
     if original_action_count > 12:
         notes.append(
             "Too many actions "
-            f"({original_action_count}). Please ask for 12 or fewer, or request batching."
+            f"({original_action_count}). This plan is high risk and requires confirmation to "
+            "enqueue; consider batching into 12 or fewer steps."
         )
     if original_action_count > max_actions:
         notes.append(


### PR DESCRIPTION
### Motivation
- The ask plan note previously read like a hard refusal even though confirmation or `--yes` allows enqueueing. 
- Update messaging so operators understand that plans with many steps are high-risk warnings that require explicit confirmation. 
- Preserve existing gating semantics (confirmation required) while removing misleading wording. 

### Description
- Adjusted the too-many-actions note in `_normalize_llm_plan` in `gismo/cli/main.py` to say: "Too many actions (N). This plan is high risk and requires confirmation to enqueue; consider batching into 12 or fewer steps.". 
- Recorded the change in `Handoff.md` under recent status to reflect the messaging clarification. 
- No changes were made to enqueue gating or confirmation logic, and no refactors were performed. 

### Testing
- Ran the full verification suite with `python scripts/verify.py`, which completed successfully. 
- The existing unit tests that assert the presence of the prefix `"Too many actions (N)"` continue to pass without modification. 
- Automated test run: `python scripts/verify.py` (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba3032bd48330a6bcb8a8848dbec5)