### PR TITLE
Surface memory provenance in runs show and export (injected/suggested/applied/denied; policy + confirmation)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -172,15 +172,16 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added agent memory flags for read-only context injection and gated suggestion application.
-- Agent memory suggestion application links audit events to the originating plan.
+- Added run-level memory provenance summaries for `runs show` output and JSON exports.
+- Export now includes plan events plus memory event linkage fields for audit consumers.
 
 Next steps:
-- Run Windows CI or native Windows smoke tests to confirm parity with `ask` memory behavior.
-- Run pytest -q on Windows to confirm agent memory tests and guardrails remain stable.
+- Review memory provenance output formatting with real operator runs.
+- Validate Windows smoke tests for run-level memory provenance and export JSONL consumers.
 
 Tests run:
 - python scripts/verify.py
+- pytest -q
 
 Operator examples:
 - python -m gismo.cli.main --db .\tmp\dev.db runs list

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Run introspection:
 
   gismo runs list
   gismo runs show RUN_ID
+  gismo runs show RUN_ID --json
 
 Export audit logs:
 
@@ -134,6 +135,7 @@ Windows examples (explicit module invocation):
 
   python -m gismo.cli.main --db .\tmp\dev.db runs list
   python -m gismo.cli.main --db .\tmp\dev.db runs show RUN_ID
+  python -m gismo.cli.main --db .\tmp\dev.db runs show RUN_ID --json
   python -m gismo.cli.main --db .\tmp\dev.db export RUN_ID
 
 Planner (local LLM via Ollama):

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -864,7 +864,131 @@ def run_operator(db_path: str, command_parts: list[str], policy_path: str | None
         state_store.close()
 
 
-def run_show(db_path: str, run_id: str) -> None:
+def _serialize_run_show_payload(
+    run,
+    *,
+    status: str,
+    start_time: datetime | None,
+    end_time: datetime | None,
+    counts: dict[str, int],
+    tasks: list,
+    tool_calls: list,
+    memory_provenance: object,
+) -> dict[str, object]:
+    task_payloads = []
+    for task in tasks:
+        task_payloads.append(
+            {
+                "id": task.id,
+                "title": task.title,
+                "status": task.status.value,
+                "error": task.error,
+                "output_json": task.output_json,
+                "created_at": task.created_at.isoformat(),
+                "updated_at": task.updated_at.isoformat(),
+                "failure_type": task.failure_type.value if task.failure_type else None,
+                "status_reason": task.status_reason,
+            }
+        )
+    call_payloads = []
+    for call in tool_calls:
+        call_payloads.append(
+            {
+                "id": call.id,
+                "task_id": call.task_id,
+                "tool_name": call.tool_name,
+                "status": call.status.value,
+                "started_at": call.started_at.isoformat(),
+                "finished_at": call.finished_at.isoformat() if call.finished_at else None,
+                "output_json": call.output_json,
+                "error": call.error,
+                "failure_type": call.failure_type.value if call.failure_type else None,
+            }
+        )
+    memory_payload = memory_provenance.to_dict()
+    return {
+        "run": {
+            "id": run.id,
+            "label": run.label,
+            "created_at": run.created_at.isoformat(),
+        },
+        "status": status,
+        "started_at": start_time.isoformat() if start_time else None,
+        "finished_at": end_time.isoformat() if end_time else None,
+        "task_counts": counts,
+        "tasks": task_payloads,
+        "tool_calls": call_payloads,
+        "memory_provenance": memory_payload,
+    }
+
+
+def _print_memory_provenance(provenance: object) -> None:
+    payload = provenance.to_dict()
+    injected = payload["injected"]
+    suggested = payload["suggested"]
+    applied = payload["applied"]
+    policy = payload["policy"]
+
+    print("Memory provenance:")
+    print("  Injected memory:")
+    print(f"    count: {injected.get('count', 0)}")
+    namespaces = injected.get("namespaces") or []
+    if namespaces:
+        print(f"    namespaces: {', '.join(namespaces)}")
+    else:
+        print("    namespaces: -")
+    cap_items = injected.get("cap_items")
+    cap_bytes = injected.get("cap_bytes")
+    if cap_items is not None or cap_bytes is not None:
+        print(f"    caps: items={cap_items or '-'} bytes={cap_bytes or '-'}")
+    if injected.get("bytes") is not None:
+        print(f"    bytes_used: {injected['bytes']}")
+
+    print("  Suggested memory updates:")
+    print(f"    count: {suggested.get('count', 0)}")
+    items = suggested.get("items") or []
+    if not items:
+        print("    (none)")
+    else:
+        for item in items:
+            print(
+                "    - "
+                f"{item.get('namespace')}/{item.get('key')} "
+                f"kind={item.get('kind')} "
+                f"confidence={item.get('confidence')} "
+                f"source={item.get('source')}"
+            )
+    if suggested.get("truncated"):
+        print(f"    +{suggested.get('remaining', 0)} more")
+
+    print("  Apply results:")
+    print(
+        "    "
+        f"applied={applied.get('applied', 0)} "
+        f"skipped={applied.get('skipped', 0)} "
+        f"denied={applied.get('denied', 0)}"
+    )
+    applied_items = applied.get("applied_items") or []
+    if applied_items:
+        print("    applied:")
+        for item in applied_items:
+            print(f"      - {item.get('namespace')}/{item.get('key')}")
+    denied_items = applied.get("denied_items") or []
+    if denied_items:
+        print("    denied:")
+        for item in denied_items:
+            reason = item.get("reason")
+            suffix = f" reason={reason}" if reason else ""
+            print(f"      - {item.get('namespace')}/{item.get('key')}{suffix}")
+
+    print("  Policy/confirmation:")
+    print(f"    policy_path: {policy.get('path') or '-'}")
+    print(f"    yes: {policy.get('yes')}")
+    print(f"    non_interactive: {policy.get('non_interactive')}")
+    print(f"    decision_path: {policy.get('decision_path') or '-'}")
+
+
+def run_show(db_path: str, run_id: str, *, json_output: bool = False) -> None:
     state_store = StateStore(db_path)
     try:
         run = state_store.get_run(run_id)
@@ -877,6 +1001,21 @@ def run_show(db_path: str, run_id: str) -> None:
         status = _run_status(tasks)
         start_time, end_time = _run_time_bounds(run, tasks, tool_calls)
         counts = _task_status_counts(tasks)
+        memory_provenance = state_store.get_memory_provenance(run.id)
+
+        if json_output:
+            payload = _serialize_run_show_payload(
+                run,
+                status=status,
+                start_time=start_time,
+                end_time=end_time,
+                counts=counts,
+                tasks=tasks,
+                tool_calls=tool_calls,
+                memory_provenance=memory_provenance,
+            )
+            print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+            return
 
         print("=== GISMO Run Summary ===")
         print(f"Run ID:     {run.id}")
@@ -892,6 +1031,8 @@ def run_show(db_path: str, run_id: str) -> None:
         print("Tasks:")
         if not tasks:
             print("  (no tasks)")
+            if memory_provenance.has_data():
+                _print_memory_provenance(memory_provenance)
             return
 
         for task in tasks:
@@ -922,6 +1063,8 @@ def run_show(db_path: str, run_id: str) -> None:
                     print(f"      output: {_summarize_value(call.output_json, 200)}")
                 if call.error:
                     print(f"      error: {_summarize_value(call.error, 200)}")
+        if memory_provenance.has_data():
+            _print_memory_provenance(memory_provenance)
     finally:
         state_store.close()
 
@@ -978,6 +1121,8 @@ class MemoryApplyResult:
     denied: int
     applied_items: list[dict[str, str]]
     exit_code: int | None = None
+    policy_path: str | None = None
+    decision_path: str | None = None
 
 
 def _memory_policy_hash(policy_path: str | None) -> str:
@@ -1032,6 +1177,13 @@ def _memory_request_from_suggestion(
     }
 
 
+def _memory_decision_path(*, yes: bool, non_interactive: bool) -> str:
+    interactive = _is_interactive_tty()
+    if non_interactive or yes or not interactive:
+        return "non-interactive"
+    return "interactive"
+
+
 def _apply_memory_suggestions(
     db_path: str,
     suggestions: list[dict[str, str]],
@@ -1046,8 +1198,16 @@ def _apply_memory_suggestions(
         return MemoryApplyResult(applied=0, skipped=0, denied=0, applied_items=[])
     policy, resolved_policy_path = _load_memory_policy(policy_path)
     policy_hash = _memory_policy_hash(resolved_policy_path)
+    decision_path = _memory_decision_path(yes=yes, non_interactive=non_interactive)
     action = "memory.put"
-    result = MemoryApplyResult(applied=0, skipped=0, denied=0, applied_items=[])
+    result = MemoryApplyResult(
+        applied=0,
+        skipped=0,
+        denied=0,
+        applied_items=[],
+        policy_path=resolved_policy_path,
+        decision_path=decision_path,
+    )
     candidates: list[tuple[dict[str, str], object, MemoryDecision]] = []
     for suggestion in suggestions:
         value = json.loads(suggestion["value_json"])
@@ -1556,6 +1716,12 @@ class MemoryInjection:
     count: int
     bytes: int
     keys: list[dict[str, str]]
+    cap_items: int
+    cap_bytes: int
+
+
+MEMORY_INJECTION_ITEM_CAP = 20
+MEMORY_INJECTION_BYTE_CAP = 8192
 
 
 def _serialize_memory_value(value: object) -> str:
@@ -1580,16 +1746,16 @@ def _memory_entries_for_prompt(items: list[MemoryItem]) -> list[dict[str, str]]:
 
 
 def _build_memory_injection(db_path: str) -> MemoryInjection:
-    items = memory_list_prompt_items(db_path, limit=20)
+    items = memory_list_prompt_items(db_path, limit=MEMORY_INJECTION_ITEM_CAP)
     entries = _memory_entries_for_prompt(items)
     capped_entries: list[dict[str, str]] = []
     total_bytes = 0
     for entry in entries:
         serialized = json.dumps(entry, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
         entry_bytes = len(serialized.encode("utf-8"))
-        if len(capped_entries) >= 20:
+        if len(capped_entries) >= MEMORY_INJECTION_ITEM_CAP:
             break
-        if total_bytes + entry_bytes > 8192:
+        if total_bytes + entry_bytes > MEMORY_INJECTION_BYTE_CAP:
             break
         capped_entries.append(entry)
         total_bytes += entry_bytes
@@ -1606,6 +1772,8 @@ def _build_memory_injection(db_path: str) -> MemoryInjection:
         count=len(capped_entries),
         bytes=total_bytes,
         keys=keys,
+        cap_items=MEMORY_INJECTION_ITEM_CAP,
+        cap_bytes=MEMORY_INJECTION_BYTE_CAP,
     )
 
 
@@ -1621,6 +1789,8 @@ def _apply_memory_injection_payload(
             "memory_injected_count": memory_injection.count,
             "memory_injected_keys": memory_injection.keys,
             "memory_injected_bytes": memory_injection.bytes,
+            "memory_injected_cap_items": memory_injection.cap_items,
+            "memory_injected_cap_bytes": memory_injection.cap_bytes,
         }
     )
 
@@ -1900,6 +2070,10 @@ def run_ask(
                             "denied": apply_result.denied,
                         },
                         "apply_memory_suggestions_applied": apply_result.applied_items,
+                        "apply_memory_policy_path": apply_result.policy_path,
+                        "apply_memory_yes": yes,
+                        "apply_memory_non_interactive": non_interactive,
+                        "apply_memory_decision_path": apply_result.decision_path,
                     }
                 )
                 state_store.record_event(
@@ -1927,6 +2101,13 @@ def run_ask(
                             "denied": 0,
                         },
                         "apply_memory_suggestions_applied": [],
+                        "apply_memory_policy_path": None,
+                        "apply_memory_yes": yes,
+                        "apply_memory_non_interactive": non_interactive,
+                        "apply_memory_decision_path": _memory_decision_path(
+                            yes=yes,
+                            non_interactive=non_interactive,
+                        ),
                     }
                 )
                 state_store.record_event(
@@ -1948,6 +2129,13 @@ def run_ask(
                         "denied": 0,
                     },
                     "apply_memory_suggestions_applied": [],
+                    "apply_memory_policy_path": None,
+                    "apply_memory_yes": yes,
+                    "apply_memory_non_interactive": non_interactive,
+                    "apply_memory_decision_path": _memory_decision_path(
+                        yes=yes,
+                        non_interactive=non_interactive,
+                    ),
                 }
             )
             state_store.record_event(
@@ -2084,6 +2272,7 @@ def run_agent(
                 denied=0,
                 applied_items=[],
             )
+            plan_event_id = str(uuid4())
             event_recorded = False
             if apply_memory_suggestions:
                 suggestions = plan.get("memory_suggestions") or []
@@ -2098,6 +2287,13 @@ def run_agent(
                                 "denied": 0,
                             },
                             "apply_memory_suggestions_applied": [],
+                            "apply_memory_policy_path": None,
+                            "apply_memory_yes": yes,
+                            "apply_memory_non_interactive": non_interactive,
+                            "apply_memory_decision_path": _memory_decision_path(
+                                yes=yes,
+                                non_interactive=non_interactive,
+                            ),
                         }
                     )
                     state_store.record_event(
@@ -2105,18 +2301,17 @@ def run_agent(
                         event_type=EVENT_TYPE_LLM_PLAN,
                         message="LLM plan generated.",
                         json_payload=payload,
-                        event_id=str(uuid4()),
+                        event_id=plan_event_id,
                     )
                     event_recorded = True
                 else:
-                    agent_event_id = str(uuid4())
                     apply_result = _apply_memory_suggestions(
                         db_path,
                         suggestions,
                         policy_path=policy_path,
                         yes=yes,
                         non_interactive=non_interactive,
-                        related_event_id=agent_event_id,
+                        related_event_id=plan_event_id,
                         actor="agent",
                     )
                     payload.update(
@@ -2128,6 +2323,10 @@ def run_agent(
                                 "denied": apply_result.denied,
                             },
                             "apply_memory_suggestions_applied": apply_result.applied_items,
+                            "apply_memory_policy_path": apply_result.policy_path,
+                            "apply_memory_yes": yes,
+                            "apply_memory_non_interactive": non_interactive,
+                            "apply_memory_decision_path": apply_result.decision_path,
                         }
                     )
                     state_store.record_event(
@@ -2135,7 +2334,7 @@ def run_agent(
                         event_type=EVENT_TYPE_LLM_PLAN,
                         message="LLM plan generated.",
                         json_payload=payload,
-                        event_id=agent_event_id,
+                        event_id=plan_event_id,
                     )
                     event_recorded = True
                     print(
@@ -2157,6 +2356,13 @@ def run_agent(
                             "denied": 0,
                         },
                         "apply_memory_suggestions_applied": [],
+                        "apply_memory_policy_path": None,
+                        "apply_memory_yes": yes,
+                        "apply_memory_non_interactive": non_interactive,
+                        "apply_memory_decision_path": _memory_decision_path(
+                            yes=yes,
+                            non_interactive=non_interactive,
+                        ),
                     }
                 )
                 state_store.record_event(
@@ -2164,6 +2370,7 @@ def run_agent(
                     event_type=EVENT_TYPE_LLM_PLAN,
                     message="LLM plan generated.",
                     json_payload=payload,
+                    event_id=plan_event_id,
                 )
 
             actions = plan.get("actions", [])
@@ -2178,7 +2385,12 @@ def run_agent(
 
             run = state_store.create_run(
                 label="agent-cycle",
-                metadata={"goal": goal_text, "cycle": cycle, "source": "agent"},
+                metadata={
+                    "goal": goal_text,
+                    "cycle": cycle,
+                    "source": "agent",
+                    "plan_event_id": plan_event_id,
+                },
             )
             run_ids.append(run.id)
 
@@ -2410,7 +2622,7 @@ def _handle_runs_list(args: argparse.Namespace) -> None:
 
 
 def _handle_runs_show(args: argparse.Namespace) -> None:
-    run_show(args.db_path, args.run_id)
+    run_show(args.db_path, args.run_id, json_output=args.json)
 
 
 def _handle_memory_put(args: argparse.Namespace) -> None:
@@ -3166,6 +3378,11 @@ def build_parser() -> argparse.ArgumentParser:
     runs_show_parser.add_argument(
         "run_id",
         help="Run ID to show",
+    )
+    runs_show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the run summary as JSON",
     )
     runs_show_parser.set_defaults(handler=_handle_runs_show)
 

--- a/gismo/core/export.py
+++ b/gismo/core/export.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from gismo.core.models import Run, Task, ToolCall
 from gismo.core.paths import resolve_exports_dir
-from gismo.core.state import StateStore
+from gismo.core.state import MemoryEventRecord, MemoryProvenance, StateStore
 
 
 def export_run_jsonl(
@@ -30,7 +30,24 @@ def export_run_jsonl(
     resolved_out = _resolve_output_path(run_id, out_path, exports_dir)
     tasks = list(state_store.list_tasks(run_id))
     tool_calls = list(state_store.list_tool_calls(run_id))
-    records = _build_records(run, tasks, tool_calls, redact=redact)
+    memory_provenance = state_store.get_memory_provenance(run.id)
+    plan_event_id = None
+    if isinstance(run.metadata_json, dict):
+        plan_event_id = run.metadata_json.get("plan_event_id")
+    plan_event = state_store.get_event(plan_event_id) if plan_event_id else None
+    memory_events = state_store.list_memory_events(
+        related_run_id=run.id,
+        related_ask_event_id=plan_event_id,
+    )
+    records = _build_records(
+        run,
+        tasks,
+        tool_calls,
+        memory_provenance=memory_provenance,
+        plan_event=plan_event,
+        memory_events=memory_events,
+        redact=redact,
+    )
     _write_jsonl(resolved_out, records)
     return resolved_out
 
@@ -76,17 +93,28 @@ def _build_records(
     tasks: list[Task],
     tool_calls: list[ToolCall],
     *,
+    memory_provenance: MemoryProvenance,
+    plan_event: Any | None,
+    memory_events: list[MemoryEventRecord],
     redact: bool,
 ) -> list[dict[str, Any]]:
     sorted_tasks = sorted(tasks, key=lambda task: task.created_at)
     sorted_calls = sorted(tool_calls, key=lambda call: (call.started_at, call.attempt_number))
-    records = [_serialize_run(run)]
+    records = [_serialize_run(run, memory_provenance)]
+    if plan_event is not None:
+        records.append(
+            _serialize_event(plan_event, memory_provenance=memory_provenance, redact=redact)
+        )
+    if memory_events:
+        records.extend(
+            _serialize_memory_event(event, redact=redact) for event in memory_events
+        )
     records.extend(_serialize_task(task, redact=redact) for task in sorted_tasks)
     records.extend(_serialize_tool_call(call, redact=redact) for call in sorted_calls)
     return records
 
 
-def _serialize_run(run: Run) -> dict[str, Any]:
+def _serialize_run(run: Run, memory_provenance: MemoryProvenance) -> dict[str, Any]:
     payload = asdict(run)
     payload["created_at"] = run.created_at.isoformat()
     return {
@@ -97,6 +125,60 @@ def _serialize_run(run: Run) -> dict[str, Any]:
         "metadata": run.metadata_json,
         "status": "CREATED",
         "failure_type": "NONE",
+        "memory_provenance": memory_provenance.to_dict(),
+    }
+
+
+def _serialize_event(
+    event: Any,
+    *,
+    memory_provenance: MemoryProvenance,
+    redact: bool,
+) -> dict[str, Any]:
+    payload = event.json_payload
+    if redact:
+        payload = _redact_payload(payload)
+    return {
+        "record_type": "event",
+        "id": event.id,
+        "timestamp": event.ts.isoformat(),
+        "actor": event.actor,
+        "event_type": event.event_type,
+        "message": event.message,
+        "payload": payload,
+        "memory_provenance": memory_provenance.to_dict(),
+    }
+
+
+def _serialize_memory_event(
+    event: MemoryEventRecord,
+    *,
+    redact: bool,
+) -> dict[str, Any]:
+    request = event.request
+    result_meta = event.result_meta
+    if redact:
+        request = _redact_payload(request)
+        result_meta = _redact_payload(result_meta)
+    confirmation = result_meta.get("confirmation", {}) if isinstance(result_meta, dict) else {}
+    return {
+        "record_type": "memory_event",
+        "id": event.id,
+        "timestamp": event.timestamp.isoformat(),
+        "operation": event.operation,
+        "actor": event.actor,
+        "policy_hash": event.policy_hash,
+        "request": request,
+        "result_meta": result_meta,
+        "related_run_id": event.related_run_id,
+        "related_ask_event_id": event.related_ask_event_id,
+        "originating_run_id": event.related_run_id,
+        "originating_event_id": event.related_ask_event_id,
+        "policy_decision": result_meta.get("policy_decision"),
+        "policy_reason": result_meta.get("policy_reason"),
+        "confirmation_required": confirmation.get("required"),
+        "confirmation_provided": confirmation.get("provided"),
+        "confirmation_mode": confirmation.get("mode"),
     }
 
 

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
@@ -21,6 +22,56 @@ from gismo.core.models import (
     ToolCall,
     ToolCallStatus,
 )
+
+
+@dataclass(frozen=True)
+class MemoryEventRecord:
+    id: str
+    timestamp: datetime
+    operation: str
+    actor: str
+    policy_hash: str
+    request: Dict[str, Any]
+    result_meta: Dict[str, Any]
+    related_run_id: Optional[str]
+    related_ask_event_id: Optional[str]
+
+
+@dataclass(frozen=True)
+class MemoryProvenance:
+    injected: Dict[str, Any]
+    suggested: Dict[str, Any]
+    applied: Dict[str, Any]
+    policy: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "injected": self.injected,
+            "suggested": self.suggested,
+            "applied": self.applied,
+            "policy": self.policy,
+        }
+
+    def has_data(self) -> bool:
+        if self.injected.get("count"):
+            return True
+        if self.injected.get("namespaces"):
+            return True
+        if self.injected.get("bytes") is not None:
+            return True
+        if self.injected.get("cap_items") is not None or self.injected.get("cap_bytes") is not None:
+            return True
+        if self.suggested.get("count"):
+            return True
+        if self.suggested.get("items"):
+            return True
+        if any(self.applied.get(key) for key in ("applied", "skipped", "denied")):
+            return True
+        if self.applied.get("applied_items") or self.applied.get("denied_items"):
+            return True
+        if self.policy.get("path") or self.policy.get("decision_path"):
+            return True
+        return False
 
 
 class StateStore:
@@ -389,6 +440,57 @@ class StateStore:
                 (limit,),
             ).fetchall()
         return [self._row_to_event(row) for row in rows]
+
+    def get_event(self, event_id: str) -> Optional[Event]:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM events WHERE id = ?",
+                (event_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_event(row)
+
+    def list_memory_events(
+        self,
+        *,
+        related_run_id: Optional[str] = None,
+        related_ask_event_id: Optional[str] = None,
+    ) -> list[MemoryEventRecord]:
+        if related_run_id is None and related_ask_event_id is None:
+            return []
+        clauses = []
+        params: list[object] = []
+        if related_run_id is not None:
+            clauses.append("related_run_id = ?")
+            params.append(related_run_id)
+        if related_ask_event_id is not None:
+            clauses.append("related_ask_event_id = ?")
+            params.append(related_ask_event_id)
+        where_clause = " OR ".join(clauses)
+        with self._connection() as connection:
+            rows = connection.execute(
+                f"SELECT * FROM memory_events WHERE {where_clause} ORDER BY timestamp ASC, id ASC",
+                tuple(params),
+            ).fetchall()
+        return [self._row_to_memory_event(row) for row in rows]
+
+    def get_memory_provenance(self, run_id: str) -> MemoryProvenance:
+        run = self.get_run(run_id)
+        plan_event_id = None
+        payload: Dict[str, Any] | None = None
+        if run is not None and isinstance(run.metadata_json, dict):
+            plan_event_id = run.metadata_json.get("plan_event_id")
+        if plan_event_id:
+            event = self.get_event(plan_event_id)
+            if event and isinstance(event.json_payload, dict):
+                payload = event.json_payload
+
+        memory_events = self.list_memory_events(
+            related_run_id=run_id,
+            related_ask_event_id=plan_event_id,
+        )
+        return _build_memory_provenance(payload, memory_events)
 
     def _sync_queue_retry_columns(self, connection: sqlite3.Connection) -> None:
         columns = {
@@ -1336,6 +1438,200 @@ class StateStore:
             message=row["message"],
             json_payload=json.loads(row["json_payload"]) if row["json_payload"] else None,
         )
+
+    def _row_to_memory_event(self, row: sqlite3.Row) -> MemoryEventRecord:
+        return MemoryEventRecord(
+            id=row["id"],
+            timestamp=_parse_dt(row["timestamp"]),
+            operation=row["operation"],
+            actor=row["actor"],
+            policy_hash=row["policy_hash"],
+            request=json.loads(row["request_json"]),
+            result_meta=json.loads(row["result_meta_json"]),
+            related_run_id=row["related_run_id"],
+            related_ask_event_id=row["related_ask_event_id"],
+        )
+
+
+MEMORY_PROVENANCE_SUGGESTION_LIMIT = 5
+
+
+def _build_memory_provenance(
+    payload: Dict[str, Any] | None,
+    memory_events: list[MemoryEventRecord],
+) -> MemoryProvenance:
+    injected_keys = []
+    injected_count = 0
+    injected_bytes = None
+    cap_items = None
+    cap_bytes = None
+    if payload:
+        injected_keys = payload.get("memory_injected_keys") or []
+        if isinstance(payload.get("memory_injected_count"), int):
+            injected_count = payload["memory_injected_count"]
+        elif isinstance(injected_keys, list):
+            injected_count = len(injected_keys)
+        if isinstance(payload.get("memory_injected_bytes"), int):
+            injected_bytes = payload["memory_injected_bytes"]
+        if isinstance(payload.get("memory_injected_cap_items"), int):
+            cap_items = payload["memory_injected_cap_items"]
+        if isinstance(payload.get("memory_injected_cap_bytes"), int):
+            cap_bytes = payload["memory_injected_cap_bytes"]
+    namespaces = sorted(
+        {
+            entry.get("namespace")
+            for entry in injected_keys
+            if isinstance(entry, dict) and entry.get("namespace")
+        }
+    )
+    injected = {
+        "count": injected_count,
+        "namespaces": namespaces,
+        "bytes": injected_bytes,
+        "cap_items": cap_items,
+        "cap_bytes": cap_bytes,
+    }
+
+    suggestions = []
+    if payload:
+        plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
+        raw_suggestions = plan.get("memory_suggestions") if isinstance(plan, dict) else None
+        if isinstance(raw_suggestions, list):
+            for suggestion in raw_suggestions:
+                if not isinstance(suggestion, dict):
+                    continue
+                namespace = suggestion.get("namespace")
+                key = suggestion.get("key")
+                if not namespace or not key:
+                    continue
+                suggestions.append(
+                    {
+                        "namespace": str(namespace),
+                        "key": str(key),
+                        "kind": str(suggestion.get("kind") or ""),
+                        "confidence": str(suggestion.get("confidence") or ""),
+                        "source": str(suggestion.get("source") or ""),
+                    }
+                )
+    suggestions = sorted(
+        suggestions,
+        key=lambda item: (
+            item["namespace"],
+            item["key"],
+            item["kind"],
+            item["confidence"],
+            item["source"],
+        ),
+    )
+    suggested_count = len(suggestions)
+    truncated = suggested_count > MEMORY_PROVENANCE_SUGGESTION_LIMIT
+    remaining = max(0, suggested_count - MEMORY_PROVENANCE_SUGGESTION_LIMIT)
+    suggested_items = suggestions[:MEMORY_PROVENANCE_SUGGESTION_LIMIT]
+    suggested = {
+        "count": suggested_count,
+        "items": suggested_items,
+        "truncated": truncated,
+        "remaining": remaining,
+    }
+
+    applied_items = _memory_items_from_events(memory_events, decision="allowed")
+    denied_items = _memory_items_from_events(memory_events, decision="denied", include_reason=True)
+    if not applied_items and payload:
+        payload_applied = payload.get("apply_memory_suggestions_applied")
+        if isinstance(payload_applied, list):
+            for item in payload_applied:
+                if not isinstance(item, dict):
+                    continue
+                namespace = item.get("namespace")
+                key = item.get("key")
+                if namespace and key:
+                    applied_items.append({"namespace": str(namespace), "key": str(key)})
+    applied_items = _sorted_unique_items(applied_items)
+    denied_items = _sorted_unique_items(denied_items, include_reason=True)
+
+    applied_count = len(applied_items)
+    skipped_count = 0
+    denied_count = len(denied_items)
+    if payload:
+        result = payload.get("apply_memory_suggestions_result")
+        if isinstance(result, dict):
+            if isinstance(result.get("applied"), int):
+                applied_count = result["applied"]
+            if isinstance(result.get("skipped"), int):
+                skipped_count = result["skipped"]
+            if isinstance(result.get("denied"), int):
+                denied_count = result["denied"]
+    applied = {
+        "applied": applied_count,
+        "skipped": skipped_count,
+        "denied": denied_count,
+        "applied_items": applied_items,
+        "denied_items": denied_items,
+    }
+
+    policy = {
+        "path": payload.get("apply_memory_policy_path") if payload else None,
+        "yes": payload.get("apply_memory_yes") if payload else None,
+        "non_interactive": payload.get("apply_memory_non_interactive") if payload else None,
+        "decision_path": payload.get("apply_memory_decision_path") if payload else None,
+    }
+
+    return MemoryProvenance(
+        injected=injected,
+        suggested=suggested,
+        applied=applied,
+        policy=policy,
+    )
+
+
+def _memory_items_from_events(
+    memory_events: list[MemoryEventRecord],
+    *,
+    decision: str,
+    include_reason: bool = False,
+) -> list[Dict[str, str]]:
+    items: list[Dict[str, str]] = []
+    for event in memory_events:
+        if event.operation != "put":
+            continue
+        result_meta = event.result_meta
+        if result_meta.get("policy_decision") != decision:
+            continue
+        request = event.request
+        namespace = request.get("namespace")
+        key = request.get("key")
+        if not namespace or not key:
+            continue
+        item = {"namespace": str(namespace), "key": str(key)}
+        if include_reason:
+            reason = result_meta.get("policy_reason")
+            if reason:
+                item["reason"] = str(reason)
+        items.append(item)
+    return items
+
+
+def _sorted_unique_items(
+    items: list[Dict[str, str]],
+    *,
+    include_reason: bool = False,
+) -> list[Dict[str, str]]:
+    seen = set()
+    unique_items: list[Dict[str, str]] = []
+    for item in items:
+        key = (item.get("namespace"), item.get("key"), item.get("reason") if include_reason else None)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_items.append(item)
+    unique_items.sort(
+        key=lambda item: (
+            item.get("namespace", ""),
+            item.get("key", ""),
+            item.get("reason", "") if include_reason else "",
+        )
+    )
+    return unique_items
 
 
 def _parse_dt(value: str) -> datetime:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,14 +2,16 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from uuid import uuid4
 
 from gismo.core.agent import SimpleAgent
 from gismo.core.export import export_latest_run_jsonl, export_run_jsonl
-from gismo.core.models import ToolCall, ToolCallStatus
+from gismo.core.models import EVENT_TYPE_LLM_PLAN, ToolCall, ToolCallStatus
 from gismo.core.orchestrator import Orchestrator
 from gismo.core.permissions import PermissionPolicy
 from gismo.core.state import StateStore
 from gismo.core.tools import EchoTool, ToolRegistry
+from gismo.memory.store import record_event as memory_record_event
 
 
 class ExportTest(unittest.TestCase):
@@ -130,6 +132,89 @@ class ExportTest(unittest.TestCase):
             self.assertEqual(stdout_record["outputs"]["stderr"], "[REDACTED]")
             large_record = next(record for record in tool_records if record["tool_name"] == "echo")
             self.assertEqual(large_record["outputs"], "[REDACTED]")
+
+    def test_export_includes_memory_provenance_and_events(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            plan_event_id = str(uuid4())
+            run = state_store.create_run(
+                label="memory-export",
+                metadata={"plan_event_id": plan_event_id},
+            )
+            payload = {
+                "plan": {
+                    "memory_suggestions": [
+                        {
+                            "namespace": "global",
+                            "key": "default_model",
+                            "kind": "preference",
+                            "confidence": "high",
+                            "source": "llm",
+                        }
+                    ]
+                },
+                "memory_injection_enabled": True,
+                "memory_injected_count": 1,
+                "memory_injected_keys": [{"namespace": "global", "key": "default_model"}],
+                "memory_injected_bytes": 128,
+                "memory_injected_cap_items": 20,
+                "memory_injected_cap_bytes": 8192,
+                "apply_memory_suggestions_requested": False,
+                "apply_memory_suggestions_result": {"applied": 0, "skipped": 0, "denied": 0},
+                "apply_memory_suggestions_applied": [],
+                "apply_memory_policy_path": None,
+                "apply_memory_yes": False,
+                "apply_memory_non_interactive": True,
+                "apply_memory_decision_path": "non-interactive",
+            }
+            state_store.record_event(
+                actor="agent",
+                event_type=EVENT_TYPE_LLM_PLAN,
+                message="LLM plan generated.",
+                json_payload=payload,
+                event_id=plan_event_id,
+            )
+            memory_record_event(
+                db_path,
+                operation="put",
+                actor="agent",
+                policy_hash="test-hash",
+                request={
+                    "namespace": "global",
+                    "key": "default_model",
+                    "kind": "preference",
+                    "value_json": "\"phi3:mini\"",
+                    "tags_json": None,
+                    "confidence": "high",
+                    "source": "llm",
+                    "ttl_seconds": None,
+                },
+                result_meta={
+                    "policy_decision": "denied",
+                    "policy_reason": "confirmation_required",
+                    "confirmation": {"required": True, "provided": False, "mode": None},
+                },
+                related_ask_event_id=plan_event_id,
+            )
+            output_path = export_run_jsonl(
+                state_store,
+                run.id,
+                base_dir=Path(tmpdir),
+            )
+            records = [
+                json.loads(line)
+                for line in output_path.read_text(encoding="utf-8").strip().splitlines()
+            ]
+            run_record = next(record for record in records if record["record_type"] == "run")
+            self.assertIn("memory_provenance", run_record)
+            event_record = next(record for record in records if record["record_type"] == "event")
+            self.assertIn("memory_provenance", event_record)
+            memory_event = next(
+                record for record in records if record["record_type"] == "memory_event"
+            )
+            self.assertEqual(memory_event["originating_event_id"], plan_event_id)
+            self.assertEqual(memory_event["policy_decision"], "denied")
 
 
 if __name__ == "__main__":

--- a/tests/test_run_show_cli.py
+++ b/tests/test_run_show_cli.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
-from gismo.core.models import ToolCall
+from uuid import uuid4
+
+from gismo.core.models import EVENT_TYPE_LLM_PLAN, ToolCall
 from gismo.core.state import StateStore
+from gismo.memory.store import record_event as memory_record_event
 
 
 def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -73,3 +77,132 @@ def test_run_show_outputs_summary(repo_root: Path, db_path: Path) -> None:
     assert task_fail.id in stdout
     assert "tool=echo" in stdout
     assert "output:" in stdout
+
+
+def test_run_show_includes_memory_provenance(repo_root: Path, db_path: Path) -> None:
+    state_store = StateStore(str(db_path))
+    plan_event_id = str(uuid4())
+    run = state_store.create_run(
+        label="memory",
+        metadata={"plan_event_id": plan_event_id},
+    )
+    payload = {
+        "plan": {
+            "memory_suggestions": [
+                {
+                    "namespace": "global",
+                    "key": "default_model",
+                    "kind": "preference",
+                    "confidence": "high",
+                    "source": "llm",
+                }
+            ]
+        },
+        "memory_injection_enabled": True,
+        "memory_injected_count": 1,
+        "memory_injected_keys": [{"namespace": "global", "key": "default_model"}],
+        "memory_injected_bytes": 128,
+        "memory_injected_cap_items": 20,
+        "memory_injected_cap_bytes": 8192,
+        "apply_memory_suggestions_requested": True,
+        "apply_memory_suggestions_result": {"applied": 0, "skipped": 0, "denied": 1},
+        "apply_memory_suggestions_applied": [],
+        "apply_memory_policy_path": "policy/readonly.json",
+        "apply_memory_yes": True,
+        "apply_memory_non_interactive": False,
+        "apply_memory_decision_path": "non-interactive",
+    }
+    state_store.record_event(
+        actor="agent",
+        event_type=EVENT_TYPE_LLM_PLAN,
+        message="LLM plan generated.",
+        json_payload=payload,
+        event_id=plan_event_id,
+    )
+    memory_record_event(
+        str(db_path),
+        operation="put",
+        actor="agent",
+        policy_hash="test-hash",
+        request={
+            "namespace": "global",
+            "key": "default_model",
+            "kind": "preference",
+            "value_json": "\"phi3:mini\"",
+            "tags_json": None,
+            "confidence": "high",
+            "source": "llm",
+            "ttl_seconds": None,
+        },
+        result_meta={
+            "policy_decision": "denied",
+            "policy_reason": "confirmation_required",
+            "confirmation": {"required": True, "provided": False, "mode": None},
+        },
+        related_ask_event_id=plan_event_id,
+    )
+    state_store.close()
+
+    proc = _run_cli(["runs", "--db", str(db_path), "show", run.id], cwd=repo_root)
+    assert proc.returncode == 0, proc.stderr
+    stdout = proc.stdout
+    assert "Memory provenance:" in stdout
+    assert "Injected memory:" in stdout
+    assert "Suggested memory updates:" in stdout
+    assert "Apply results:" in stdout
+    assert "Policy/confirmation:" in stdout
+
+
+def test_run_show_json_includes_memory_provenance(repo_root: Path, db_path: Path) -> None:
+    state_store = StateStore(str(db_path))
+    plan_event_id = str(uuid4())
+    run = state_store.create_run(
+        label="memory-json",
+        metadata={"plan_event_id": plan_event_id},
+    )
+    payload = {
+        "plan": {
+            "memory_suggestions": [
+                {
+                    "namespace": "global",
+                    "key": "default_model",
+                    "kind": "preference",
+                    "confidence": "high",
+                    "source": "llm",
+                }
+            ]
+        },
+        "memory_injection_enabled": True,
+        "memory_injected_count": 1,
+        "memory_injected_keys": [{"namespace": "global", "key": "default_model"}],
+        "memory_injected_bytes": 128,
+        "memory_injected_cap_items": 20,
+        "memory_injected_cap_bytes": 8192,
+        "apply_memory_suggestions_requested": False,
+        "apply_memory_suggestions_result": {"applied": 0, "skipped": 0, "denied": 0},
+        "apply_memory_suggestions_applied": [],
+        "apply_memory_policy_path": None,
+        "apply_memory_yes": False,
+        "apply_memory_non_interactive": True,
+        "apply_memory_decision_path": "non-interactive",
+    }
+    state_store.record_event(
+        actor="agent",
+        event_type=EVENT_TYPE_LLM_PLAN,
+        message="LLM plan generated.",
+        json_payload=payload,
+        event_id=plan_event_id,
+    )
+    state_store.close()
+
+    proc = _run_cli(
+        ["runs", "--db", str(db_path), "show", "--json", run.id],
+        cwd=repo_root,
+    )
+    assert proc.returncode == 0, proc.stderr
+    output = json.loads(proc.stdout)
+    assert output["run"]["id"] == run.id
+    memory_provenance = output["memory_provenance"]
+    assert memory_provenance["injected"]["count"] == 1
+    assert memory_provenance["suggested"]["count"] == 1
+    assert "policy" in memory_provenance


### PR DESCRIPTION
### Motivation
- Operators need a deterministic, auditable view of what memory was injected, suggested, applied, skipped or denied for a given run without manual DB inspection.
- Make plan-level memory provenance (injection, suggestions, apply results, policy & confirmation) available to both human-readable `runs show` and machine-readable exports. 
- Preserve existing policy enforcement semantics and confirmation behavior; this change is reporting-only and does not grant new autonomy.

### Description
- Added run-level provenance plumbing: new `MemoryProvenance` + `MemoryEventRecord` helpers and `StateStore.get_memory_provenance(run_id)` that aggregate plan/ask events and `memory_events` to produce a deterministic provenance summary.  
- Surface provenance in CLI: `gismo runs show <RUN_ID>` prints a `Memory provenance` section when present and `gismo runs show <RUN_ID> --json` emits a JSON run summary including `memory_provenance`.  
- Export augmentation: `gismo export` JSONL now embeds a normalized `memory_provenance` object in run records, emits the original plan/event record (with provenance), and emits `memory_event` records with stable linkage fields (`originating_run_id`, `originating_event_id`) and explicit policy/confirmation fields.  
- Minor supporting changes: link agent runs to the plan event id (`plan_event_id`) for provenance lookup, include memory injection caps in payloads, and extend memory apply results with `policy_path` and `decision_path` for clearer auditing; deterministic truncation and stable ordering are used when summarizing suggestions.

### Testing
- Ran repository verification: `python scripts/verify.py` (completed successfully).
- Ran test suite: `pytest -q` (completed successfully; tests passed in CI run: 156 passed, 3 skipped).
- Added/updated unit tests covering: `runs show` text output including provenance, `runs show --json` provenance structure, and JSONL export including `memory_provenance` and `memory_event` linkage (all exercised by the test run above).
- No Windows DB handle guardrail regressions observed; existing `tests/test_db_handle_guardrails.py` remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c24e6b3ac8330b7f6e7070a0116b8)