### PR TITLE
Revert README and Handoff changes from memory implementation merge

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -36,7 +36,6 @@ In progress:
 - Phase 2 (Control & Guardrails): ~75%
 
 Planned:
-- Phase 3 (Memory & Context)
 - Phase 4 (Interactive GISMO)
 
 -------------------------------------------------------------------------------
@@ -172,14 +171,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added SQLite-backed memory primitives with CLI support (put/get/search/delete) and audit events.
-- Memory operations are deterministic, tombstone-aware, and include end-to-end CLI tests.
-- Updated CLI documentation with memory command examples.
+- Reverted memory-related documentation additions from the merged implementation.
+- Restored README and handoff notes to reflect governance discipline.
 
 Next steps:
-- Wire policy-aware confirmation gates for persistent memory namespaces.
-- Consider adding memory read/write hooks to the planner once policy enforcement is defined.
-- Monitor Windows locking regressions for memory CLI interactions.
+- Reintroduce memory documentation only when explicitly approved for the release scope.
+- Keep doc updates limited to approved changes.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -120,14 +120,6 @@ Export audit logs:
   gismo export --run RUN_ID
   gismo export RUN_ID
 
-Memory primitives (SQLite-backed):
-
-  gismo memory put --namespace global --key default_model --kind preference \\
-    --value '\"phi3:mini\"' --confidence high --source operator --tag llm
-  gismo memory get --namespace global default_model
-  gismo memory search \"phi3\" --namespace global --kind preference
-  gismo memory delete --namespace global default_model
-
 Windows examples (explicit module invocation):
 
   python -m gismo.cli.main --db .\tmp\dev.db runs list


### PR DESCRIPTION
### Motivation
- Restore governance discipline by removing documentation that was unintentionally merged with the memory implementation. 
- Ensure operator-facing docs reflect the approved scope and avoid advertising unapproved memory features. 

### Description
- Removed the memory CLI examples block from `README.md` and updated `Handoff.md` to note the documentation reversion and updated next steps. 
- Updated `Handoff.md` status to indicate the memory-related docs were reverted and to require explicit approval before reintroducing memory documentation. 
- No code was changed; the repository diff contains modifications only to `README.md` and `Handoff.md`.

### Testing
- Ran the verification script with `python scripts/verify.py`. 
- Result: the automated test suite completed successfully (all tests passed; summary `OK`, with a small number of skipped tests for optional integrations).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bcd83e36c8330b539c11dee967d4c)