### PR TITLE
Add Windows SQLite handle guardrail tests (fail on ResourceWarning, assert DB deletable)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -171,12 +171,11 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added explicit StateStore/MemoryStore close paths in CLI flows to avoid SQLite handle leaks on Windows.
-- Updated Ollama client payload test to force python transport for request capture.
+- Added Windows SQLite handle guardrail tests covering ask/memory CLI flows.
 
 Next steps:
 - Run Windows CI or native Windows smoke tests to confirm SQLite handles close cleanly.
-- Re-run full verify.py and pytest on Windows to confirm no resource warnings.
+- Run pytest -q on Windows to ensure ResourceWarning is surfaced as errors in guardrails.
 
 Tests run:
 - python scripts/verify.py

--- a/tests/test_db_handle_guardrails.py
+++ b/tests/test_db_handle_guardrails.py
@@ -1,0 +1,203 @@
+import contextlib
+import gc
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+from unittest import mock
+
+from gismo.cli import main as cli_main
+from gismo.memory import policy_hash_for_path
+from gismo.memory.store import put_item as memory_put_item
+
+
+class DbHandleGuardrailsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.policy_path = self.repo_root / "policy" / "dev-safe.json"
+
+    def _run_cli(self, args: list[str]) -> None:
+        with mock.patch.object(sys, "argv", ["gismo", *args]):
+            with contextlib.redirect_stdout(io.StringIO()):
+                with contextlib.redirect_stderr(io.StringIO()):
+                    cli_main.main()
+
+    def _run_ask(self, db_path: Path, args: list[str], response: str) -> None:
+        env = {
+            "GISMO_OLLAMA_MODEL": "",
+            "GISMO_OLLAMA_TIMEOUT_S": "",
+            "GISMO_OLLAMA_URL": "",
+            "GISMO_LLM_MODEL": "",
+            "OLLAMA_HOST": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                self._run_cli(["--db", str(db_path), "ask", *args])
+
+    def _write_policy(self, tmpdir: str, policy: dict[str, object]) -> Path:
+        path = Path(tmpdir) / "policy.json"
+        path.write_text(json.dumps(policy), encoding="utf-8")
+        return path
+
+    def _assert_db_deletable(self, db_path: Path) -> None:
+        self.assertTrue(db_path.exists())
+        try:
+            os.remove(db_path)
+        except OSError as exc:
+            self.fail(f"Expected DB path to be deletable, got error: {exc}")
+        self.assertFalse(db_path.exists())
+
+    def test_ask_dry_run_releases_db_handle(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "greet",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                self._run_ask(db_path, ["--dry-run", "say", "hello"], response)
+                gc.collect()
+                self._assert_db_deletable(db_path)
+
+    def test_ask_memory_dry_run_releases_db_handle(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "recall",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                self._run_ask(
+                    db_path,
+                    ["--memory", "--dry-run", "remember", "context"],
+                    response,
+                )
+                gc.collect()
+                self._assert_db_deletable(db_path)
+
+    def test_memory_put_releases_db_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                self._run_cli(
+                    [
+                        "memory",
+                        "put",
+                        "--db",
+                        str(db_path),
+                        "--policy",
+                        str(self.policy_path),
+                        "--namespace",
+                        "global",
+                        "--key",
+                        "default_model",
+                        "--kind",
+                        "preference",
+                        "--value-text",
+                        "phi3:mini",
+                        "--confidence",
+                        "high",
+                        "--source",
+                        "operator",
+                        "--yes",
+                    ]
+                )
+                gc.collect()
+                self._assert_db_deletable(db_path)
+
+    def test_memory_get_releases_db_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            policy_hash = policy_hash_for_path(str(self.policy_path))
+            memory_put_item(
+                str(db_path),
+                namespace="global",
+                key="default_model",
+                kind="preference",
+                value="phi3:mini",
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash=policy_hash,
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                self._run_cli(
+                    [
+                        "memory",
+                        "get",
+                        "--db",
+                        str(db_path),
+                        "--policy",
+                        str(self.policy_path),
+                        "--namespace",
+                        "global",
+                        "--json",
+                        "default_model",
+                    ]
+                )
+                gc.collect()
+                self._assert_db_deletable(db_path)
+
+    def test_ask_apply_memory_suggestions_releases_db_handle(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "default_model",
+                        "kind": "preference",
+                        "value_json": "\"phi3:mini\"",
+                        "confidence": "high",
+                        "why": "Operator prefers the default model.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            policy_path = self._write_policy(
+                tmpdir,
+                {
+                    "allowed_tools": ["memory.put"],
+                    "memory": {"allow": {"memory.put": ["global"]}},
+                },
+            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                self._run_ask(
+                    db_path,
+                    [
+                        "--apply-memory-suggestions",
+                        "--yes",
+                        "--dry-run",
+                        "--policy",
+                        str(policy_path),
+                        "remember",
+                        "model",
+                    ],
+                    response,
+                )
+                gc.collect()
+                self._assert_db_deletable(db_path)


### PR DESCRIPTION
### Motivation
- Prevent regressions where CLI commands leave SQLite connections open on Windows causing `WinError 32` or `ResourceWarning: unclosed database`.
- Make ResourceWarnings fail the test run so handle leaks are visible early via CI and local verification.
- Validate representative CLI flows that touch the DB (ask, memory put/get, apply-memory-suggestions) release their handles.
- Keep scope limited to tests only with no functional changes to GISMO runtime behavior.

### Description
- Add `tests/test_db_handle_guardrails.py` which runs in-process CLI invocations for `ask --dry-run`, `ask --memory --dry-run`, `memory put ... --yes`, `memory get ...`, and `ask --apply-memory-suggestions --yes` with a mocked LLM response.
- Each test sets `warnings.simplefilter("error", ResourceWarning)`, invokes the CLI, runs `gc.collect()`, and immediately asserts the DB file can be removed with `os.remove(db_path)` to ensure no open handles.
- Include small test harness helpers (`_run_cli`, `_run_ask`, `_assert_db_deletable`, `_write_policy`) inside the test module only (no production code changes).
- Update `Handoff.md` to record the new guardrail tests and next steps; no code or dependency changes were made.

### Testing
- Ran the full verification: `python scripts/verify.py`, which completed successfully (test suite run during verification reported passing tests).
- The new guardrail tests exercised the CLI flows and passed under the verification run, surfacing no `ResourceWarning` failures.
- The test harness uses mocked LLM responses and in-process CLI invocation to make the checks deterministic and fast.
- Note: these tests are intended to catch in-process handle leaks; they will not detect leaks from separate external processes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1fab402083308c46ef935cb406ee)