### PR TITLE
Make `--db` flag position-agnostic for queue and other subcommands

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -175,11 +175,13 @@ Status:
 - Ollama JSON parsing hardens against fenced output and reports richer errors.
 - Ollama-related tests are hermetic by default with an optional integration gate.
 - Ask CLI too-many-actions warning now clarifies confirmation-required behavior.
+- CLI `--db` flag now respects both pre- and post-subcommand placement for queue and other commands.
 
 Next steps:
 - Make planner prompts policy-aware (still pending).
 - Monitor operator feedback on ask timeout UX.
 - Confirm Windows operator docs emphasize the console entrypoint when installed.
+- Watch for any remaining CLI flag ordering regressions as new subcommands land.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Fallback (no console script available):
 STATE & DEFAULT PATHS
 
 - Default DB path: .gismo/state.db
+- The `--db` flag can appear before or after the subcommand (e.g., `gismo --db PATH queue stats` or `gismo queue stats --db PATH`).
 - Exports are DB-anchored:
   By default, exports are written to an `exports/` directory located next to the DB file.
   Example:

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -2024,7 +2024,7 @@ def build_parser() -> argparse.ArgumentParser:
     queue_parser = subparsers.add_parser(
         "queue",
         help="Inspect the queue (stats, list, show)",
-        parents=[db_parent],
+        parents=[db_parent_optional],
     )
     queue_subparsers = queue_parser.add_subparsers(dest="queue_command", required=True)
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -98,6 +98,28 @@ class CliMainParserTest(unittest.TestCase):
         serve_args = parser.parse_args(["ipc", "serve", "--db", db_path])
         self.assertEqual(serve_args.db_path, db_path)
 
+    def test_db_path_before_and_after_subcommand(self) -> None:
+        parser = cli_main.build_parser()
+        db_path = "custom.db"
+
+        queue_before = parser.parse_args(["--db", db_path, "queue", "stats"])
+        self.assertEqual(queue_before.db_path, db_path)
+
+        queue_after = parser.parse_args(["queue", "stats", "--db", db_path])
+        self.assertEqual(queue_after.db_path, db_path)
+
+        run_before = parser.parse_args(["--db", db_path, "run", "echo:", "hi"])
+        self.assertEqual(run_before.db_path, db_path)
+
+        run_after = parser.parse_args(["run", "--db", db_path, "echo:", "hi"])
+        self.assertEqual(run_after.db_path, db_path)
+
+        export_before = parser.parse_args(["--db", db_path, "export", "--latest"])
+        self.assertEqual(export_before.db_path, db_path)
+
+        export_after = parser.parse_args(["export", "--latest", "--db", db_path])
+        self.assertEqual(export_after.db_path, db_path)
+
     def test_supervise_subcommand_routes_to_supervise(self) -> None:
         parser = cli_main.build_parser()
         args = parser.parse_args(["supervise", "status", "--token", "token"])


### PR DESCRIPTION
### Motivation
- The top-level `--db` value could be overridden by the queue subparser default, causing inconsistent behavior when the flag was placed before the subcommand.
- The CLI must treat `--db` consistently whether specified before or after any subcommand to preserve deterministic invocation semantics.
- This change keeps CLI routing and help output unchanged while correcting only argparse parent wiring.

### Description
- Changed the `queue` subparser to use the optional DB parent (`db_parent_optional`) so a top-level `--db` is preserved when specified before `queue`.
- Added parser unit tests (`test_db_path_before_and_after_subcommand`) covering `queue`, `run`, and `export` to lock the behavior for both pre- and post-subcommand placement.
- Updated `README.md` to document that `--db` can appear before or after subcommands and updated `Handoff.md` status notes.

### Testing
- Run the full verification suite with `python scripts/verify.py`, which completed successfully (all tests passed, 111 tests ran with 1 skipped in the parse run shown).
- Parser-level checks can be exercised manually with: `gismo --db PATH queue stats` and `gismo queue stats --db PATH` and equivalent forms for `run` and `export` to confirm `args.db_path` is preserved.
- Automated parser tests added/modified: `tests/test_cli_main.py` (new assertions for before/after placement), and the rest of the test suite was exercised by `python scripts/verify.py` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba617561c8330b938fb7a056ccd29)