### PR TITLE
Integrate memory context & gated suggestions into agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,5 +145,6 @@ The default “proof of life” for GISMO is a CLI demo that:
 
 Leashed autonomy:
 - The `agent` CLI loop must only plan → enqueue → execute via the queue/daemon and keep confirmation gates intact.
+- Agent memory context injection and suggestion application are optional, gated behaviors; defaults remain read-only unless explicitly enabled.
 
 If a change breaks this, it is not acceptable without explicit approval.

--- a/Handoff.md
+++ b/Handoff.md
@@ -161,6 +161,7 @@ Leashed agent loop:
 - Added `agent` CLI to turn a goal into a plan, enqueue it, and execute via the daemon.
 - Confirmation gates now apply to high-risk plans and any shell/write actions.
 - Agent summaries report confidence, risk flags, run IDs, and final status.
+- Agent memory handling now mirrors `ask` (read-only context injection, advisory suggestions, gated apply).
 
 This is a controlled autonomy feature and should be treated as guarded behavior.
 
@@ -171,11 +172,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added Windows SQLite handle guardrail tests covering ask/memory CLI flows.
+- Added agent memory flags for read-only context injection and gated suggestion application.
+- Agent memory suggestion application links audit events to the originating plan.
 
 Next steps:
-- Run Windows CI or native Windows smoke tests to confirm SQLite handles close cleanly.
-- Run pytest -q on Windows to ensure ResourceWarning is surfaced as errors in guardrails.
+- Run Windows CI or native Windows smoke tests to confirm parity with `ask` memory behavior.
+- Run pytest -q on Windows to confirm agent memory tests and guardrails remain stable.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -149,10 +149,15 @@ Agent loop (leashed autonomy):
   gismo agent "Summarize the last 10 queue failures" --dry-run
   gismo agent "Do X safely" --once
   gismo agent "Do X safely" --max-cycles 3 --yes
+  gismo agent "Plan with memory context" --dry-run --memory
+  gismo agent "Apply memory suggestions" --dry-run --apply-memory-suggestions \
+    --policy policy/dev-safe.json --yes
 
 Agent notes:
 - The agent loop is leashed autonomy: it plans, enqueues, and executes only through the queue/daemon.
 - Confirmation is required for high-risk plans or any shell/write actions unless --yes is provided.
+- Memory context and suggestion handling mirror `ask`: suggestions are advisory unless
+  --apply-memory-suggestions is set (policy/confirmation-gated; use --non-interactive to fail closed).
 
 Planner behavior:
 - Produces enqueue-only plans under strict schema.

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -1039,11 +1039,11 @@ def _apply_memory_suggestions(
     policy_path: str | None,
     yes: bool,
     non_interactive: bool,
-    related_ask_event_id: str,
+    related_event_id: str,
+    actor: str,
 ) -> MemoryApplyResult:
     if not suggestions:
         return MemoryApplyResult(applied=0, skipped=0, denied=0, applied_items=[])
-    actor = "ask"
     policy, resolved_policy_path = _load_memory_policy(policy_path)
     policy_hash = _memory_policy_hash(resolved_policy_path)
     action = "memory.put"
@@ -1065,7 +1065,7 @@ def _apply_memory_suggestions(
                     source="llm",
                 ),
                 result_meta=_memory_policy_result_meta(decision),
-                related_ask_event_id=related_ask_event_id,
+                related_ask_event_id=related_event_id,
             )
             result.denied += 1
 
@@ -1104,7 +1104,7 @@ def _apply_memory_suggestions(
                         source="llm",
                     ),
                     result_meta=_memory_policy_result_meta(denied),
-                    related_ask_event_id=related_ask_event_id,
+                    related_ask_event_id=related_event_id,
                 )
                 result.denied += 1
             result.skipped += len(allowed) - len(confirm_needed)
@@ -1133,7 +1133,7 @@ def _apply_memory_suggestions(
                             source="llm",
                         ),
                         result_meta=_memory_policy_result_meta(denied),
-                        related_ask_event_id=related_ask_event_id,
+                        related_ask_event_id=related_event_id,
                     )
                     result.denied += 1
                 return result
@@ -1165,7 +1165,7 @@ def _apply_memory_suggestions(
                             source="llm",
                         ),
                         result_meta=_memory_policy_result_meta(denied),
-                        related_ask_event_id=related_ask_event_id,
+                        related_ask_event_id=related_event_id,
                     )
                     result.denied += 1
                     decision.allowed = False
@@ -1196,7 +1196,7 @@ def _apply_memory_suggestions(
             actor=actor,
             policy_hash=policy_hash,
             result_meta_extra=_memory_policy_result_meta(decision),
-            related_ask_event_id=related_ask_event_id,
+            related_ask_event_id=related_event_id,
         )
         result.applied += 1
         result.applied_items.append(
@@ -1888,7 +1888,8 @@ def run_ask(
                     policy_path=policy_path,
                     yes=yes,
                     non_interactive=non_interactive,
-                    related_ask_event_id=ask_event_id,
+                    related_event_id=ask_event_id,
+                    actor="ask",
                 )
                 payload.update(
                     {
@@ -2044,6 +2045,9 @@ def run_agent(
     max_cycles: int,
     yes: bool,
     dry_run: bool,
+    use_memory: bool = False,
+    apply_memory_suggestions: bool = False,
+    non_interactive: bool = False,
 ) -> None:
     if not goal_text or not goal_text.strip():
         raise ValueError("agent requires a goal description.")
@@ -2055,6 +2059,7 @@ def run_agent(
     last_actions_count = 0
     for cycle in range(1, cycles_limit + 1):
         print(f"=== Agent Cycle {cycle} ===")
+        memory_injection = _build_memory_injection(db_path) if use_memory else None
         plan, assessment, state_store, _payload = _request_llm_plan(
             db_path,
             goal_text,
@@ -2068,8 +2073,99 @@ def run_agent(
             debug=False,
             actor="agent",
             assessment_policy_path=policy_path,
+            memory_injection=memory_injection,
+            record_event=False,
         )
         try:
+            payload = _payload
+            apply_result = MemoryApplyResult(
+                applied=0,
+                skipped=0,
+                denied=0,
+                applied_items=[],
+            )
+            event_recorded = False
+            if apply_memory_suggestions:
+                suggestions = plan.get("memory_suggestions") or []
+                if not suggestions:
+                    print("No suggestions to apply")
+                    payload.update(
+                        {
+                            "apply_memory_suggestions_requested": True,
+                            "apply_memory_suggestions_result": {
+                                "applied": 0,
+                                "skipped": 0,
+                                "denied": 0,
+                            },
+                            "apply_memory_suggestions_applied": [],
+                        }
+                    )
+                    state_store.record_event(
+                        actor="agent",
+                        event_type=EVENT_TYPE_LLM_PLAN,
+                        message="LLM plan generated.",
+                        json_payload=payload,
+                        event_id=str(uuid4()),
+                    )
+                    event_recorded = True
+                else:
+                    agent_event_id = str(uuid4())
+                    apply_result = _apply_memory_suggestions(
+                        db_path,
+                        suggestions,
+                        policy_path=policy_path,
+                        yes=yes,
+                        non_interactive=non_interactive,
+                        related_event_id=agent_event_id,
+                        actor="agent",
+                    )
+                    payload.update(
+                        {
+                            "apply_memory_suggestions_requested": True,
+                            "apply_memory_suggestions_result": {
+                                "applied": apply_result.applied,
+                                "skipped": apply_result.skipped,
+                                "denied": apply_result.denied,
+                            },
+                            "apply_memory_suggestions_applied": apply_result.applied_items,
+                        }
+                    )
+                    state_store.record_event(
+                        actor="agent",
+                        event_type=EVENT_TYPE_LLM_PLAN,
+                        message="LLM plan generated.",
+                        json_payload=payload,
+                        event_id=agent_event_id,
+                    )
+                    event_recorded = True
+                    print(
+                        "Memory suggestions summary: "
+                        f"applied={apply_result.applied} "
+                        f"skipped={apply_result.skipped} "
+                        f"denied={apply_result.denied}"
+                    )
+                    if apply_result.exit_code is not None:
+                        raise SystemExit(apply_result.exit_code)
+
+            if not event_recorded:
+                payload.update(
+                    {
+                        "apply_memory_suggestions_requested": False,
+                        "apply_memory_suggestions_result": {
+                            "applied": 0,
+                            "skipped": 0,
+                            "denied": 0,
+                        },
+                        "apply_memory_suggestions_applied": [],
+                    }
+                )
+                state_store.record_event(
+                    actor="agent",
+                    event_type=EVENT_TYPE_LLM_PLAN,
+                    message="LLM plan generated.",
+                    json_payload=payload,
+                )
+
             actions = plan.get("actions", [])
             last_actions_count = len(actions)
             last_assessment = assessment
@@ -2405,6 +2501,9 @@ def _handle_agent(args: argparse.Namespace) -> None:
         max_cycles=max_cycles,
         yes=args.yes,
         dry_run=args.dry_run,
+        use_memory=args.use_memory,
+        apply_memory_suggestions=args.apply_memory_suggestions,
+        non_interactive=args.non_interactive,
     )
 
 
@@ -3466,6 +3565,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--yes",
         action="store_true",
         help="Skip confirmation prompts for high-risk plans",
+    )
+    agent_parser.add_argument(
+        "--memory",
+        dest="use_memory",
+        action="store_true",
+        help="Inject eligible memory items into the planner prompt (read-only)",
+    )
+    agent_parser.add_argument(
+        "--apply-memory-suggestions",
+        action="store_true",
+        help="Apply memory suggestions from the plan (policy-gated)",
+    )
+    agent_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting for memory suggestions",
     )
     agent_parser.add_argument(
         "--dry-run",

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -2,6 +2,7 @@ import contextlib
 import io
 import json
 import os
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
@@ -21,6 +22,11 @@ class AgentCliTest(unittest.TestCase):
             "GISMO_LLM_MODEL": "",
             "OLLAMA_HOST": "",
         }
+
+    def _write_policy(self, tmpdir: str, policy: dict) -> str:
+        path = Path(tmpdir) / "policy.json"
+        path.write_text(json.dumps(policy), encoding="utf-8")
+        return str(path)
 
     def test_agent_dry_run_does_not_enqueue(self) -> None:
         response = json.dumps(
@@ -147,3 +153,159 @@ class AgentCliTest(unittest.TestCase):
             self.assertEqual(exc.exception.code, 2)
             state_store = StateStore(db_path)
             self.assertEqual(state_store.list_queue_items(limit=10), [])
+
+    def test_agent_memory_suggestions_are_advisory_by_default(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "default_model",
+                        "kind": "preference",
+                        "value_json": "\"phi3:mini\"",
+                        "confidence": "high",
+                        "why": "Operator prefers the default model.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    buffer = io.StringIO()
+                    with contextlib.redirect_stdout(buffer):
+                        cli_main.run_agent(
+                            db_path,
+                            "remember defaults",
+                            policy_path=None,
+                            once=True,
+                            max_cycles=1,
+                            yes=False,
+                            dry_run=True,
+                        )
+            output = buffer.getvalue()
+            self.assertIn("Suggested memory updates (advisory only):", output)
+            self.assertIn("gismo memory put", output)
+            with sqlite3.connect(db_path) as connection:
+                item_count = connection.execute(
+                    "SELECT COUNT(*) FROM memory_items"
+                ).fetchone()[0]
+            self.assertEqual(item_count, 0)
+
+    def test_agent_apply_memory_suggestions_requires_confirmation(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "operator_pref",
+                        "kind": "preference",
+                        "value_json": "\"fast\"",
+                        "confidence": "high",
+                        "why": "Operator prefers speed.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_path = self._write_policy(
+                tmpdir,
+                {
+                    "allowed_tools": ["memory.put"],
+                    "memory": {
+                        "allow": {"memory.put": ["global"]},
+                        "require_confirmation": {"memory.put": ["global"]},
+                    },
+                },
+            )
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch("builtins.input", return_value="y"), mock.patch(
+                        "sys.stdin.isatty",
+                        return_value=True,
+                    ), mock.patch("sys.stdout.isatty", return_value=True):
+                        cli_main.run_agent(
+                            db_path,
+                            "remember preference",
+                            policy_path=policy_path,
+                            once=True,
+                            max_cycles=1,
+                            yes=False,
+                            dry_run=True,
+                            apply_memory_suggestions=True,
+                        )
+            with sqlite3.connect(db_path) as connection:
+                item_count = connection.execute(
+                    "SELECT COUNT(*) FROM memory_items"
+                ).fetchone()[0]
+                event_row = connection.execute(
+                    "SELECT related_ask_event_id FROM memory_events"
+                ).fetchone()
+            self.assertEqual(item_count, 1)
+            self.assertIsNotNone(event_row)
+            related_event_id = event_row[0]
+            self.assertIsNotNone(related_event_id)
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            self.assertEqual(event.id, related_event_id)
+
+    def test_agent_apply_memory_suggestions_non_interactive_fails_closed(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "remember",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+                "memory_suggestions": [
+                    {
+                        "namespace": "global",
+                        "key": "operator_pref",
+                        "kind": "preference",
+                        "value_json": "\"safe\"",
+                        "confidence": "high",
+                        "why": "Operator prefers safety.",
+                    }
+                ],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_path = self._write_policy(
+                tmpdir,
+                {
+                    "allowed_tools": ["memory.put"],
+                    "memory": {
+                        "allow": {"memory.put": ["global"]},
+                        "require_confirmation": {"memory.put": ["global"]},
+                    },
+                },
+            )
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with self.assertRaises(SystemExit):
+                        cli_main.run_agent(
+                            db_path,
+                            "remember preference",
+                            policy_path=policy_path,
+                            once=True,
+                            max_cycles=1,
+                            yes=False,
+                            dry_run=True,
+                            apply_memory_suggestions=True,
+                            non_interactive=True,
+                        )
+            with sqlite3.connect(db_path) as connection:
+                item_count = connection.execute(
+                    "SELECT COUNT(*) FROM memory_items"
+                ).fetchone()[0]
+            self.assertEqual(item_count, 0)


### PR DESCRIPTION
### Motivation
- Bring the `agent` command to parity with `ask` by supporting read-only memory injection, optional memory suggestions, and gated application behavior.
- Keep memory read-only by default and require explicit `--apply-memory-suggestions` to perform writes. 
- Preserve auditability by linking applied memory items to the originating agent plan event. 
- Reuse existing `ask` helpers where possible and avoid changing existing agent execution semantics.

### Description
- Added agent CLI flags `--memory`, `--apply-memory-suggestions`, and `--non-interactive` and plumbed them into `run_agent` and the argument parser. 
- When `--memory` is used the agent injects bounded, filtered memory via `_build_memory_injection` into the planning prompt and records injection metadata in the plan event payload. 
- When `--apply-memory-suggestions` is used the code invokes `_apply_memory_suggestions` (policy-checked and confirmation-gated), records apply results in the plan event, and links memory audit events to the originating agent event id. 
- Added/updated tests in `tests/test_agent_cli.py` and updated docs (`README.md`, `AGENTS.md`, `Handoff.md`) to reflect the new flags and behavior.

### Testing
- Ran the full verification suite with `python scripts/verify.py`, which completed successfully and reported all tests OK. 
- New unit tests verify that the agent does not write memory by default, surfaces memory suggestions in output, and only applies suggestions with the flag plus confirmation or `--yes`. 
- Manual CLI examples to exercise behavior: `gismo agent "Plan with memory context" --dry-run --memory` and `gismo agent "Apply memory suggestions" --dry-run --apply-memory-suggestions --policy policy/dev-safe.json --yes`. 
- `pytest -q` is expected to succeed under the repository CI as part of standard verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c2249cbd083308817827b13f609c7)