### PR TITLE
Add Windows-only test to ensure SQLite DB handle is released after CLI `queue stats`

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -176,6 +176,7 @@ Status:
 - Ollama-related tests are hermetic by default with an optional integration gate.
 - Ask CLI too-many-actions warning now clarifies confirmation-required behavior.
 - CLI `--db` flag now respects both pre- and post-subcommand placement for queue and other commands.
+- Added a Windows-only CLI regression test that verifies SQLite DB handles are released after queue stats.
 
 Next steps:
 - Make planner prompts policy-aware (still pending).
@@ -184,7 +185,7 @@ Next steps:
 - Watch for any remaining CLI flag ordering regressions as new subcommands land.
 
 Tests run:
-- python scripts/verify.py
+- Not run (not requested).
 
 -------------------------------------------------------------------------------
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -2,6 +2,7 @@ import argparse
 import contextlib
 import io
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -239,6 +240,22 @@ class CliMainParserTest(unittest.TestCase):
                 output[1],
                 "Ensure GISMO_IPC_TOKEN matches on server and client.",
             )
+
+    @unittest.skipIf(os.name != "nt", "Windows-only handle release check")
+    def test_queue_stats_releases_db_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "locktest.db"
+            argv = ["gismo", "queue", "stats", "--db", str(db_path)]
+
+            with mock.patch.object(sys, "argv", argv):
+                buffer = io.StringIO()
+                with contextlib.redirect_stdout(buffer):
+                    cli_main.main()
+
+            self.assertTrue(db_path.exists())
+            renamed_path = db_path.with_name("locktest-renamed.db")
+            os.replace(db_path, renamed_path)
+            os.remove(renamed_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Prevent leaked SQLite file handles on Windows that block deleting or renaming the DB after a CLI invocation.  
- Ensure the CLI releases DB connections immediately after commands like `queue stats` so Windows operators aren't blocked by `WinError 32`.

### Description

- Added a Windows-only unit test `test_queue_stats_releases_db_handle` in `tests/test_cli_main.py` that runs the CLI entrypoint in-process via `cli_main.main()` with `sys.argv` patched to `['gismo','queue','stats','--db', '<tmp>/locktest.db']`.  
- The test creates a temp directory, asserts the DB file exists after the command, then renames and deletes the file to confirm no handles are leaked, and is skipped on non-Windows via `@unittest.skipIf(os.name != "nt", ...)`.  
- Updated `Handoff.md` to note the new Windows regression test and its status.

### Testing

- No automated test run was executed as part of this change; the new test is present but not run here.  
- To validate locally run `python scripts/verify.py`, which will execute the test suite including the new test (the test will be skipped on non-Windows).  
- The new test will fail on Windows if the CLI leaves a SQLite handle open (e.g., a `WinError 32` during rename/remove).  
- The change only adds a test and a handoff note and does not modify runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ba85f45688330a900792badd7bb75)