### PR TITLE
Implement memory primitives (SQLite + CLI + tests) per MEMORY_CONTRACT v0.1

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -172,15 +172,14 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added leashed `agent` CLI for goal-based plan → enqueue → execute cycles (queue/daemon only).
-- Agent cycles honor confirmation gates for high-risk and shell/write actions.
-- Updated docs with agent usage examples.
+- Added SQLite-backed memory primitives with CLI support (put/get/search/delete) and audit events.
+- Memory operations are deterministic, tombstone-aware, and include end-to-end CLI tests.
+- Updated CLI documentation with memory command examples.
 
 Next steps:
-- Make planner prompts policy-aware (still pending).
-- Monitor operator feedback on ask timeout UX.
-- Confirm Windows operator docs emphasize the console entrypoint when installed.
-- Watch for any remaining CLI flag ordering regressions as new subcommands land.
+- Wire policy-aware confirmation gates for persistent memory namespaces.
+- Consider adding memory read/write hooks to the planner once policy enforcement is defined.
+- Monitor Windows locking regressions for memory CLI interactions.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Export audit logs:
   gismo export --run RUN_ID
   gismo export RUN_ID
 
+Memory primitives (SQLite-backed):
+
+  gismo memory put --namespace global --key default_model --kind preference \\
+    --value '\"phi3:mini\"' --confidence high --source operator --tag llm
+  gismo memory get --namespace global default_model
+  gismo memory search \"phi3\" --namespace global --kind preference
+  gismo memory delete --namespace global default_model
+
 Windows examples (explicit module invocation):
 
   python -m gismo.cli.main --db .\tmp\dev.db runs list

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -38,6 +38,14 @@ from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFil
 from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
 from gismo.llm.ollama import OllamaError, ollama_chat, resolve_ollama_config
 from gismo.llm.prompts import build_system_prompt, build_user_prompt
+from gismo.memory.store import (
+    MemoryItem,
+    get_item as memory_get_item,
+    policy_hash_for_path,
+    put_item as memory_put_item,
+    search_items as memory_search_items,
+    tombstone_item as memory_tombstone_item,
+)
 
 
 def _fmt_dt(dt) -> str:
@@ -58,6 +66,43 @@ def _summarize_value(value: object, max_len: int) -> str:
     else:
         text = json.dumps(value, ensure_ascii=False, sort_keys=True)
     return _truncate(text, max_len)
+
+
+def _serialize_memory_item(item: MemoryItem) -> dict[str, object]:
+    return {
+        "id": item.id,
+        "namespace": item.namespace,
+        "key": item.key,
+        "kind": item.kind,
+        "value": item.value,
+        "tags": item.tags,
+        "confidence": item.confidence,
+        "source": item.source,
+        "ttl_seconds": item.ttl_seconds,
+        "is_tombstoned": item.is_tombstoned,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+    }
+
+
+def _print_memory_item_summary(item: MemoryItem) -> None:
+    print(f"Namespace:  {item.namespace}")
+    print(f"Key:        {item.key}")
+    print(f"Kind:       {item.kind}")
+    print(f"Updated:    {item.updated_at}")
+    if item.is_tombstoned:
+        print("Status:     tombstoned")
+
+
+def _print_memory_search_results(items: list[MemoryItem]) -> None:
+    if not items:
+        print("(no matches)")
+        return
+    for item in items:
+        print(
+            f"- {item.namespace}/{item.key} kind={item.kind} "
+            f"updated={item.updated_at} tombstoned={item.is_tombstoned}"
+        )
 
 
 def _coerce_str_list(value: object) -> list[str]:
@@ -762,6 +807,117 @@ def run_list(db_path: str, limit: int, newest_first: bool) -> None:
         )
 
 
+def _memory_policy_hash(policy_path: str | None) -> str:
+    try:
+        return policy_hash_for_path(policy_path)
+    except FileNotFoundError as exc:
+        print(f"Policy file not found: {policy_path}")
+        raise SystemExit(2) from exc
+
+
+def _parse_memory_value(value_text: str | None, value_json: str | None) -> object:
+    if value_text and value_json:
+        print("Provide either --value or --value-text, not both.")
+        raise SystemExit(2)
+    if value_text is not None:
+        return value_text
+    if value_json is None:
+        print("Provide --value or --value-text for memory put.")
+        raise SystemExit(2)
+    try:
+        return json.loads(value_json)
+    except json.JSONDecodeError as exc:
+        print(f"Invalid JSON for --value: {exc}")
+        raise SystemExit(2) from exc
+
+
+def run_memory_put(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy_hash = _memory_policy_hash(args.policy)
+    value = _parse_memory_value(args.value_text, args.value)
+    tags = args.tag or []
+    item = memory_put_item(
+        args.db_path,
+        namespace=args.namespace,
+        key=args.key,
+        kind=args.kind,
+        value=value,
+        tags=tags,
+        confidence=args.confidence,
+        source=args.source,
+        ttl_seconds=args.ttl_seconds,
+        actor=actor,
+        policy_hash=policy_hash,
+    )
+    print(f"DB: {args.db_path}")
+    print("Stored memory item:")
+    _print_memory_item_summary(item)
+
+
+def run_memory_get(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy_hash = _memory_policy_hash(args.policy)
+    item = memory_get_item(
+        args.db_path,
+        args.namespace,
+        args.key,
+        include_tombstoned=args.include_tombstoned,
+        actor=actor,
+        policy_hash=policy_hash,
+    )
+    if item is None:
+        print(f"Memory item not found: {args.namespace}/{args.key}")
+        raise SystemExit(2)
+    if args.json:
+        print(json.dumps(_serialize_memory_item(item), ensure_ascii=False, sort_keys=True))
+        return
+    print(f"DB: {args.db_path}")
+    _print_memory_item_summary(item)
+
+
+def run_memory_search(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy_hash = _memory_policy_hash(args.policy)
+    items = memory_search_items(
+        args.db_path,
+        args.query or "",
+        namespace=args.namespace,
+        kind=args.kind,
+        tag=args.tag,
+        source=args.source,
+        confidence_min=args.confidence_min,
+        include_tombstoned=args.include_tombstoned,
+        limit=args.limit,
+        actor=actor,
+        policy_hash=policy_hash,
+    )
+    if args.json:
+        payload = [_serialize_memory_item(item) for item in items]
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return
+    print(f"DB: {args.db_path}")
+    print(f"Matches: {len(items)}")
+    _print_memory_search_results(items)
+
+
+def run_memory_delete(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy_hash = _memory_policy_hash(args.policy)
+    item = memory_tombstone_item(
+        args.db_path,
+        args.namespace,
+        args.key,
+        actor=actor,
+        policy_hash=policy_hash,
+    )
+    if item is None:
+        print(f"Memory item not found: {args.namespace}/{args.key}")
+        raise SystemExit(2)
+    print(f"DB: {args.db_path}")
+    print("Tombstoned memory item:")
+    _print_memory_item_summary(item)
+
+
 def run_export(
     db_path: str,
     *,
@@ -1397,6 +1553,22 @@ def _handle_runs_list(args: argparse.Namespace) -> None:
 
 def _handle_runs_show(args: argparse.Namespace) -> None:
     run_show(args.db_path, args.run_id)
+
+
+def _handle_memory_put(args: argparse.Namespace) -> None:
+    run_memory_put(args)
+
+
+def _handle_memory_get(args: argparse.Namespace) -> None:
+    run_memory_get(args)
+
+
+def _handle_memory_search(args: argparse.Namespace) -> None:
+    run_memory_search(args)
+
+
+def _handle_memory_delete(args: argparse.Namespace) -> None:
+    run_memory_delete(args)
 
 
 def _handle_export(args: argparse.Namespace) -> None:
@@ -2175,6 +2347,180 @@ def build_parser() -> argparse.ArgumentParser:
         help="Redact file contents, shell output, and large tool outputs",
     )
     export_parser.set_defaults(handler=_handle_export)
+
+    memory_parser = subparsers.add_parser(
+        "memory",
+        help="Manage persistent memory items",
+        parents=[db_parent_optional],
+    )
+    memory_subparsers = memory_parser.add_subparsers(dest="memory_command", required=True)
+
+    memory_put_parser = memory_subparsers.add_parser(
+        "put",
+        help="Create or update a memory item",
+        parents=[db_parent_optional],
+    )
+    memory_put_parser.add_argument(
+        "--namespace",
+        required=True,
+        help="Memory namespace (e.g., global, project:<name>, run:<id>)",
+    )
+    memory_put_parser.add_argument(
+        "--key",
+        required=True,
+        help="Memory key",
+    )
+    memory_put_parser.add_argument(
+        "--kind",
+        required=True,
+        choices=["fact", "preference", "constraint", "procedure", "note", "summary"],
+        help="Memory kind",
+    )
+    memory_put_parser.add_argument(
+        "--value",
+        help="JSON value to store",
+    )
+    memory_put_parser.add_argument(
+        "--value-text",
+        dest="value_text",
+        help="Shortcut for string values (stored as JSON string)",
+    )
+    memory_put_parser.add_argument(
+        "--confidence",
+        required=True,
+        choices=["high", "medium", "low"],
+        help="Confidence level",
+    )
+    memory_put_parser.add_argument(
+        "--source",
+        required=True,
+        choices=["operator", "system", "llm"],
+        help="Source actor",
+    )
+    memory_put_parser.add_argument(
+        "--tag",
+        action="append",
+        default=[],
+        help="Tag (repeatable)",
+    )
+    memory_put_parser.add_argument(
+        "--ttl-seconds",
+        type=int,
+        default=None,
+        help="Optional TTL in seconds",
+    )
+    memory_put_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_put_parser.set_defaults(handler=_handle_memory_put)
+
+    memory_get_parser = memory_subparsers.add_parser(
+        "get",
+        help="Fetch a memory item by namespace/key",
+        parents=[db_parent_optional],
+    )
+    memory_get_parser.add_argument(
+        "--namespace",
+        required=True,
+        help="Memory namespace",
+    )
+    memory_get_parser.add_argument("key", help="Memory key")
+    memory_get_parser.add_argument(
+        "--include-tombstoned",
+        action="store_true",
+        help="Include tombstoned items",
+    )
+    memory_get_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON",
+    )
+    memory_get_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_get_parser.set_defaults(handler=_handle_memory_get)
+
+    memory_search_parser = memory_subparsers.add_parser(
+        "search",
+        help="Search memory items",
+        parents=[db_parent_optional],
+    )
+    memory_search_parser.add_argument(
+        "query",
+        nargs="?",
+        default="",
+        help="Search query (matches key/value)",
+    )
+    memory_search_parser.add_argument(
+        "--namespace",
+        default=None,
+        help="Filter by namespace",
+    )
+    memory_search_parser.add_argument(
+        "--kind",
+        choices=["fact", "preference", "constraint", "procedure", "note", "summary"],
+        help="Filter by kind",
+    )
+    memory_search_parser.add_argument(
+        "--tag",
+        default=None,
+        help="Filter by tag",
+    )
+    memory_search_parser.add_argument(
+        "--source",
+        choices=["operator", "system", "llm"],
+        help="Filter by source",
+    )
+    memory_search_parser.add_argument(
+        "--confidence-min",
+        dest="confidence_min",
+        choices=["high", "medium", "low"],
+        help="Minimum confidence filter",
+    )
+    memory_search_parser.add_argument(
+        "--include-tombstoned",
+        action="store_true",
+        help="Include tombstoned items",
+    )
+    memory_search_parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of results",
+    )
+    memory_search_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON",
+    )
+    memory_search_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_search_parser.set_defaults(handler=_handle_memory_search)
+
+    memory_delete_parser = memory_subparsers.add_parser(
+        "delete",
+        help="Tombstone a memory item",
+        parents=[db_parent_optional],
+    )
+    memory_delete_parser.add_argument(
+        "--namespace",
+        required=True,
+        help="Memory namespace",
+    )
+    memory_delete_parser.add_argument("key", help="Memory key")
+    memory_delete_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_delete_parser.set_defaults(handler=_handle_memory_delete)
 
     enqueue_parser = subparsers.add_parser(
         "enqueue",

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -160,6 +160,87 @@ class StateStore:
                 )
                 """
             )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memory_items (
+                    id TEXT PRIMARY KEY,
+                    namespace TEXT NOT NULL,
+                    key TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    value_json TEXT NOT NULL,
+                    tags_json TEXT NULL,
+                    confidence TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    ttl_seconds INTEGER NULL,
+                    is_tombstoned INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memory_events (
+                    id TEXT PRIMARY KEY,
+                    timestamp TEXT NOT NULL,
+                    operation TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    policy_hash TEXT NOT NULL,
+                    request_json TEXT NOT NULL,
+                    result_meta_json TEXT NOT NULL,
+                    related_run_id TEXT NULL,
+                    related_ask_event_id TEXT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_namespace_key
+                ON memory_items (namespace, key)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_items_namespace
+                ON memory_items (namespace)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_items_kind
+                ON memory_items (kind)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_items_tombstoned
+                ON memory_items (is_tombstoned)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_timestamp
+                ON memory_events (timestamp)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_operation
+                ON memory_events (operation)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_actor
+                ON memory_events (actor)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_related_run
+                ON memory_events (related_run_id)
+                """
+            )
             self._ensure_columns(connection)
             cursor.execute(
                 """

--- a/gismo/memory/__init__.py
+++ b/gismo/memory/__init__.py
@@ -1,0 +1,23 @@
+"""Memory subsystem for GISMO."""
+
+from gismo.memory.store import (
+    MemoryItem,
+    MemoryStore,
+    append_event,
+    get_item,
+    policy_hash_for_path,
+    put_item,
+    search_items,
+    tombstone_item,
+)
+
+__all__ = [
+    "MemoryItem",
+    "MemoryStore",
+    "append_event",
+    "get_item",
+    "policy_hash_for_path",
+    "put_item",
+    "search_items",
+    "tombstone_item",
+]

--- a/gismo/memory/store.py
+++ b/gismo/memory/store.py
@@ -1,0 +1,653 @@
+"""SQLite-backed memory storage primitives."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+from uuid import uuid4
+
+MAX_EVENT_STRING_LEN = 1000
+
+
+@dataclass(frozen=True)
+class MemoryItem:
+    id: str
+    namespace: str
+    key: str
+    kind: str
+    value: Any
+    tags: list[str]
+    confidence: str
+    source: str
+    ttl_seconds: Optional[int]
+    is_tombstoned: bool
+    created_at: str
+    updated_at: str
+
+
+class MemoryStore:
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.db_path)
+        connection.row_factory = sqlite3.Row
+        self._apply_pragmas(connection)
+        return connection
+
+    def _apply_pragmas(self, connection: sqlite3.Connection) -> None:
+        try:
+            connection.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.Error:
+            pass
+        try:
+            connection.execute("PRAGMA busy_timeout = 5000")
+        except sqlite3.Error:
+            pass
+
+    @contextmanager
+    def _connection(self) -> Iterable[sqlite3.Connection]:
+        connection = self._connect()
+        try:
+            yield connection
+        finally:
+            connection.close()
+
+    def _init_db(self) -> None:
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memory_items (
+                    id TEXT PRIMARY KEY,
+                    namespace TEXT NOT NULL,
+                    key TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    value_json TEXT NOT NULL,
+                    tags_json TEXT NULL,
+                    confidence TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    ttl_seconds INTEGER NULL,
+                    is_tombstoned INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS memory_events (
+                    id TEXT PRIMARY KEY,
+                    timestamp TEXT NOT NULL,
+                    operation TEXT NOT NULL,
+                    actor TEXT NOT NULL,
+                    policy_hash TEXT NOT NULL,
+                    request_json TEXT NOT NULL,
+                    result_meta_json TEXT NOT NULL,
+                    related_run_id TEXT NULL,
+                    related_ask_event_id TEXT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_memory_items_namespace_key
+                ON memory_items (namespace, key)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_items_namespace
+                ON memory_items (namespace)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_items_kind
+                ON memory_items (kind)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_items_tombstoned
+                ON memory_items (is_tombstoned)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_timestamp
+                ON memory_events (timestamp)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_operation
+                ON memory_events (operation)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_actor
+                ON memory_events (actor)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_memory_events_related_run
+                ON memory_events (related_run_id)
+                """
+            )
+            connection.commit()
+
+    def put_item(
+        self,
+        *,
+        namespace: str,
+        key: str,
+        kind: str,
+        value: Any,
+        tags: Optional[list[str]],
+        confidence: str,
+        source: str,
+        ttl_seconds: Optional[int],
+        actor: str,
+        policy_hash: str,
+        related_run_id: Optional[str] = None,
+        related_ask_event_id: Optional[str] = None,
+    ) -> MemoryItem:
+        created_at = _utc_now().isoformat()
+        updated_at = created_at
+        value_json = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        tags_json = json.dumps(tags, ensure_ascii=False, sort_keys=True) if tags else None
+        new_id = str(uuid4())
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                INSERT INTO memory_items (
+                    id,
+                    namespace,
+                    key,
+                    kind,
+                    value_json,
+                    tags_json,
+                    confidence,
+                    source,
+                    ttl_seconds,
+                    is_tombstoned,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+                ON CONFLICT(namespace, key)
+                DO UPDATE SET
+                    kind = excluded.kind,
+                    value_json = excluded.value_json,
+                    tags_json = excluded.tags_json,
+                    confidence = excluded.confidence,
+                    source = excluded.source,
+                    ttl_seconds = excluded.ttl_seconds,
+                    is_tombstoned = 0,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    new_id,
+                    namespace,
+                    key,
+                    kind,
+                    value_json,
+                    tags_json,
+                    confidence,
+                    source,
+                    ttl_seconds,
+                    created_at,
+                    updated_at,
+                ),
+            )
+            connection.commit()
+            item = self._fetch_item(
+                connection,
+                namespace=namespace,
+                key=key,
+                include_tombstoned=True,
+            )
+            if item is None:
+                raise RuntimeError("Failed to load memory item after put")
+            request = {
+                "namespace": namespace,
+                "key": key,
+                "kind": kind,
+                "value_json": value_json,
+                "tags_json": tags_json,
+                "confidence": confidence,
+                "source": source,
+                "ttl_seconds": ttl_seconds,
+            }
+            result_meta = {
+                "item_id": item.id,
+                "updated_at": item.updated_at,
+                "is_tombstoned": item.is_tombstoned,
+            }
+            append_event(
+                connection,
+                operation="put",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=result_meta,
+                related_run_id=related_run_id,
+                related_ask_event_id=related_ask_event_id,
+            )
+            connection.commit()
+            return item
+
+    def get_item(
+        self,
+        namespace: str,
+        key: str,
+        *,
+        include_tombstoned: bool,
+        actor: str,
+        policy_hash: str,
+        related_run_id: Optional[str] = None,
+        related_ask_event_id: Optional[str] = None,
+    ) -> MemoryItem | None:
+        with self._connection() as connection:
+            item = self._fetch_item(
+                connection,
+                namespace=namespace,
+                key=key,
+                include_tombstoned=include_tombstoned,
+            )
+            request = {
+                "namespace": namespace,
+                "key": key,
+                "include_tombstoned": include_tombstoned,
+            }
+            result_meta = {
+                "found": item is not None,
+                "item_id": item.id if item else None,
+                "updated_at": item.updated_at if item else None,
+            }
+            append_event(
+                connection,
+                operation="get",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=result_meta,
+                related_run_id=related_run_id,
+                related_ask_event_id=related_ask_event_id,
+            )
+            connection.commit()
+            return item
+
+    def search_items(
+        self,
+        query: str,
+        *,
+        namespace: Optional[str] = None,
+        kind: Optional[str] = None,
+        tag: Optional[str] = None,
+        source: Optional[str] = None,
+        confidence_min: Optional[str] = None,
+        include_tombstoned: bool = False,
+        limit: int = 50,
+        actor: str,
+        policy_hash: str,
+        related_run_id: Optional[str] = None,
+        related_ask_event_id: Optional[str] = None,
+    ) -> list[MemoryItem]:
+        filters = []
+        params: list[Any] = []
+        if namespace:
+            filters.append("namespace = ?")
+            params.append(namespace)
+        if kind:
+            filters.append("kind = ?")
+            params.append(kind)
+        if source:
+            filters.append("source = ?")
+            params.append(source)
+        if tag:
+            filters.append("tags_json LIKE ?")
+            params.append(f"%\"{tag}\"%")
+        if confidence_min:
+            filters.append(
+                "(CASE confidence "
+                "WHEN 'low' THEN 1 "
+                "WHEN 'medium' THEN 2 "
+                "WHEN 'high' THEN 3 "
+                "ELSE 0 END) >= ?"
+            )
+            params.append(_confidence_rank(confidence_min))
+        if not include_tombstoned:
+            filters.append("is_tombstoned = 0")
+        if query:
+            filters.append("(key LIKE ? OR value_json LIKE ?)")
+            like_query = f"%{query}%"
+            params.extend([like_query, like_query])
+        where_clause = ""
+        if filters:
+            where_clause = "WHERE " + " AND ".join(filters)
+        sql = (
+            "SELECT * FROM memory_items "
+            f"{where_clause} "
+            "ORDER BY updated_at DESC, key ASC "
+            "LIMIT ?"
+        )
+        params.append(limit)
+
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            rows = cursor.execute(sql, params).fetchall()
+            items = [_row_to_item(row) for row in rows]
+            request = {
+                "query": query,
+                "namespace": namespace,
+                "kind": kind,
+                "tag": tag,
+                "source": source,
+                "confidence_min": confidence_min,
+                "include_tombstoned": include_tombstoned,
+                "limit": limit,
+            }
+            result_meta = {
+                "count": len(items),
+            }
+            append_event(
+                connection,
+                operation="search",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=result_meta,
+                related_run_id=related_run_id,
+                related_ask_event_id=related_ask_event_id,
+            )
+            connection.commit()
+            return items
+
+    def tombstone_item(
+        self,
+        namespace: str,
+        key: str,
+        *,
+        actor: str,
+        policy_hash: str,
+        related_run_id: Optional[str] = None,
+        related_ask_event_id: Optional[str] = None,
+    ) -> MemoryItem | None:
+        updated_at = _utc_now().isoformat()
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                UPDATE memory_items
+                SET is_tombstoned = 1, updated_at = ?
+                WHERE namespace = ? AND key = ?
+                """,
+                (updated_at, namespace, key),
+            )
+            connection.commit()
+            item = self._fetch_item(
+                connection,
+                namespace=namespace,
+                key=key,
+                include_tombstoned=True,
+            )
+            request = {
+                "namespace": namespace,
+                "key": key,
+            }
+            result_meta = {
+                "found": item is not None,
+                "item_id": item.id if item else None,
+                "updated_at": item.updated_at if item else None,
+            }
+            append_event(
+                connection,
+                operation="delete",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=result_meta,
+                related_run_id=related_run_id,
+                related_ask_event_id=related_ask_event_id,
+            )
+            connection.commit()
+            return item
+
+    def _fetch_item(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        namespace: str,
+        key: str,
+        include_tombstoned: bool,
+    ) -> MemoryItem | None:
+        sql = "SELECT * FROM memory_items WHERE namespace = ? AND key = ?"
+        params: list[Any] = [namespace, key]
+        if not include_tombstoned:
+            sql += " AND is_tombstoned = 0"
+        cursor = connection.cursor()
+        row = cursor.execute(sql, params).fetchone()
+        if not row:
+            return None
+        return _row_to_item(row)
+
+
+def put_item(
+    db_path: str,
+    *,
+    namespace: str,
+    key: str,
+    kind: str,
+    value: Any,
+    tags: Optional[list[str]],
+    confidence: str,
+    source: str,
+    ttl_seconds: Optional[int],
+    actor: str,
+    policy_hash: str,
+    related_run_id: Optional[str] = None,
+    related_ask_event_id: Optional[str] = None,
+) -> MemoryItem:
+    return MemoryStore(db_path).put_item(
+        namespace=namespace,
+        key=key,
+        kind=kind,
+        value=value,
+        tags=tags,
+        confidence=confidence,
+        source=source,
+        ttl_seconds=ttl_seconds,
+        actor=actor,
+        policy_hash=policy_hash,
+        related_run_id=related_run_id,
+        related_ask_event_id=related_ask_event_id,
+    )
+
+
+def get_item(
+    db_path: str,
+    namespace: str,
+    key: str,
+    *,
+    include_tombstoned: bool,
+    actor: str,
+    policy_hash: str,
+    related_run_id: Optional[str] = None,
+    related_ask_event_id: Optional[str] = None,
+) -> MemoryItem | None:
+    return MemoryStore(db_path).get_item(
+        namespace,
+        key,
+        include_tombstoned=include_tombstoned,
+        actor=actor,
+        policy_hash=policy_hash,
+        related_run_id=related_run_id,
+        related_ask_event_id=related_ask_event_id,
+    )
+
+
+def search_items(
+    db_path: str,
+    query: str,
+    *,
+    namespace: Optional[str] = None,
+    kind: Optional[str] = None,
+    tag: Optional[str] = None,
+    source: Optional[str] = None,
+    confidence_min: Optional[str] = None,
+    include_tombstoned: bool = False,
+    limit: int = 50,
+    actor: str,
+    policy_hash: str,
+    related_run_id: Optional[str] = None,
+    related_ask_event_id: Optional[str] = None,
+) -> list[MemoryItem]:
+    return MemoryStore(db_path).search_items(
+        query,
+        namespace=namespace,
+        kind=kind,
+        tag=tag,
+        source=source,
+        confidence_min=confidence_min,
+        include_tombstoned=include_tombstoned,
+        limit=limit,
+        actor=actor,
+        policy_hash=policy_hash,
+        related_run_id=related_run_id,
+        related_ask_event_id=related_ask_event_id,
+    )
+
+
+def tombstone_item(
+    db_path: str,
+    namespace: str,
+    key: str,
+    *,
+    actor: str,
+    policy_hash: str,
+    related_run_id: Optional[str] = None,
+    related_ask_event_id: Optional[str] = None,
+) -> MemoryItem | None:
+    return MemoryStore(db_path).tombstone_item(
+        namespace,
+        key,
+        actor=actor,
+        policy_hash=policy_hash,
+        related_run_id=related_run_id,
+        related_ask_event_id=related_ask_event_id,
+    )
+
+
+def append_event(
+    connection: sqlite3.Connection,
+    *,
+    operation: str,
+    actor: str,
+    policy_hash: str,
+    request: dict[str, Any],
+    result_meta: dict[str, Any],
+    related_run_id: Optional[str],
+    related_ask_event_id: Optional[str],
+) -> None:
+    timestamp = _utc_now().isoformat()
+    event_id = str(uuid4())
+    request_json = _serialize_bounded_json(request)
+    result_meta_json = _serialize_bounded_json(result_meta)
+    cursor = connection.cursor()
+    cursor.execute(
+        """
+        INSERT INTO memory_events (
+            id,
+            timestamp,
+            operation,
+            actor,
+            policy_hash,
+            request_json,
+            result_meta_json,
+            related_run_id,
+            related_ask_event_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event_id,
+            timestamp,
+            operation,
+            actor,
+            policy_hash,
+            request_json,
+            result_meta_json,
+            related_run_id,
+            related_ask_event_id,
+        ),
+    )
+
+
+def policy_hash_for_path(policy_path: str | None) -> str:
+    if policy_path:
+        contents = Path(policy_path).read_bytes()
+    else:
+        contents = b"default"
+    return hashlib.sha256(contents).hexdigest()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _confidence_rank(value: str) -> int:
+    lowered = value.lower()
+    if lowered == "high":
+        return 3
+    if lowered == "medium":
+        return 2
+    if lowered == "low":
+        return 1
+    return 0
+
+
+def _row_to_item(row: sqlite3.Row) -> MemoryItem:
+    tags_json = row["tags_json"]
+    return MemoryItem(
+        id=row["id"],
+        namespace=row["namespace"],
+        key=row["key"],
+        kind=row["kind"],
+        value=json.loads(row["value_json"]),
+        tags=json.loads(tags_json) if tags_json else [],
+        confidence=row["confidence"],
+        source=row["source"],
+        ttl_seconds=row["ttl_seconds"],
+        is_tombstoned=bool(row["is_tombstoned"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def _serialize_bounded_json(payload: dict[str, Any]) -> str:
+    normalized = _truncate_large_strings(payload)
+    return json.dumps(normalized, ensure_ascii=False, sort_keys=True)
+
+
+def _truncate_large_strings(value: Any) -> Any:
+    if isinstance(value, str):
+        if len(value) <= MAX_EVENT_STRING_LEN:
+            return value
+        return value[: max(0, MAX_EVENT_STRING_LEN - 1)] + "…"
+    if isinstance(value, list):
+        return [_truncate_large_strings(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _truncate_large_strings(val) for key, val in value.items()}
+    return value

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -1,0 +1,276 @@
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+class MemoryCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.db_path = Path(self.temp_dir.name) / "state.db"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_memory_put_get_search_delete_and_events(self) -> None:
+        put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--key",
+                "default_model",
+                "--kind",
+                "preference",
+                "--value-text",
+                "phi3:mini",
+                "--confidence",
+                "high",
+                "--source",
+                "operator",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(put.returncode, 0, put.stderr)
+
+        get = _run_cli(
+            [
+                "memory",
+                "get",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--json",
+                "default_model",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(get.returncode, 0, get.stderr)
+        item = json.loads(get.stdout)
+        self.assertEqual(item["value"], "phi3:mini")
+
+        search = _run_cli(
+            [
+                "memory",
+                "search",
+                "phi3",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(search.returncode, 0, search.stderr)
+        results = json.loads(search.stdout)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["key"], "default_model")
+
+        delete = _run_cli(
+            [
+                "memory",
+                "delete",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "default_model",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(delete.returncode, 0, delete.stderr)
+
+        get_missing = _run_cli(
+            [
+                "memory",
+                "get",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "default_model",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(get_missing.returncode, 0)
+        self.assertIn("not found", get_missing.stdout.lower())
+
+        get_tombstoned = _run_cli(
+            [
+                "memory",
+                "get",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--include-tombstoned",
+                "--json",
+                "default_model",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(get_tombstoned.returncode, 0, get_tombstoned.stderr)
+        tombstoned_item = json.loads(get_tombstoned.stdout)
+        self.assertTrue(tombstoned_item["is_tombstoned"])
+
+        with sqlite3.connect(self.db_path) as connection:
+            cursor = connection.cursor()
+            count = cursor.execute("SELECT COUNT(*) FROM memory_events").fetchone()[0]
+        self.assertEqual(count, 6)
+
+    def test_memory_upsert_and_ordering(self) -> None:
+        first_put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--key",
+                "alpha",
+                "--kind",
+                "note",
+                "--value-text",
+                "first",
+                "--confidence",
+                "low",
+                "--source",
+                "operator",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(first_put.returncode, 0, first_put.stderr)
+
+        second_put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--key",
+                "beta",
+                "--kind",
+                "note",
+                "--value-text",
+                "second",
+                "--confidence",
+                "low",
+                "--source",
+                "operator",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(second_put.returncode, 0, second_put.stderr)
+
+        upsert = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--key",
+                "alpha",
+                "--kind",
+                "note",
+                "--value-text",
+                "updated",
+                "--confidence",
+                "medium",
+                "--source",
+                "operator",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(upsert.returncode, 0, upsert.stderr)
+
+        get_alpha = _run_cli(
+            [
+                "memory",
+                "get",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--json",
+                "alpha",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(get_alpha.returncode, 0, get_alpha.stderr)
+        alpha_item = json.loads(get_alpha.stdout)
+        self.assertEqual(alpha_item["value"], "updated")
+        self.assertEqual(alpha_item["confidence"], "medium")
+
+        search = _run_cli(
+            [
+                "memory",
+                "search",
+                "",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(search.returncode, 0, search.stderr)
+        results = json.loads(search.stdout)
+        keys = [item["key"] for item in results]
+        self.assertEqual(keys[0], "alpha")
+        self.assertEqual(keys[1], "beta")
+
+    def test_memory_db_file_released_after_cli(self) -> None:
+        put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--namespace",
+                "global",
+                "--key",
+                "lock_check",
+                "--kind",
+                "note",
+                "--value-text",
+                "released",
+                "--confidence",
+                "high",
+                "--source",
+                "operator",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(put.returncode, 0, put.stderr)
+        self.assertTrue(self.db_path.exists())
+        self.db_path.unlink()
+        self.assertFalse(self.db_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Implement the MEMORY_CONTRACT v0.1 primitives to provide persistent, auditable memory storage for operator-managed state.
- Expose deterministic, tombstone-aware read/write/search primitives via the CLI so operators can manage memory explicitly.
- Ensure every memory operation emits an audit event (`memory_events`) and preserve hooks for future policy enforcement.
- Protect Windows compatibility by deterministically closing SQLite connections and verifying DB file release after CLI use.

### Description
- Added SQLite schema and indexes for `memory_items` and `memory_events` (created in `gismo/core/state.py`) and a new `gismo/memory/store.py` implementing `MemoryStore` with `put_item`, `get_item`, `search_items`, `tombstone_item`, and `append_event`.
- Wired CLI commands `memory put|get|search|delete` in `gismo/cli/main.py` with flags per the contract (namespace/key/kind/confidence/source, `--value`/`--value-text`, `--include-tombstoned`, `--limit`, `--json`, `--policy`, etc.) and human/JSON output modes.
- Added `tests/test_memory_cli.py` exercising full CLI round-trips: put/get/search/delete, upsert ordering, tombstone default exclusion and include flag, event row creation, and DB file release after CLI exit.
- Updated `README.md` with memory command examples and `Handoff.md` with status, next steps, and tests run.

### Testing
- Ran the full verification suite with `python scripts/verify.py` which executed the test suite and completed successfully (all tests passed; some integration tests skipped as expected).
- `tests/test_memory_cli.py` was executed as part of verification and validated CLI workflows, tombstone behavior, deterministic ordering, and event creation.
- Verified that `memory.search` ordering is deterministic (`updated_at DESC, key ASC`) and that an entry in `memory_events` is written for each `put|get|search|delete` operation via unit tests.
- Confirmed the temporary DB file can be deleted after CLI exit to guard against Windows locking regressions via the new test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bcac77e2483308843764017157e69)