### PR TITLE
Add --apply-memory-suggestions to gismo ask (interactive, policy-gated, audited)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -171,14 +171,13 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added policy + confirmation gating for memory put/delete operations in the CLI.
-- Audited memory decision outcomes (allowed/denied/confirmed) in memory events.
-- Added optional ask --memory prompt injection with deterministic filters, bounds, and audit metadata.
-- Added advisory ask memory suggestions in plan output with validation, bounds, and explicit apply commands.
+- Added ask --apply-memory-suggestions to apply vetted memory suggestions with policy + confirmation gates.
+- Linked applied memory events back to the originating ask audit event for traceability.
+- Added ask audit metadata for applied/skipped/denied memory suggestions.
 
 Next steps:
 - Extend policy samples if new memory namespaces are introduced.
-- Validate memory prompt injection ordering against real operator datasets.
+- Validate memory suggestion workflows with operator review cycles.
 - Re-run Windows validation on a native host before release tagging.
 - Consider sample workflows for operator-reviewed memory suggestions.
 
@@ -190,7 +189,7 @@ Operator examples:
 - python -m gismo.cli.main --db .\tmp\dev.db runs list
 - python -m gismo.cli.main --db .\tmp\dev.db runs show RUN_ID
 - python -m gismo.cli.main --db .\tmp\dev.db export RUN_ID
- - python -m gismo.cli.main --db .\tmp\dev.db agent "Summarize last 10 queue failures" --dry-run
+- python -m gismo.cli.main --db .\tmp\dev.db agent "Summarize last 10 queue failures" --dry-run
 
 -------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Planner (local LLM via Ollama):
   gismo ask "Summarize the last 10 queue failures" --dry-run
   gismo ask "Do X safely" --enqueue
   gismo ask "Plan with memory context" --dry-run --memory
+  gismo ask "Remember the default model" --apply-memory-suggestions \
+    --policy policy/dev-safe.json --yes
 
 Agent loop (leashed autonomy):
 
@@ -157,6 +159,7 @@ Planner behavior:
 - Actions are bounded (hard limit on action count).
 - Normalization/coercion exists so malformed model output does not break the system.
 - Optional memory suggestions may be included in plan output for operator review (advisory only; no auto-write).
+- Use --apply-memory-suggestions to write memory items from validated suggestions (policy-gated).
 - Ollama is called in JSON mode and uses keep_alive to avoid repeated model reloads.
 - Full audit trail is recorded for planner outputs and execution.
 - Every plan includes a confidence assessment, risk flags, and a short explanation.
@@ -164,6 +167,7 @@ Planner behavior:
 - --explain prints additional assessment details.
 - Use --debug to print tracebacks for ask failures.
 - --memory injects eligible read-only memory context into the planner prompt (bounded, audited).
+- --apply-memory-suggestions writes memory_suggestions after policy + confirmation checks. Use --yes to auto-confirm.
 
 Planner configuration:
 - Increase --timeout-s on CPU machines (60s baseline) if prompts time out.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from gismo.cli.operator import (
     make_idempotency_key,
@@ -936,6 +936,15 @@ class MemoryDecision:
     reason: str | None
 
 
+@dataclass
+class MemoryApplyResult:
+    applied: int
+    skipped: int
+    denied: int
+    applied_items: list[dict[str, str]]
+    exit_code: int | None = None
+
+
 def _memory_policy_hash(policy_path: str | None) -> str:
     try:
         return policy_hash_for_path(policy_path)
@@ -968,6 +977,197 @@ def _memory_policy_result_meta(decision: MemoryDecision) -> dict[str, object]:
             "mode": decision.confirmation_mode,
         },
     }
+
+
+def _memory_request_from_suggestion(
+    suggestion: dict[str, str],
+    *,
+    value: object,
+    source: str,
+) -> dict[str, object]:
+    return {
+        "namespace": suggestion["namespace"],
+        "key": suggestion["key"],
+        "kind": suggestion["kind"],
+        "value_json": json.dumps(value, ensure_ascii=False, sort_keys=True),
+        "tags_json": None,
+        "confidence": suggestion["confidence"],
+        "source": source,
+        "ttl_seconds": None,
+    }
+
+
+def _apply_memory_suggestions(
+    db_path: str,
+    suggestions: list[dict[str, str]],
+    *,
+    policy_path: str | None,
+    yes: bool,
+    non_interactive: bool,
+    related_ask_event_id: str,
+) -> MemoryApplyResult:
+    if not suggestions:
+        return MemoryApplyResult(applied=0, skipped=0, denied=0, applied_items=[])
+    actor = "ask"
+    policy, resolved_policy_path = _load_memory_policy(policy_path)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
+    action = "memory.put"
+    result = MemoryApplyResult(applied=0, skipped=0, denied=0, applied_items=[])
+    candidates: list[tuple[dict[str, str], object, MemoryDecision]] = []
+    for suggestion in suggestions:
+        value = json.loads(suggestion["value_json"])
+        decision = _evaluate_memory_policy(policy, action, suggestion["namespace"])
+        candidates.append((suggestion, value, decision))
+        if not decision.allowed:
+            memory_record_event(
+                db_path,
+                operation="put",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=_memory_request_from_suggestion(
+                    suggestion,
+                    value=value,
+                    source="llm",
+                ),
+                result_meta=_memory_policy_result_meta(decision),
+                related_ask_event_id=related_ask_event_id,
+            )
+            result.denied += 1
+
+    allowed = [
+        (suggestion, value, decision)
+        for suggestion, value, decision in candidates
+        if decision.allowed
+    ]
+    if not allowed:
+        return result
+
+    confirm_needed = [
+        (suggestion, value, decision)
+        for suggestion, value, decision in allowed
+        if decision.confirmation_required
+    ]
+    if confirm_needed and not yes:
+        if non_interactive or not _is_interactive_tty():
+            for suggestion, value, _decision in confirm_needed:
+                denied = MemoryDecision(
+                    action=action,
+                    allowed=False,
+                    confirmation_required=True,
+                    confirmation_provided=False,
+                    confirmation_mode=None,
+                    reason="confirmation_required",
+                )
+                memory_record_event(
+                    db_path,
+                    operation="put",
+                    actor=actor,
+                    policy_hash=policy_hash,
+                    request=_memory_request_from_suggestion(
+                        suggestion,
+                        value=value,
+                        source="llm",
+                    ),
+                    result_meta=_memory_policy_result_meta(denied),
+                    related_ask_event_id=related_ask_event_id,
+                )
+                result.denied += 1
+            result.skipped += len(allowed) - len(confirm_needed)
+            result.exit_code = 2
+            return result
+        if len(confirm_needed) == len(allowed) and len(confirm_needed) > 1:
+            response = input("Apply all memory suggestions? [y/N]:")
+            if response.strip().lower() not in {"y", "yes"}:
+                for suggestion, value, _decision in confirm_needed:
+                    denied = MemoryDecision(
+                        action=action,
+                        allowed=False,
+                        confirmation_required=True,
+                        confirmation_provided=False,
+                        confirmation_mode=None,
+                        reason="confirmation_declined",
+                    )
+                    memory_record_event(
+                        db_path,
+                        operation="put",
+                        actor=actor,
+                        policy_hash=policy_hash,
+                        request=_memory_request_from_suggestion(
+                            suggestion,
+                            value=value,
+                            source="llm",
+                        ),
+                        result_meta=_memory_policy_result_meta(denied),
+                        related_ask_event_id=related_ask_event_id,
+                    )
+                    result.denied += 1
+                return result
+            for _suggestion, _value, decision in confirm_needed:
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "prompt"
+        else:
+            for suggestion, value, decision in confirm_needed:
+                response = input(
+                    f"Apply memory suggestion {suggestion['namespace']}/{suggestion['key']}? [y/N]:"
+                )
+                if response.strip().lower() not in {"y", "yes"}:
+                    denied = MemoryDecision(
+                        action=action,
+                        allowed=False,
+                        confirmation_required=True,
+                        confirmation_provided=False,
+                        confirmation_mode=None,
+                        reason="confirmation_declined",
+                    )
+                    memory_record_event(
+                        db_path,
+                        operation="put",
+                        actor=actor,
+                        policy_hash=policy_hash,
+                        request=_memory_request_from_suggestion(
+                            suggestion,
+                            value=value,
+                            source="llm",
+                        ),
+                        result_meta=_memory_policy_result_meta(denied),
+                        related_ask_event_id=related_ask_event_id,
+                    )
+                    result.denied += 1
+                    decision.allowed = False
+                else:
+                    decision.confirmation_provided = True
+                    decision.confirmation_mode = "prompt"
+    elif confirm_needed and yes:
+        for _suggestion, _value, decision in confirm_needed:
+            decision.confirmation_provided = True
+            decision.confirmation_mode = "yes-flag"
+
+    for suggestion, value, decision in allowed:
+        if not decision.allowed:
+            continue
+        if decision.confirmation_required and not decision.confirmation_provided:
+            result.skipped += 1
+            continue
+        item = memory_put_item(
+            db_path,
+            namespace=suggestion["namespace"],
+            key=suggestion["key"],
+            kind=suggestion["kind"],
+            value=value,
+            tags=None,
+            confidence=suggestion["confidence"],
+            source="llm",
+            ttl_seconds=None,
+            actor=actor,
+            policy_hash=policy_hash,
+            result_meta_extra=_memory_policy_result_meta(decision),
+            related_ask_event_id=related_ask_event_id,
+        )
+        result.applied += 1
+        result.applied_items.append(
+            {"namespace": item.namespace, "key": item.key}
+        )
+    return result
 
 
 def _evaluate_memory_policy(policy: PermissionPolicy, action: str, namespace: str) -> MemoryDecision:
@@ -1399,7 +1599,8 @@ def _request_llm_plan(
     actor: str,
     memory_injection: MemoryInjection | None = None,
     assessment_policy_path: str | None = None,
-) -> tuple[dict, PlanAssessment, StateStore]:
+    record_event: bool = True,
+) -> tuple[dict, PlanAssessment, StateStore, dict[str, object]]:
     if not user_text or not user_text.strip():
         raise ValueError(f"{actor} requires a natural language request.")
     config = resolve_ollama_config(url=host, model=model, timeout_s=timeout_s)
@@ -1548,13 +1749,14 @@ def _request_llm_plan(
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     _apply_memory_injection_payload(payload, memory_injection)
-    state_store.record_event(
-        actor=actor,
-        event_type=EVENT_TYPE_LLM_PLAN,
-        message="LLM plan generated.",
-        json_payload=payload,
-    )
-    return plan, assessment, state_store
+    if record_event:
+        state_store.record_event(
+            actor=actor,
+            event_type=EVENT_TYPE_LLM_PLAN,
+            message="LLM plan generated.",
+            json_payload=payload,
+        )
+    return plan, assessment, state_store, payload
 
 
 def _enqueue_plan_actions(
@@ -1601,9 +1803,12 @@ def run_ask(
     explain: bool,
     debug: bool = False,
     use_memory: bool = False,
+    apply_memory_suggestions: bool = False,
+    non_interactive: bool = False,
+    policy_path: str | None = None,
 ) -> None:
     memory_injection = _build_memory_injection(db_path) if use_memory else None
-    plan, assessment, state_store = _request_llm_plan(
+    plan, assessment, state_store, payload = _request_llm_plan(
         db_path,
         user_text,
         model=model,
@@ -1617,7 +1822,94 @@ def run_ask(
         actor="ask",
         memory_injection=memory_injection,
         assessment_policy_path=None,
+        record_event=False,
     )
+
+    apply_result = MemoryApplyResult(
+        applied=0,
+        skipped=0,
+        denied=0,
+        applied_items=[],
+    )
+    if apply_memory_suggestions:
+        suggestions = plan.get("memory_suggestions") or []
+        if not suggestions:
+            print("No suggestions to apply")
+        else:
+            ask_event_id = str(uuid4())
+            apply_result = _apply_memory_suggestions(
+                db_path,
+                suggestions,
+                policy_path=policy_path,
+                yes=yes,
+                non_interactive=non_interactive,
+                related_ask_event_id=ask_event_id,
+            )
+            payload.update(
+                {
+                    "apply_memory_suggestions_requested": True,
+                    "apply_memory_suggestions_result": {
+                        "applied": apply_result.applied,
+                        "skipped": apply_result.skipped,
+                        "denied": apply_result.denied,
+                    },
+                    "apply_memory_suggestions_applied": apply_result.applied_items,
+                }
+            )
+            state_store.record_event(
+                actor="ask",
+                event_type=EVENT_TYPE_LLM_PLAN,
+                message="LLM plan generated.",
+                json_payload=payload,
+                event_id=ask_event_id,
+            )
+            print(
+                "Memory suggestions summary: "
+                f"applied={apply_result.applied} "
+                f"skipped={apply_result.skipped} "
+                f"denied={apply_result.denied}"
+            )
+            if apply_result.exit_code is not None:
+                raise SystemExit(apply_result.exit_code)
+        if not suggestions:
+            payload.update(
+                {
+                    "apply_memory_suggestions_requested": True,
+                    "apply_memory_suggestions_result": {
+                        "applied": 0,
+                        "skipped": 0,
+                        "denied": 0,
+                    },
+                    "apply_memory_suggestions_applied": [],
+                }
+            )
+            state_store.record_event(
+                actor="ask",
+                event_type=EVENT_TYPE_LLM_PLAN,
+                message="LLM plan generated.",
+                json_payload=payload,
+                event_id=str(uuid4()),
+            )
+            return
+
+    if not apply_memory_suggestions:
+        payload.update(
+            {
+                "apply_memory_suggestions_requested": False,
+                "apply_memory_suggestions_result": {
+                    "applied": 0,
+                    "skipped": 0,
+                    "denied": 0,
+                },
+                "apply_memory_suggestions_applied": [],
+            }
+        )
+        state_store.record_event(
+            actor="ask",
+            event_type=EVENT_TYPE_LLM_PLAN,
+            message="LLM plan generated.",
+            json_payload=payload,
+        )
 
     if not enqueue:
         return
@@ -1716,7 +2008,7 @@ def run_agent(
     last_actions_count = 0
     for cycle in range(1, cycles_limit + 1):
         print(f"=== Agent Cycle {cycle} ===")
-        plan, assessment, state_store = _request_llm_plan(
+        plan, assessment, state_store, _payload = _request_llm_plan(
             db_path,
             goal_text,
             model=None,
@@ -2047,6 +2339,9 @@ def _handle_ask(args: argparse.Namespace) -> None:
         explain=args.explain,
         debug=args.debug,
         use_memory=args.use_memory,
+        apply_memory_suggestions=args.apply_memory_suggestions,
+        non_interactive=args.non_interactive,
+        policy_path=args.policy,
     )
 
 
@@ -3050,9 +3345,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Inject eligible memory items into the planner prompt (read-only)",
     )
     ask_parser.add_argument(
+        "--apply-memory-suggestions",
+        action="store_true",
+        help="Apply memory suggestions from the plan (policy-gated)",
+    )
+    ask_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file for memory writes",
+    )
+    ask_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting for memory suggestions",
+    )
+    ask_parser.add_argument(
         "--yes",
         action="store_true",
-        help="Skip confirmation prompts for enqueue actions",
+        help="Skip confirmation prompts for enqueue actions and memory suggestions",
     )
     ask_parser.add_argument(
         "--explain",

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
+from uuid import uuid4
 
 from gismo.core.models import (
     DaemonHeartbeat,
@@ -326,6 +327,7 @@ class StateStore:
         event_type: str,
         message: str,
         json_payload: Optional[Dict[str, Any]] = None,
+        event_id: Optional[str] = None,
         connection: Optional[sqlite3.Connection] = None,
     ) -> Event:
         if connection is None:
@@ -335,6 +337,7 @@ class StateStore:
                     event_type,
                     message,
                     json_payload,
+                    event_id=event_id,
                     connection=connection,
                 )
                 connection.commit()
@@ -345,6 +348,7 @@ class StateStore:
             event_type=event_type,
             message=message,
             json_payload=json_payload,
+            id=event_id or str(uuid4()),
         )
         connection.execute(
             """

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -17,6 +17,11 @@ from gismo.memory.store import tombstone_item as memory_tombstone_item
 
 
 class AskCliTest(unittest.TestCase):
+    def _write_policy(self, tmpdir: str, policy: dict) -> str:
+        path = Path(tmpdir) / "policy.json"
+        path.write_text(json.dumps(policy), encoding="utf-8")
+        return str(path)
+
     def test_ask_dry_run_writes_event_and_prints_plan(self) -> None:
         response = json.dumps(
             {
@@ -357,6 +362,217 @@ class AskCliTest(unittest.TestCase):
                     "SELECT COUNT(*) FROM memory_items"
                 ).fetchone()[0]
             self.assertEqual(initial_count, final_count)
+
+    def test_ask_apply_memory_suggestions_writes_items_and_links_audit(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "default_model",
+                        "kind": "preference",
+                        "value_json": "\"phi3:mini\"",
+                        "confidence": "high",
+                        "why": "Operator prefers the default model.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_path = self._write_policy(
+                tmpdir,
+                {
+                    "allowed_tools": ["memory.put"],
+                    "memory": {"allow": {"memory.put": ["global"]}},
+                },
+            )
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    cli_main.run_ask(
+                        db_path,
+                        "remember the model",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=10,
+                        yes=True,
+                        explain=False,
+                        apply_memory_suggestions=True,
+                        policy_path=policy_path,
+                    )
+            with sqlite3.connect(db_path) as connection:
+                item_count = connection.execute(
+                    "SELECT COUNT(*) FROM memory_items"
+                ).fetchone()[0]
+                event_row = connection.execute(
+                    "SELECT related_ask_event_id, result_meta_json FROM memory_events"
+                ).fetchone()
+            self.assertEqual(item_count, 1)
+            self.assertIsNotNone(event_row)
+            related_ask_event_id, result_meta_json = event_row
+            self.assertIsNotNone(related_ask_event_id)
+            result_meta = json.loads(result_meta_json)
+            self.assertEqual(result_meta["policy_action"], "memory.put")
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            self.assertEqual(event.id, related_ask_event_id)
+            payload = event.json_payload
+            assert payload is not None
+            self.assertTrue(payload["apply_memory_suggestions_requested"])
+            self.assertEqual(payload["apply_memory_suggestions_result"]["applied"], 1)
+            self.assertEqual(
+                payload["apply_memory_suggestions_applied"],
+                [{"namespace": "global", "key": "default_model"}],
+            )
+
+    def test_ask_apply_memory_suggestions_requires_confirmation_interactive(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "operator_pref",
+                        "kind": "preference",
+                        "value_json": "\"fast\"",
+                        "confidence": "high",
+                        "why": "Operator prefers speed.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_path = self._write_policy(
+                tmpdir,
+                {
+                    "allowed_tools": ["memory.put"],
+                    "memory": {
+                        "allow": {"memory.put": ["global"]},
+                        "require_confirmation": {"memory.put": ["global"]},
+                    },
+                },
+            )
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch("builtins.input", return_value="y"), mock.patch(
+                        "sys.stdin.isatty",
+                        return_value=True,
+                    ), mock.patch("sys.stdout.isatty", return_value=True):
+                        cli_main.run_ask(
+                            db_path,
+                            "remember preference",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=False,
+                            dry_run=True,
+                            max_actions=10,
+                            yes=False,
+                            explain=False,
+                            apply_memory_suggestions=True,
+                            policy_path=policy_path,
+                        )
+            with sqlite3.connect(db_path) as connection:
+                item_count = connection.execute(
+                    "SELECT COUNT(*) FROM memory_items"
+                ).fetchone()[0]
+            self.assertEqual(item_count, 1)
+
+    def test_ask_apply_memory_suggestions_non_interactive_fails_closed(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "operator_pref",
+                        "kind": "preference",
+                        "value_json": "\"safe\"",
+                        "confidence": "high",
+                        "why": "Operator prefers safety.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_path = self._write_policy(
+                tmpdir,
+                {
+                    "allowed_tools": ["memory.put"],
+                    "memory": {
+                        "allow": {"memory.put": ["global"]},
+                        "require_confirmation": {"memory.put": ["global"]},
+                    },
+                },
+            )
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with self.assertRaises(SystemExit):
+                        cli_main.run_ask(
+                            db_path,
+                            "remember preference",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=False,
+                            dry_run=True,
+                            max_actions=10,
+                            yes=False,
+                            explain=False,
+                            apply_memory_suggestions=True,
+                            non_interactive=True,
+                            policy_path=policy_path,
+                        )
+            with sqlite3.connect(db_path) as connection:
+                item_count = connection.execute(
+                    "SELECT COUNT(*) FROM memory_items"
+                ).fetchone()[0]
+            self.assertEqual(item_count, 0)
 
     def test_ask_invalid_json_fails_cleanly(self) -> None:
         response = "not json"


### PR DESCRIPTION
### Motivation
- Provide a controlled operator path to persist LLM-produced `memory_suggestions` while preserving existing policy gating, confirmation workflows, and auditability.
- Keep default behavior unchanged: `gismo ask` remains read-only unless the operator explicitly requests apply.
- Fail closed in non-interactive contexts when confirmation would be required for any suggestion.
- Ensure every applied suggestion is auditable and linked back to the originating ask event for traceability.

### Description
- Added CLI flags to the `ask` subcommand: `--apply-memory-suggestions`, `--policy`, and `--non-interactive`, and extended `--yes` to cover suggestion confirmation.
- Implemented `_apply_memory_suggestions` which evaluates per-suggestion policy via `_evaluate_memory_policy`, prompts (single or per-item) when confirmation is required, writes items via `memory_put_item`, and records `memory_events` with `related_ask_event_id` linkage.
- Changed planner flow to return the plan payload without auto-recording so the ask handler can annotate and write a single ask event (with `event_id`) that links to any created memory events; added optional `event_id` support to `StateStore.record_event`.
- Tests and docs: added unit tests covering successful apply, interactive confirmation, and non-interactive fail-closed behavior, and updated `README.md` and `Handoff.md` to document the new flag and status.

### Testing
- Ran the repository verification: `python scripts/verify.py` and it completed successfully (skipped tests are expected on this platform).
- Ran the full test suite: `pytest -q` which passed: `145 passed, 3 skipped`.
- New tests added: `tests/test_ask_cli.py` cases for applying suggestions, interactive confirmation, and non-interactive fail-closed, and they passed as part of the suite.
- No automated test failures were introduced; CLI/daemon orchestration behavior remains unchanged for enqueue/agent flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bda4341b8833096c0693009779751)