### PR TITLE
Policy-gate memory put/delete with confirmation hooks

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -171,12 +171,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Reverted memory-related documentation additions from the merged implementation.
-- Restored README and handoff notes to reflect governance discipline.
+- Added policy + confirmation gating for memory put/delete operations in the CLI.
+- Audited memory decision outcomes (allowed/denied/confirmed) in memory events.
 
 Next steps:
-- Reintroduce memory documentation only when explicitly approved for the release scope.
-- Keep doc updates limited to approved changes.
+- Extend policy samples if new memory namespaces are introduced.
+- Re-run Windows validation on a native host before release tagging.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Export audit logs:
 
   gismo export --latest
   gismo export --run RUN_ID
+
+Memory management (policy-gated; confirmation required for high-risk namespaces):
+
+  gismo memory put --namespace global --key key --kind note --value-text "value" \
+    --confidence high --source operator --policy policy/dev-safe.json --yes
+  gismo memory delete --namespace global key --policy policy/dev-safe.json --yes
+
+Notes:
+- Global/project namespaces require confirmation unless policy explicitly exempts them.
+- Use --non-interactive to fail closed instead of prompting.
   gismo export RUN_ID
 
 Windows examples (explicit module invocation):

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -6,6 +6,7 @@ import json
 import re
 import sys
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID
@@ -43,6 +44,7 @@ from gismo.memory.store import (
     get_item as memory_get_item,
     policy_hash_for_path,
     put_item as memory_put_item,
+    record_event as memory_record_event,
     search_items as memory_search_items,
     tombstone_item as memory_tombstone_item,
 )
@@ -807,12 +809,79 @@ def run_list(db_path: str, limit: int, newest_first: bool) -> None:
         )
 
 
+@dataclass
+class MemoryDecision:
+    action: str
+    allowed: bool
+    confirmation_required: bool
+    confirmation_provided: bool
+    confirmation_mode: str | None
+    reason: str | None
+
+
 def _memory_policy_hash(policy_path: str | None) -> str:
     try:
         return policy_hash_for_path(policy_path)
     except FileNotFoundError as exc:
         print(f"Policy file not found: {policy_path}")
         raise SystemExit(2) from exc
+
+
+def _load_memory_policy(policy_path: str | None) -> tuple[PermissionPolicy, str | None]:
+    repo_root = Path(__file__).resolve().parents[2]
+    resolved_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
+    try:
+        policy = load_policy(resolved_path, repo_root=repo_root)
+    except (OSError, ValueError, PermissionError) as exc:
+        print(f"Policy file not valid: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    return policy, resolved_path
+
+
+def _memory_policy_result_meta(decision: MemoryDecision) -> dict[str, object]:
+    return {
+        "policy_action": decision.action,
+        "policy_decision": "allowed" if decision.allowed else "denied",
+        "policy_reason": decision.reason,
+        "confirmation": {
+            "required": decision.confirmation_required,
+            "provided": decision.confirmation_provided,
+            "mode": decision.confirmation_mode,
+        },
+    }
+
+
+def _evaluate_memory_policy(policy: PermissionPolicy, action: str, namespace: str) -> MemoryDecision:
+    try:
+        policy.check_tool_allowed(action)
+    except PermissionError:
+        return MemoryDecision(
+            action=action,
+            allowed=False,
+            confirmation_required=False,
+            confirmation_provided=False,
+            confirmation_mode=None,
+            reason="policy_denied",
+        )
+    if not policy.memory.is_allowed(action, namespace):
+        return MemoryDecision(
+            action=action,
+            allowed=False,
+            confirmation_required=False,
+            confirmation_provided=False,
+            confirmation_mode=None,
+            reason="policy_denied",
+        )
+    return MemoryDecision(
+        action=action,
+        allowed=True,
+        confirmation_required=policy.memory.requires_confirmation(action, namespace),
+        confirmation_provided=False,
+        confirmation_mode=None,
+        reason=None,
+    )
 
 
 def _parse_memory_value(value_text: str | None, value_json: str | None) -> object:
@@ -833,9 +902,84 @@ def _parse_memory_value(value_text: str | None, value_json: str | None) -> objec
 
 def run_memory_put(args: argparse.Namespace) -> None:
     actor = "operator"
-    policy_hash = _memory_policy_hash(args.policy)
+    policy, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
     value = _parse_memory_value(args.value_text, args.value)
     tags = args.tag or []
+    action = "memory.put"
+    decision = _evaluate_memory_policy(policy, action, args.namespace)
+    request = {
+        "namespace": args.namespace,
+        "key": args.key,
+        "kind": args.kind,
+        "value_json": json.dumps(value, ensure_ascii=False, sort_keys=True),
+        "tags_json": json.dumps(tags, ensure_ascii=False, sort_keys=True) if tags else None,
+        "confidence": args.confidence,
+        "source": args.source,
+        "ttl_seconds": args.ttl_seconds,
+    }
+    if not decision.allowed:
+        memory_record_event(
+            args.db_path,
+            operation="put",
+            actor=actor,
+            policy_hash=policy_hash,
+            request=request,
+            result_meta=_memory_policy_result_meta(decision),
+        )
+        print("Memory put blocked by policy.", file=sys.stderr)
+        raise SystemExit(2)
+    if decision.confirmation_required:
+        if args.yes:
+            decision.confirmation_provided = True
+            decision.confirmation_mode = "yes-flag"
+        elif args.non_interactive or not _is_interactive_tty():
+            denied = MemoryDecision(
+                action=decision.action,
+                allowed=False,
+                confirmation_required=True,
+                confirmation_provided=False,
+                confirmation_mode=None,
+                reason="confirmation_required",
+            )
+            memory_record_event(
+                args.db_path,
+                operation="put",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=_memory_policy_result_meta(denied),
+            )
+            print(
+                "Confirmation required for memory put. Re-run with --yes to proceed.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        else:
+            response = input(
+                "This memory write requires confirmation. Proceed? [y/N]:"
+            )
+            if response.strip().lower() not in {"y", "yes"}:
+                denied = MemoryDecision(
+                    action=decision.action,
+                    allowed=False,
+                    confirmation_required=True,
+                    confirmation_provided=False,
+                    confirmation_mode=None,
+                    reason="confirmation_declined",
+                )
+                memory_record_event(
+                    args.db_path,
+                    operation="put",
+                    actor=actor,
+                    policy_hash=policy_hash,
+                    request=request,
+                    result_meta=_memory_policy_result_meta(denied),
+                )
+                print("Confirmation declined; memory not written.", file=sys.stderr)
+                raise SystemExit(2)
+            decision.confirmation_provided = True
+            decision.confirmation_mode = "prompt"
     item = memory_put_item(
         args.db_path,
         namespace=args.namespace,
@@ -848,6 +992,7 @@ def run_memory_put(args: argparse.Namespace) -> None:
         ttl_seconds=args.ttl_seconds,
         actor=actor,
         policy_hash=policy_hash,
+        result_meta_extra=_memory_policy_result_meta(decision),
     )
     print(f"DB: {args.db_path}")
     print("Stored memory item:")
@@ -856,7 +1001,8 @@ def run_memory_put(args: argparse.Namespace) -> None:
 
 def run_memory_get(args: argparse.Namespace) -> None:
     actor = "operator"
-    policy_hash = _memory_policy_hash(args.policy)
+    _, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
     item = memory_get_item(
         args.db_path,
         args.namespace,
@@ -877,7 +1023,8 @@ def run_memory_get(args: argparse.Namespace) -> None:
 
 def run_memory_search(args: argparse.Namespace) -> None:
     actor = "operator"
-    policy_hash = _memory_policy_hash(args.policy)
+    _, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
     items = memory_search_items(
         args.db_path,
         args.query or "",
@@ -902,13 +1049,83 @@ def run_memory_search(args: argparse.Namespace) -> None:
 
 def run_memory_delete(args: argparse.Namespace) -> None:
     actor = "operator"
-    policy_hash = _memory_policy_hash(args.policy)
+    policy, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
+    action = "memory.delete"
+    decision = _evaluate_memory_policy(policy, action, args.namespace)
+    request = {
+        "namespace": args.namespace,
+        "key": args.key,
+    }
+    if not decision.allowed:
+        memory_record_event(
+            args.db_path,
+            operation="delete",
+            actor=actor,
+            policy_hash=policy_hash,
+            request=request,
+            result_meta=_memory_policy_result_meta(decision),
+        )
+        print("Memory delete blocked by policy.", file=sys.stderr)
+        raise SystemExit(2)
+    if decision.confirmation_required:
+        if args.yes:
+            decision.confirmation_provided = True
+            decision.confirmation_mode = "yes-flag"
+        elif args.non_interactive or not _is_interactive_tty():
+            denied = MemoryDecision(
+                action=decision.action,
+                allowed=False,
+                confirmation_required=True,
+                confirmation_provided=False,
+                confirmation_mode=None,
+                reason="confirmation_required",
+            )
+            memory_record_event(
+                args.db_path,
+                operation="delete",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=_memory_policy_result_meta(denied),
+            )
+            print(
+                "Confirmation required for memory delete. Re-run with --yes to proceed.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        else:
+            response = input(
+                "This memory delete requires confirmation. Proceed? [y/N]:"
+            )
+            if response.strip().lower() not in {"y", "yes"}:
+                denied = MemoryDecision(
+                    action=decision.action,
+                    allowed=False,
+                    confirmation_required=True,
+                    confirmation_provided=False,
+                    confirmation_mode=None,
+                    reason="confirmation_declined",
+                )
+                memory_record_event(
+                    args.db_path,
+                    operation="delete",
+                    actor=actor,
+                    policy_hash=policy_hash,
+                    request=request,
+                    result_meta=_memory_policy_result_meta(denied),
+                )
+                print("Confirmation declined; memory not deleted.", file=sys.stderr)
+                raise SystemExit(2)
+            decision.confirmation_provided = True
+            decision.confirmation_mode = "prompt"
     item = memory_tombstone_item(
         args.db_path,
         args.namespace,
         args.key,
         actor=actor,
         policy_hash=policy_hash,
+        result_meta_extra=_memory_policy_result_meta(decision),
     )
     if item is None:
         print(f"Memory item not found: {args.namespace}/{args.key}")
@@ -2410,6 +2627,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional TTL in seconds",
     )
     memory_put_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for high-risk memory writes",
+    )
+    memory_put_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting for confirmation",
+    )
+    memory_put_parser.add_argument(
         "--policy",
         default=None,
         help="Optional policy file path for audit hashing",
@@ -2519,6 +2746,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--policy",
         default=None,
         help="Optional policy file path for audit hashing",
+    )
+    memory_delete_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for high-risk memory deletes",
+    )
+    memory_delete_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting for confirmation",
     )
     memory_delete_parser.set_defaults(handler=_handle_memory_delete)
 

--- a/gismo/core/permissions.py
+++ b/gismo/core/permissions.py
@@ -20,10 +20,25 @@ class ShellPolicy:
 
 
 @dataclass
+class MemoryPolicy:
+    allow: dict[str, list[str]] = field(default_factory=dict)
+    require_confirmation: dict[str, list[str]] = field(default_factory=dict)
+
+    def is_allowed(self, action: str, namespace: str) -> bool:
+        allowed = self.allow.get(action, [])
+        return _matches_namespace(namespace, allowed)
+
+    def requires_confirmation(self, action: str, namespace: str) -> bool:
+        required = self.require_confirmation.get(action, [])
+        return _matches_namespace(namespace, required)
+
+
+@dataclass
 class PermissionPolicy:
     allowed_tools: Set[str] = field(default_factory=set)
     fs: FileSystemPolicy = field(default_factory=lambda: FileSystemPolicy(Path(".")))
     shell: ShellPolicy = field(default_factory=lambda: ShellPolicy(Path(".")))
+    memory: MemoryPolicy = field(default_factory=MemoryPolicy)
 
     def allow(self, tool_name: str) -> None:
         self.allowed_tools.add(tool_name)
@@ -54,10 +69,16 @@ def load_policy(
     allowed_tools = _ensure_string_list(data.get("allowed_tools", []), "allowed_tools")
     fs_config = data.get("fs", {}) or {}
     shell_config = data.get("shell", {}) or {}
+    memory_config = data.get("memory", {}) or {}
     fs_base_dir = _resolve_base_dir(repo_root, fs_config.get("base_dir", "."))
     shell_base_dir = _resolve_base_dir(repo_root, shell_config.get("base_dir", "."))
     allowlist = _ensure_command_allowlist(shell_config.get("allowlist", []))
     timeout_seconds = _ensure_timeout(shell_config.get("timeout_seconds", 10))
+    memory_allow = _ensure_namespace_map(memory_config.get("allow", {}), "memory.allow")
+    memory_confirmation = _ensure_namespace_map(
+        memory_config.get("require_confirmation", {}),
+        "memory.require_confirmation",
+    )
     return PermissionPolicy(
         allowed_tools=set(allowed_tools),
         fs=FileSystemPolicy(base_dir=fs_base_dir),
@@ -65,6 +86,10 @@ def load_policy(
             base_dir=shell_base_dir,
             allowlist=allowlist,
             timeout_seconds=timeout_seconds,
+        ),
+        memory=MemoryPolicy(
+            allow=memory_allow,
+            require_confirmation=memory_confirmation,
         ),
     )
 
@@ -96,6 +121,32 @@ def _ensure_timeout(value: object) -> float:
             raise ValueError("shell.timeout_seconds must be positive")
         return float(value)
     raise ValueError("shell.timeout_seconds must be a number")
+
+
+def _ensure_namespace_map(value: object, field_name: str) -> dict[str, list[str]]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be a mapping of action -> namespaces")
+    normalized: dict[str, list[str]] = {}
+    for key, namespaces in value.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ValueError(f"{field_name} keys must be non-empty strings")
+        normalized[key] = _ensure_string_list(namespaces, f"{field_name}.{key}")
+    return normalized
+
+
+def _matches_namespace(namespace: str, patterns: Iterable[str]) -> bool:
+    for pattern in patterns:
+        if pattern == "*":
+            return True
+        if pattern.endswith("*"):
+            if namespace.startswith(pattern[:-1]):
+                return True
+            continue
+        if namespace == pattern:
+            return True
+    return False
 
 
 def _resolve_base_dir(repo_root: Path, base_dir_value: object) -> Path:

--- a/gismo/memory/__init__.py
+++ b/gismo/memory/__init__.py
@@ -7,6 +7,7 @@ from gismo.memory.store import (
     get_item,
     policy_hash_for_path,
     put_item,
+    record_event,
     search_items,
     tombstone_item,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "get_item",
     "policy_hash_for_path",
     "put_item",
+    "record_event",
     "search_items",
     "tombstone_item",
 ]

--- a/gismo/memory/store.py
+++ b/gismo/memory/store.py
@@ -159,6 +159,7 @@ class MemoryStore:
         ttl_seconds: Optional[int],
         actor: str,
         policy_hash: str,
+        result_meta_extra: Optional[dict[str, Any]] = None,
         related_run_id: Optional[str] = None,
         related_ask_event_id: Optional[str] = None,
     ) -> MemoryItem:
@@ -235,6 +236,8 @@ class MemoryStore:
                 "updated_at": item.updated_at,
                 "is_tombstoned": item.is_tombstoned,
             }
+            if result_meta_extra:
+                result_meta.update(result_meta_extra)
             append_event(
                 connection,
                 operation="put",
@@ -382,6 +385,7 @@ class MemoryStore:
         *,
         actor: str,
         policy_hash: str,
+        result_meta_extra: Optional[dict[str, Any]] = None,
         related_run_id: Optional[str] = None,
         related_ask_event_id: Optional[str] = None,
     ) -> MemoryItem | None:
@@ -412,6 +416,8 @@ class MemoryStore:
                 "item_id": item.id if item else None,
                 "updated_at": item.updated_at if item else None,
             }
+            if result_meta_extra:
+                result_meta.update(result_meta_extra)
             append_event(
                 connection,
                 operation="delete",
@@ -457,6 +463,7 @@ def put_item(
     ttl_seconds: Optional[int],
     actor: str,
     policy_hash: str,
+    result_meta_extra: Optional[dict[str, Any]] = None,
     related_run_id: Optional[str] = None,
     related_ask_event_id: Optional[str] = None,
 ) -> MemoryItem:
@@ -471,6 +478,7 @@ def put_item(
         ttl_seconds=ttl_seconds,
         actor=actor,
         policy_hash=policy_hash,
+        result_meta_extra=result_meta_extra,
         related_run_id=related_run_id,
         related_ask_event_id=related_ask_event_id,
     )
@@ -537,6 +545,7 @@ def tombstone_item(
     *,
     actor: str,
     policy_hash: str,
+    result_meta_extra: Optional[dict[str, Any]] = None,
     related_run_id: Optional[str] = None,
     related_ask_event_id: Optional[str] = None,
 ) -> MemoryItem | None:
@@ -545,9 +554,36 @@ def tombstone_item(
         key,
         actor=actor,
         policy_hash=policy_hash,
+        result_meta_extra=result_meta_extra,
         related_run_id=related_run_id,
         related_ask_event_id=related_ask_event_id,
     )
+
+
+def record_event(
+    db_path: str,
+    *,
+    operation: str,
+    actor: str,
+    policy_hash: str,
+    request: dict[str, Any],
+    result_meta: dict[str, Any],
+    related_run_id: Optional[str] = None,
+    related_ask_event_id: Optional[str] = None,
+) -> None:
+    store = MemoryStore(db_path)
+    with store._connection() as connection:
+        append_event(
+            connection,
+            operation=operation,
+            actor=actor,
+            policy_hash=policy_hash,
+            request=request,
+            result_meta=result_meta,
+            related_run_id=related_run_id,
+            related_ask_event_id=related_ask_event_id,
+        )
+        connection.commit()
 
 
 def append_event(

--- a/policy/dev-safe.json
+++ b/policy/dev-safe.json
@@ -1,6 +1,24 @@
 {
-  "allowed_tools": ["echo", "read_file", "list_dir", "write_note", "run_shell"],
+  "allowed_tools": [
+    "echo",
+    "read_file",
+    "list_dir",
+    "write_note",
+    "run_shell",
+    "memory.put",
+    "memory.delete"
+  ],
   "fs": { "base_dir": "." },
+  "memory": {
+    "allow": {
+      "memory.put": ["run:*", "project:*", "global"],
+      "memory.delete": ["run:*", "project:*", "global"]
+    },
+    "require_confirmation": {
+      "memory.put": ["project:*", "global"],
+      "memory.delete": ["project:*", "global"]
+    }
+  },
   "shell": {
     "base_dir": ".",
     "allowlist": [

--- a/policy/dev.json
+++ b/policy/dev.json
@@ -5,10 +5,21 @@
     "read_file",
     "write_file",
     "list_dir",
-    "run_shell"
+    "run_shell",
+    "memory.put",
+    "memory.delete"
   ],
   "fs": {
     "base_dir": "."
+  },
+  "memory": {
+    "allow": {
+      "memory.put": ["run:*", "project:*", "global"],
+      "memory.delete": ["run:*"]
+    },
+    "require_confirmation": {
+      "memory.put": ["project:*", "global"]
+    }
   },
   "shell": {
     "base_dir": ".",

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -22,9 +22,22 @@ class MemoryCliTest(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.repo_root = Path(__file__).resolve().parents[1]
         self.db_path = Path(self.temp_dir.name) / "state.db"
+        self.policy_path = self.repo_root / "policy" / "dev-safe.json"
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
+
+    def _latest_event_meta(self, operation: str) -> dict[str, object]:
+        with sqlite3.connect(self.db_path) as connection:
+            row = connection.execute(
+                "SELECT result_meta_json FROM memory_events "
+                "WHERE operation = ? "
+                "ORDER BY timestamp DESC "
+                "LIMIT 1",
+                (operation,),
+            ).fetchone()
+        self.assertIsNotNone(row)
+        return json.loads(row[0])
 
     def test_memory_put_get_search_delete_and_events(self) -> None:
         put = _run_cli(
@@ -33,6 +46,8 @@ class MemoryCliTest(unittest.TestCase):
                 "put",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--key",
@@ -45,6 +60,7 @@ class MemoryCliTest(unittest.TestCase):
                 "high",
                 "--source",
                 "operator",
+                "--yes",
             ],
             cwd=self.repo_root,
         )
@@ -56,6 +72,8 @@ class MemoryCliTest(unittest.TestCase):
                 "get",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--json",
@@ -74,6 +92,8 @@ class MemoryCliTest(unittest.TestCase):
                 "phi3",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--json",
@@ -91,9 +111,12 @@ class MemoryCliTest(unittest.TestCase):
                 "delete",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "default_model",
+                "--yes",
             ],
             cwd=self.repo_root,
         )
@@ -105,6 +128,8 @@ class MemoryCliTest(unittest.TestCase):
                 "get",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "default_model",
@@ -120,6 +145,8 @@ class MemoryCliTest(unittest.TestCase):
                 "get",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--include-tombstoned",
@@ -144,6 +171,8 @@ class MemoryCliTest(unittest.TestCase):
                 "put",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--key",
@@ -156,6 +185,7 @@ class MemoryCliTest(unittest.TestCase):
                 "low",
                 "--source",
                 "operator",
+                "--yes",
             ],
             cwd=self.repo_root,
         )
@@ -167,6 +197,8 @@ class MemoryCliTest(unittest.TestCase):
                 "put",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--key",
@@ -179,6 +211,7 @@ class MemoryCliTest(unittest.TestCase):
                 "low",
                 "--source",
                 "operator",
+                "--yes",
             ],
             cwd=self.repo_root,
         )
@@ -190,6 +223,8 @@ class MemoryCliTest(unittest.TestCase):
                 "put",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--key",
@@ -202,6 +237,7 @@ class MemoryCliTest(unittest.TestCase):
                 "medium",
                 "--source",
                 "operator",
+                "--yes",
             ],
             cwd=self.repo_root,
         )
@@ -213,6 +249,8 @@ class MemoryCliTest(unittest.TestCase):
                 "get",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--json",
@@ -232,6 +270,8 @@ class MemoryCliTest(unittest.TestCase):
                 "",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--json",
@@ -244,6 +284,156 @@ class MemoryCliTest(unittest.TestCase):
         self.assertEqual(keys[0], "alpha")
         self.assertEqual(keys[1], "beta")
 
+    def test_memory_put_requires_confirmation_in_non_interactive(self) -> None:
+        put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "global",
+                "--key",
+                "requires_confirm",
+                "--kind",
+                "note",
+                "--value-text",
+                "blocked",
+                "--confidence",
+                "high",
+                "--source",
+                "operator",
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(put.returncode, 0)
+        self.assertIn("Confirmation required", put.stderr)
+
+        with sqlite3.connect(self.db_path) as connection:
+            item_count = connection.execute(
+                "SELECT COUNT(*) FROM memory_items"
+            ).fetchone()[0]
+        self.assertEqual(item_count, 0)
+        meta = self._latest_event_meta("put")
+        self.assertEqual(meta["policy_decision"], "denied")
+        self.assertEqual(meta["policy_reason"], "confirmation_required")
+
+    def test_memory_put_yes_records_confirmation(self) -> None:
+        put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "global",
+                "--key",
+                "confirmed",
+                "--kind",
+                "note",
+                "--value-text",
+                "allowed",
+                "--confidence",
+                "high",
+                "--source",
+                "operator",
+                "--yes",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(put.returncode, 0, put.stderr)
+        meta = self._latest_event_meta("put")
+        self.assertEqual(meta["policy_decision"], "allowed")
+        confirmation = meta["confirmation"]
+        self.assertTrue(confirmation["required"])
+        self.assertTrue(confirmation["provided"])
+        self.assertEqual(confirmation["mode"], "yes-flag")
+
+    def test_memory_delete_yes_records_confirmation(self) -> None:
+        put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "global",
+                "--key",
+                "to_delete",
+                "--kind",
+                "note",
+                "--value-text",
+                "removable",
+                "--confidence",
+                "high",
+                "--source",
+                "operator",
+                "--yes",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(put.returncode, 0, put.stderr)
+
+        delete = _run_cli(
+            [
+                "memory",
+                "delete",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "global",
+                "to_delete",
+                "--yes",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(delete.returncode, 0, delete.stderr)
+        meta = self._latest_event_meta("delete")
+        self.assertEqual(meta["policy_decision"], "allowed")
+        confirmation = meta["confirmation"]
+        self.assertTrue(confirmation["required"])
+        self.assertTrue(confirmation["provided"])
+        self.assertEqual(confirmation["mode"], "yes-flag")
+
+    def test_memory_put_run_namespace_allowed(self) -> None:
+        put = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "run:abc123",
+                "--key",
+                "run_note",
+                "--kind",
+                "note",
+                "--value-text",
+                "run-ok",
+                "--confidence",
+                "low",
+                "--source",
+                "operator",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(put.returncode, 0, put.stderr)
+        meta = self._latest_event_meta("put")
+        self.assertEqual(meta["policy_decision"], "allowed")
+        confirmation = meta["confirmation"]
+        self.assertFalse(confirmation["required"])
+
     def test_memory_db_file_released_after_cli(self) -> None:
         put = _run_cli(
             [
@@ -251,6 +441,8 @@ class MemoryCliTest(unittest.TestCase):
                 "put",
                 "--db",
                 str(self.db_path),
+                "--policy",
+                str(self.policy_path),
                 "--namespace",
                 "global",
                 "--key",
@@ -263,6 +455,7 @@ class MemoryCliTest(unittest.TestCase):
                 "high",
                 "--source",
                 "operator",
+                "--yes",
             ],
             cwd=self.repo_root,
         )


### PR DESCRIPTION
### Motivation
- Ensure all persistent memory writes and deletes are governed by the existing policy framework and recorded deterministically. 
- Require explicit confirmation for higher-risk namespaces (global and project:*) unless policy exempts them. 
- Preserve full auditability by recording the policy decision and confirmation outcome with every memory event. 
- Keep behavior isolated to the CLI/operator layer and avoid any planner/agent/daemon integration changes.

### Description
- Added a `MemoryPolicy` to `PermissionPolicy` (gismo/core/permissions.py) with namespace-based `allow` and `require_confirmation` mappings and matching helpers. 
- Gate `gismo memory put` and `gismo memory delete` in the CLI (gismo/cli/main.py) by evaluating policy, prompting or honoring `--yes`/`--non-interactive`, and failing closed in non-interactive confirmation cases. 
- Propagated policy/confirmation metadata into memory audit events via `result_meta_extra` and a `record_event` helper (gismo/memory/store.py and gismo/memory/__init__.py) so `memory_events.result_meta_json` captures the decision. 
- Updated policy samples (`policy/dev-safe.json`, `policy/dev.json`), README, Handoff notes, and expanded `tests/test_memory_cli.py` to cover allowed/denied/confirmation flows and non-interactive behavior.

### Testing
- Run the full verification suite with `python scripts/verify.py`, which executed the test suite and completed successfully (all tests passed). 
- Unit tests exercising the new flows were added/updated in `tests/test_memory_cli.py` and passed when running `python -m unittest -v tests.test_memory_cli`. 
- The Windows-oriented DB handle release check (`test_memory_db_file_released_after_cli`) was preserved and passed to avoid SQLite locking regressions. 
- Commands to manually exercise the change: `python -m gismo.cli.main memory put --db PATH --namespace global --key k --kind note --value-text v --confidence high --source operator --policy policy/dev-safe.json --yes` and `python -m gismo.cli.main memory delete --db PATH --namespace global k --policy policy/dev-safe.json --yes`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bcea5a4748330ae7679cca22dce21)