### PR TITLE
Add deterministic memory read injection to `gismo ask` (flagged, audited, bounded)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -173,9 +173,11 @@ LATEST UPDATE (OPERATOR NOTES)
 Status:
 - Added policy + confirmation gating for memory put/delete operations in the CLI.
 - Audited memory decision outcomes (allowed/denied/confirmed) in memory events.
+- Added optional ask --memory prompt injection with deterministic filters, bounds, and audit metadata.
 
 Next steps:
 - Extend policy samples if new memory namespaces are introduced.
+- Validate memory prompt injection ordering against real operator datasets.
 - Re-run Windows validation on a native host before release tagging.
 
 Tests run:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Planner (local LLM via Ollama):
 
   gismo ask "Summarize the last 10 queue failures" --dry-run
   gismo ask "Do X safely" --enqueue
+  gismo ask "Plan with memory context" --dry-run --memory
 
 Agent loop (leashed autonomy):
 
@@ -161,6 +162,7 @@ Planner behavior:
 - Higher-risk plans require confirmation before enqueueing unless --yes is used.
 - --explain prints additional assessment details.
 - Use --debug to print tracebacks for ask failures.
+- --memory injects eligible read-only memory context into the planner prompt (bounded, audited).
 
 Planner configuration:
 - Increase --timeout-s on CPU machines (60s baseline) if prompts time out.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -42,6 +42,7 @@ from gismo.llm.prompts import build_system_prompt, build_user_prompt
 from gismo.memory.store import (
     MemoryItem,
     get_item as memory_get_item,
+    list_prompt_items as memory_list_prompt_items,
     policy_hash_for_path,
     put_item as memory_put_item,
     record_event as memory_record_event,
@@ -1192,6 +1193,81 @@ def run_enqueue(
     print(f"Enqueued {item.id} status={item.status.value}")
 
 
+@dataclass(frozen=True)
+class MemoryInjection:
+    block: str
+    count: int
+    bytes: int
+    keys: list[dict[str, str]]
+
+
+def _serialize_memory_value(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _memory_entries_for_prompt(items: list[MemoryItem]) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for item in items:
+        entries.append(
+            {
+                "namespace": item.namespace,
+                "key": item.key,
+                "kind": item.kind,
+                "confidence": item.confidence,
+                "source": item.source,
+                "updated_at": item.updated_at,
+                "value_json": _serialize_memory_value(item.value),
+            }
+        )
+    return entries
+
+
+def _build_memory_injection(db_path: str) -> MemoryInjection:
+    items = memory_list_prompt_items(db_path, limit=20)
+    entries = _memory_entries_for_prompt(items)
+    capped_entries: list[dict[str, str]] = []
+    total_bytes = 0
+    for entry in entries:
+        serialized = json.dumps(entry, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        entry_bytes = len(serialized.encode("utf-8"))
+        if len(capped_entries) >= 20:
+            break
+        if total_bytes + entry_bytes > 8192:
+            break
+        capped_entries.append(entry)
+        total_bytes += entry_bytes
+    keys = [{"namespace": entry["namespace"], "key": entry["key"]} for entry in capped_entries]
+    payload_json = json.dumps(capped_entries, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    block = (
+        "READ-ONLY MEMORY CONTEXT (do not modify):\n"
+        "<<<< MEMORY READ ONLY >>>>\n"
+        f"{payload_json}\n"
+        "<<<< END MEMORY >>>>"
+    )
+    return MemoryInjection(
+        block=block,
+        count=len(capped_entries),
+        bytes=total_bytes,
+        keys=keys,
+    )
+
+
+def _apply_memory_injection_payload(
+    payload: dict[str, object],
+    memory_injection: MemoryInjection | None,
+) -> None:
+    if not memory_injection:
+        return
+    payload.update(
+        {
+            "memory_injection_enabled": True,
+            "memory_injected_count": memory_injection.count,
+            "memory_injected_keys": memory_injection.keys,
+            "memory_injected_bytes": memory_injection.bytes,
+        }
+    )
+
+
 def _request_llm_plan(
     db_path: str,
     user_text: str,
@@ -1205,6 +1281,7 @@ def _request_llm_plan(
     explain: bool,
     debug: bool,
     actor: str,
+    memory_injection: MemoryInjection | None = None,
     assessment_policy_path: str | None = None,
 ) -> tuple[dict, PlanAssessment, StateStore]:
     if not user_text or not user_text.strip():
@@ -1212,7 +1289,10 @@ def _request_llm_plan(
     config = resolve_ollama_config(url=host, model=model, timeout_s=timeout_s)
     state_store = StateStore(db_path)
     system_prompt = build_system_prompt()
-    user_prompt = build_user_prompt(user_text)
+    user_prompt = build_user_prompt(
+        user_text,
+        memory_block=memory_injection.block if memory_injection else None,
+    )
     print(f"LLM: {config.model} url={config.url} timeout={config.timeout_s}s")
     try:
         raw_response = ollama_chat(
@@ -1233,6 +1313,7 @@ def _request_llm_plan(
             "dry_run": dry_run,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
+        _apply_memory_injection_payload(payload, memory_injection)
         state_store.record_event(
             actor=actor,
             event_type=EVENT_TYPE_ASK_FAILED,
@@ -1268,6 +1349,7 @@ def _request_llm_plan(
                 "dry_run": dry_run,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
+            _apply_memory_injection_payload(payload, memory_injection)
             state_store.record_event(
                 actor=actor,
                 event_type=EVENT_TYPE_LLM_PLAN,
@@ -1296,6 +1378,7 @@ def _request_llm_plan(
             "dry_run": dry_run,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
+        _apply_memory_injection_payload(payload, memory_injection)
         state_store.record_event(
             actor=actor,
             event_type=EVENT_TYPE_LLM_PLAN,
@@ -1325,6 +1408,7 @@ def _request_llm_plan(
             "dry_run": dry_run,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
+        _apply_memory_injection_payload(payload, memory_injection)
         state_store.record_event(
             actor=actor,
             event_type=EVENT_TYPE_LLM_PLAN,
@@ -1347,6 +1431,7 @@ def _request_llm_plan(
         "dry_run": dry_run,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
+    _apply_memory_injection_payload(payload, memory_injection)
     state_store.record_event(
         actor=actor,
         event_type=EVENT_TYPE_LLM_PLAN,
@@ -1399,7 +1484,9 @@ def run_ask(
     yes: bool,
     explain: bool,
     debug: bool = False,
+    use_memory: bool = False,
 ) -> None:
+    memory_injection = _build_memory_injection(db_path) if use_memory else None
     plan, assessment, state_store = _request_llm_plan(
         db_path,
         user_text,
@@ -1412,6 +1499,7 @@ def run_ask(
         explain=explain,
         debug=debug,
         actor="ask",
+        memory_injection=memory_injection,
         assessment_policy_path=None,
     )
 
@@ -1842,6 +1930,7 @@ def _handle_ask(args: argparse.Namespace) -> None:
         yes=args.yes,
         explain=args.explain,
         debug=args.debug,
+        use_memory=args.use_memory,
     )
 
 
@@ -2837,6 +2926,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--enqueue",
         action="store_true",
         help="Enqueue validated actions for the daemon to execute",
+    )
+    ask_parser.add_argument(
+        "--memory",
+        dest="use_memory",
+        action="store_true",
+        help="Inject eligible memory items into the planner prompt (read-only)",
     )
     ask_parser.add_argument(
         "--yes",

--- a/gismo/llm/prompts.py
+++ b/gismo/llm/prompts.py
@@ -51,5 +51,7 @@ def build_system_prompt() -> str:
     )
 
 
-def build_user_prompt(user_text: str) -> str:
+def build_user_prompt(user_text: str, *, memory_block: str | None = None) -> str:
+    if memory_block:
+        return f"User request: {user_text}\n\n{memory_block}".strip()
     return f"User request: {user_text}".strip()

--- a/gismo/memory/store.py
+++ b/gismo/memory/store.py
@@ -378,6 +378,32 @@ class MemoryStore:
             connection.commit()
             return items
 
+    def list_prompt_items(self, *, limit: int = 20) -> list[MemoryItem]:
+        kinds = ["preference", "constraint", "procedure", "fact"]
+        confidences = ["high", "medium"]
+        kind_placeholders = ",".join("?" for _ in kinds)
+        confidence_placeholders = ",".join("?" for _ in confidences)
+        sql = (
+            "SELECT * FROM memory_items "
+            "WHERE is_tombstoned = 0 "
+            "AND (namespace = ? OR namespace LIKE ?) "
+            f"AND kind IN ({kind_placeholders}) "
+            f"AND confidence IN ({confidence_placeholders}) "
+            "ORDER BY updated_at DESC, key ASC "
+            "LIMIT ?"
+        )
+        params: list[Any] = [
+            "global",
+            "project:%",
+            *kinds,
+            *confidences,
+            limit,
+        ]
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            rows = cursor.execute(sql, params).fetchall()
+            return [_row_to_item(row) for row in rows]
+
     def tombstone_item(
         self,
         namespace: str,
@@ -521,7 +547,7 @@ def search_items(
     policy_hash: str,
     related_run_id: Optional[str] = None,
     related_ask_event_id: Optional[str] = None,
-) -> list[MemoryItem]:
+    ) -> list[MemoryItem]:
     return MemoryStore(db_path).search_items(
         query,
         namespace=namespace,
@@ -536,6 +562,14 @@ def search_items(
         related_run_id=related_run_id,
         related_ask_event_id=related_ask_event_id,
     )
+
+
+def list_prompt_items(
+    db_path: str,
+    *,
+    limit: int = 20,
+) -> list[MemoryItem]:
+    return MemoryStore(db_path).list_prompt_items(limit=limit)
 
 
 def tombstone_item(

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -2,6 +2,8 @@ import contextlib
 import io
 import json
 import os
+import re
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
@@ -10,6 +12,8 @@ from unittest import mock
 from gismo.cli import main as cli_main
 from gismo.core.models import EVENT_TYPE_ASK_FAILED, EVENT_TYPE_LLM_PLAN
 from gismo.core.state import StateStore
+from gismo.memory.store import put_item as memory_put_item
+from gismo.memory.store import tombstone_item as memory_tombstone_item
 
 
 class AskCliTest(unittest.TestCase):
@@ -761,6 +765,255 @@ class AskCliTest(unittest.TestCase):
             state_store = StateStore(db_path)
             items = state_store.list_queue_items(limit=20)
             self.assertEqual(len(items), 13)
+
+    def test_ask_without_memory_has_no_audit_metadata(self) -> None:
+        response = json.dumps({"intent": "noop", "assumptions": [], "actions": [], "notes": []})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    cli_main.run_ask(
+                        db_path,
+                        "noop",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=10,
+                        yes=False,
+                        explain=False,
+                    )
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            self.assertNotIn("memory_injection_enabled", payload)
+            self.assertNotIn("memory_injected_count", payload)
+
+    def test_ask_memory_injection_filters_and_orders(self) -> None:
+        response = json.dumps({"intent": "noop", "assumptions": [], "actions": [], "notes": []})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            memory_put_item(
+                db_path,
+                namespace="global",
+                key="alpha",
+                kind="fact",
+                value={"a": 1},
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash="test",
+            )
+            memory_put_item(
+                db_path,
+                namespace="project:alpha",
+                key="beta",
+                kind="preference",
+                value={"b": 2},
+                tags=None,
+                confidence="medium",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash="test",
+            )
+            memory_put_item(
+                db_path,
+                namespace="global",
+                key="gamma",
+                kind="note",
+                value={"c": 3},
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash="test",
+            )
+            memory_put_item(
+                db_path,
+                namespace="private",
+                key="delta",
+                kind="fact",
+                value={"d": 4},
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash="test",
+            )
+            memory_put_item(
+                db_path,
+                namespace="global",
+                key="epsilon",
+                kind="constraint",
+                value={"e": 5},
+                tags=None,
+                confidence="low",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash="test",
+            )
+            memory_put_item(
+                db_path,
+                namespace="project:alpha",
+                key="zeta",
+                kind="procedure",
+                value={"z": 6},
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash="test",
+            )
+            memory_tombstone_item(
+                db_path,
+                "project:alpha",
+                "zeta",
+                actor="test",
+                policy_hash="test",
+            )
+            with sqlite3.connect(db_path) as connection:
+                connection.execute(
+                    "UPDATE memory_items SET updated_at = ? WHERE namespace = ? AND key = ?",
+                    ("2024-01-02T00:00:00+00:00", "global", "alpha"),
+                )
+                connection.execute(
+                    "UPDATE memory_items SET updated_at = ? WHERE namespace = ? AND key = ?",
+                    ("2024-01-03T00:00:00+00:00", "project:alpha", "beta"),
+                )
+                connection.commit()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response) as mocked:
+                    cli_main.run_ask(
+                        db_path,
+                        "noop",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=10,
+                        yes=False,
+                        explain=False,
+                        use_memory=True,
+                    )
+            user_prompt = mocked.call_args[0][0]
+            match = re.search(
+                r"<<<< MEMORY READ ONLY >>>>\n(.*)\n<<<< END MEMORY >>>>",
+                user_prompt,
+                re.DOTALL,
+            )
+            assert match is not None
+            entries = json.loads(match.group(1))
+            self.assertEqual([entry["key"] for entry in entries], ["beta", "alpha"])
+            self.assertEqual(entries[0]["namespace"], "project:alpha")
+            self.assertEqual(entries[1]["namespace"], "global")
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            self.assertTrue(payload["memory_injection_enabled"])
+            self.assertEqual(payload["memory_injected_count"], 2)
+            self.assertEqual(
+                payload["memory_injected_keys"],
+                [{"namespace": "project:alpha", "key": "beta"}, {"namespace": "global", "key": "alpha"}],
+            )
+            self.assertLessEqual(payload["memory_injected_bytes"], 8192)
+            os.remove(db_path)
+
+    def test_ask_memory_enforces_item_and_byte_caps(self) -> None:
+        response = json.dumps({"intent": "noop", "assumptions": [], "actions": [], "notes": []})
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            for index in range(25):
+                memory_put_item(
+                    db_path,
+                    namespace="global",
+                    key=f"k{index:02d}",
+                    kind="fact",
+                    value={"blob": "x" * 1000},
+                    tags=None,
+                    confidence="high",
+                    source="operator",
+                    ttl_seconds=None,
+                    actor="test",
+                    policy_hash="test",
+                )
+            with sqlite3.connect(db_path) as connection:
+                connection.execute(
+                    "UPDATE memory_items SET updated_at = ? WHERE namespace = ?",
+                    ("2024-01-04T00:00:00+00:00", "global"),
+                )
+                connection.commit()
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response) as mocked:
+                    cli_main.run_ask(
+                        db_path,
+                        "noop",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=10,
+                        yes=False,
+                        explain=False,
+                        use_memory=True,
+                    )
+            user_prompt = mocked.call_args[0][0]
+            match = re.search(
+                r"<<<< MEMORY READ ONLY >>>>\n(.*)\n<<<< END MEMORY >>>>",
+                user_prompt,
+                re.DOTALL,
+            )
+            assert match is not None
+            entries = json.loads(match.group(1))
+            keys = [entry["key"] for entry in entries]
+            self.assertLessEqual(len(entries), 20)
+            self.assertEqual(keys, sorted(keys))
+            state_store = StateStore(db_path)
+            payload = state_store.list_events()[0].json_payload
+            assert payload is not None
+            self.assertLessEqual(payload["memory_injected_bytes"], 8192)
+            self.assertEqual(payload["memory_injected_count"], len(entries))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Improve LLM planning by optionally providing a deterministic, read-only memory context to the planner so plans are better grounded. 
- Keep planner side-effects strictly read-only and deny-by-default so no memory writes occur from `ask`/planner/agent paths. 
- Ensure memory context is auditable, bounded, and deterministic to preserve reproducibility and Windows-safe DB behavior. 

### Description
- Added `--memory` flag to `gismo ask` (cli: `--memory`, stored as `use_memory`) which, when enabled, injects a clearly delimited read-only memory block into the planner prompt. 
- Implemented `MemoryStore.list_prompt_items` and `list_prompt_items` helper to deterministically select items with filters: `namespace IN {"global"} OR namespace LIKE "project:%"`, `kind IN {"preference","constraint","procedure","fact"}`, `confidence IN {"high","medium"`, `is_tombstoned = false`, ordered by `updated_at DESC, key ASC`. 
- Enforced hard caps: at most 20 items and a serialized byte cap of 8192 (truncate list, not items), serialized entries include `namespace,key,kind,confidence,source,updated_at,value_json`, and composed prompt block is annotated as read-only. 
- Augmented ask audit events to include `memory_injection_enabled`, `memory_injected_count`, `memory_injected_keys` (array of `{namespace,key}`), and `memory_injected_bytes`; no memory writes are performed during reads. 

### Testing
- New unit tests added in `tests/test_ask_cli.py` cover that `ask` without `--memory` produces no memory metadata, `ask --memory` injects eligible items in deterministic order and excludes tombstoned/low-confidence items, and caps item count and bytes; these tests pass. 
- Ran repository validation with `python scripts/verify.py`, which completed successfully (all tests passed). 
- Existing Windows-oriented DB pragmas/connection patterns were reused to avoid DB locks and ensure temporary DB cleanup works on Windows, verified by the test suite run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd46f892483308a61b3f83a36dd66)