### PR TITLE
Add gismo memory snapshot export/import (hashed, audited, policy-gated)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -172,12 +172,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added run-level memory provenance summaries for `runs show` output and JSON exports.
-- Export now includes plan events plus memory event linkage fields for audit consumers.
+- Added deterministic memory snapshot export/import with policy-gated restores and hash validation.
+- Snapshot imports write per-item memory events linked to a snapshot import audit entry.
 
 Next steps:
-- Review memory provenance output formatting with real operator runs.
-- Validate Windows smoke tests for run-level memory provenance and export JSONL consumers.
+- Validate snapshot import flows with larger namespace exports in operator workflows.
+- Consider operator-facing docs for snapshot retention practices if needed.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -125,10 +125,16 @@ Memory management (policy-gated; confirmation required for high-risk namespaces)
   gismo memory put --namespace global --key key --kind note --value-text "value" \
     --confidence high --source operator --policy policy/dev-safe.json --yes
   gismo memory delete --namespace global key --policy policy/dev-safe.json --yes
+  gismo memory snapshot export --namespace project:* --out snapshots/project.json \
+    --policy policy/dev-safe.json
+  gismo memory snapshot import --in snapshots/project.json --mode merge \
+    --policy policy/dev-safe.json --yes --non-interactive
 
 Notes:
 - Global/project namespaces require confirmation unless policy explicitly exempts them.
 - Use --non-interactive to fail closed instead of prompting.
+- Snapshot item_hash values are computed from a canonical JSON payload that includes
+  created_at/updated_at timestamps; snapshot_hash is the sha256 of ordered item_hashes.
   gismo export RUN_ID
 
 Windows examples (explicit module invocation):

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -44,6 +44,7 @@ from gismo.llm.ollama import OllamaError, ollama_chat, resolve_ollama_config
 from gismo.llm.prompts import build_system_prompt, build_user_prompt
 from gismo.memory.store import (
     MemoryItem,
+    fetch_item_raw,
     get_item as memory_get_item,
     list_prompt_items as memory_list_prompt_items,
     policy_hash_for_path,
@@ -51,6 +52,13 @@ from gismo.memory.store import (
     record_event as memory_record_event,
     search_items as memory_search_items,
     tombstone_item as memory_tombstone_item,
+    upsert_item_with_timestamps,
+)
+from gismo.memory.snapshot import (
+    SnapshotItem,
+    export_snapshot,
+    load_snapshot,
+    validate_snapshot,
 )
 
 
@@ -1177,11 +1185,44 @@ def _memory_request_from_suggestion(
     }
 
 
+def _memory_request_from_snapshot_item(item: SnapshotItem) -> dict[str, object]:
+    return {
+        "namespace": item.namespace,
+        "key": item.key,
+        "kind": item.kind,
+        "value_json": item.value_json,
+        "tags_json": json.dumps(item.tags, ensure_ascii=False, sort_keys=True)
+        if item.tags
+        else None,
+        "confidence": item.confidence,
+        "source": item.source,
+        "ttl_seconds": None,
+        "created_at": item.created_at,
+        "updated_at": item.updated_at,
+        "is_tombstoned": item.is_tombstoned,
+    }
+
+
 def _memory_decision_path(*, yes: bool, non_interactive: bool) -> str:
     interactive = _is_interactive_tty()
     if non_interactive or yes or not interactive:
         return "non-interactive"
     return "interactive"
+
+
+def _validate_snapshot_namespace_filter(namespace_filter: str) -> None:
+    if "*" in namespace_filter and not (
+        namespace_filter == "*" or namespace_filter.endswith("*")
+    ):
+        print(
+            "Namespace filters may only use '*' as a trailing wildcard (e.g., project:*).",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+
+def _snapshot_item_action(item: SnapshotItem) -> str:
+    return "memory.delete" if item.is_tombstoned else "memory.put"
 
 
 def _apply_memory_suggestions(
@@ -1645,6 +1686,231 @@ def run_memory_delete(args: argparse.Namespace) -> None:
     print(f"DB: {args.db_path}")
     print("Tombstoned memory item:")
     _print_memory_item_summary(item)
+
+
+def run_memory_snapshot_export(args: argparse.Namespace) -> None:
+    actor = "operator"
+    _validate_snapshot_namespace_filter(args.namespace)
+    _, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
+    snapshot = export_snapshot(
+        args.db_path,
+        namespace_filter=args.namespace,
+    )
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(snapshot, ensure_ascii=False, sort_keys=True, indent=2)
+    out_path.write_text(payload + "\n", encoding="utf-8")
+    memory_record_event(
+        args.db_path,
+        event_id=str(uuid4()),
+        operation="snapshot_export",
+        actor=actor,
+        policy_hash=policy_hash,
+        request={
+            "namespace_filter": args.namespace,
+            "out_path": str(out_path),
+        },
+        result_meta={
+            "item_count": len(snapshot["items"]),
+            "snapshot_hash": snapshot["snapshot_hash"],
+        },
+    )
+    print(f"Snapshot exported to {out_path}")
+    print(f"Items: {len(snapshot['items'])}")
+
+
+def run_memory_snapshot_import(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
+    snapshot_event_id = str(uuid4())
+    snapshot_path = Path(args.in_path)
+    try:
+        snapshot_payload = load_snapshot(snapshot_path)
+        items, snapshot_hash = validate_snapshot(snapshot_payload)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        memory_record_event(
+            args.db_path,
+            event_id=snapshot_event_id,
+            operation="snapshot_import",
+            actor=actor,
+            policy_hash=policy_hash,
+            request={
+                "in_path": str(snapshot_path),
+                "mode": args.mode,
+                "yes": args.yes,
+                "non_interactive": args.non_interactive,
+            },
+            result_meta={
+                "status": "failed",
+                "error": str(exc),
+                "validated": 0,
+                "applied": 0,
+                "skipped": 0,
+                "denied": 0,
+                "mode": args.mode,
+            },
+        )
+        print(f"Invalid snapshot: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    validated = len(items)
+    applied = 0
+    skipped = 0
+    denied = 0
+    exit_code: int | None = None
+    update_created_at = args.mode == "overwrite"
+    decision_path = _memory_decision_path(yes=args.yes, non_interactive=args.non_interactive)
+
+    for item in items:
+        existing = fetch_item_raw(args.db_path, namespace=item.namespace, key=item.key)
+        if args.mode == "skip-existing" and existing is not None:
+            skipped += 1
+            continue
+        action = _snapshot_item_action(item)
+        decision = _evaluate_memory_policy(policy, action, item.namespace)
+        request = _memory_request_from_snapshot_item(item)
+        if not decision.allowed:
+            meta = _memory_policy_result_meta(decision)
+            meta.update(
+                {
+                    "snapshot_import_event_id": snapshot_event_id,
+                    "snapshot_mode": args.mode,
+                }
+            )
+            memory_record_event(
+                args.db_path,
+                operation="delete" if item.is_tombstoned else "put",
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=meta,
+            )
+            denied += 1
+            exit_code = 2
+            continue
+        if decision.confirmation_required:
+            if args.yes:
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "yes-flag"
+            elif args.non_interactive or not _is_interactive_tty():
+                denied_decision = MemoryDecision(
+                    action=decision.action,
+                    allowed=False,
+                    confirmation_required=True,
+                    confirmation_provided=False,
+                    confirmation_mode=None,
+                    reason="confirmation_required",
+                )
+                meta = _memory_policy_result_meta(denied_decision)
+                meta.update(
+                    {
+                        "snapshot_import_event_id": snapshot_event_id,
+                        "snapshot_mode": args.mode,
+                    }
+                )
+                memory_record_event(
+                    args.db_path,
+                    operation="delete" if item.is_tombstoned else "put",
+                    actor=actor,
+                    policy_hash=policy_hash,
+                    request=request,
+                    result_meta=meta,
+                )
+                denied += 1
+                exit_code = 2
+                continue
+            else:
+                response = input(
+                    f"Import snapshot item {item.namespace}/{item.key}? [y/N]:"
+                )
+                if response.strip().lower() not in {"y", "yes"}:
+                    denied_decision = MemoryDecision(
+                        action=decision.action,
+                        allowed=False,
+                        confirmation_required=True,
+                        confirmation_provided=False,
+                        confirmation_mode=None,
+                        reason="confirmation_declined",
+                    )
+                    meta = _memory_policy_result_meta(denied_decision)
+                    meta.update(
+                        {
+                            "snapshot_import_event_id": snapshot_event_id,
+                            "snapshot_mode": args.mode,
+                        }
+                    )
+                    memory_record_event(
+                        args.db_path,
+                        operation="delete" if item.is_tombstoned else "put",
+                        actor=actor,
+                        policy_hash=policy_hash,
+                        request=request,
+                        result_meta=meta,
+                    )
+                    denied += 1
+                    exit_code = 2
+                    continue
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "prompt"
+        result_meta_extra = _memory_policy_result_meta(decision)
+        result_meta_extra.update(
+            {
+                "snapshot_import_event_id": snapshot_event_id,
+                "snapshot_mode": args.mode,
+            }
+        )
+        upsert_item_with_timestamps(
+            args.db_path,
+            namespace=item.namespace,
+            key=item.key,
+            kind=item.kind,
+            value=item.value,
+            tags=item.tags,
+            confidence=item.confidence,
+            source=item.source,
+            ttl_seconds=None,
+            is_tombstoned=item.is_tombstoned,
+            created_at=item.created_at,
+            updated_at=item.updated_at,
+            update_created_at=update_created_at,
+            actor=actor,
+            policy_hash=policy_hash,
+            operation="delete" if item.is_tombstoned else "put",
+            result_meta_extra=result_meta_extra,
+        )
+        applied += 1
+
+    memory_record_event(
+        args.db_path,
+        event_id=snapshot_event_id,
+        operation="snapshot_import",
+        actor=actor,
+        policy_hash=policy_hash,
+        request={
+            "in_path": str(snapshot_path),
+            "snapshot_hash": snapshot_hash,
+            "mode": args.mode,
+            "yes": args.yes,
+            "non_interactive": args.non_interactive,
+            "decision_path": decision_path,
+        },
+        result_meta={
+            "status": "completed",
+            "validated": validated,
+            "applied": applied,
+            "skipped": skipped,
+            "denied": denied,
+            "mode": args.mode,
+        },
+    )
+    print(
+        "Snapshot import summary: "
+        f"validated={validated} applied={applied} skipped={skipped} denied={denied}"
+    )
+    if denied:
+        raise SystemExit(exit_code or 2)
 
 
 def run_export(
@@ -2641,6 +2907,14 @@ def _handle_memory_delete(args: argparse.Namespace) -> None:
     run_memory_delete(args)
 
 
+def _handle_memory_snapshot_export(args: argparse.Namespace) -> None:
+    run_memory_snapshot_export(args)
+
+
+def _handle_memory_snapshot_import(args: argparse.Namespace) -> None:
+    run_memory_snapshot_import(args)
+
+
 def _handle_export(args: argparse.Namespace) -> None:
     run_id = args.run_id
     if getattr(args, "run_id_arg", None):
@@ -3622,6 +3896,72 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fail closed instead of prompting for confirmation",
     )
     memory_delete_parser.set_defaults(handler=_handle_memory_delete)
+
+    memory_snapshot_parser = memory_subparsers.add_parser(
+        "snapshot",
+        help="Export or import memory snapshots",
+        parents=[db_parent_optional],
+    )
+    memory_snapshot_subparsers = memory_snapshot_parser.add_subparsers(
+        dest="memory_snapshot_command",
+        required=True,
+    )
+
+    memory_snapshot_export_parser = memory_snapshot_subparsers.add_parser(
+        "export",
+        help="Export memory items to a deterministic snapshot",
+        parents=[db_parent_optional],
+    )
+    memory_snapshot_export_parser.add_argument(
+        "--namespace",
+        required=True,
+        help="Namespace or prefix wildcard to export (e.g., global or project:*)",
+    )
+    memory_snapshot_export_parser.add_argument(
+        "--out",
+        required=True,
+        help="Output snapshot file path",
+    )
+    memory_snapshot_export_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_snapshot_export_parser.set_defaults(handler=_handle_memory_snapshot_export)
+
+    memory_snapshot_import_parser = memory_snapshot_subparsers.add_parser(
+        "import",
+        help="Import memory items from a snapshot",
+        parents=[db_parent_optional],
+    )
+    memory_snapshot_import_parser.add_argument(
+        "--in",
+        dest="in_path",
+        required=True,
+        help="Input snapshot file path",
+    )
+    memory_snapshot_import_parser.add_argument(
+        "--mode",
+        choices=["merge", "overwrite", "skip-existing"],
+        default="merge",
+        help="Import mode (default: merge)",
+    )
+    memory_snapshot_import_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for high-risk memory writes",
+    )
+    memory_snapshot_import_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting for confirmation",
+    )
+    memory_snapshot_import_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_snapshot_import_parser.set_defaults(handler=_handle_memory_snapshot_import)
 
     enqueue_parser = subparsers.add_parser(
         "enqueue",

--- a/gismo/memory/__init__.py
+++ b/gismo/memory/__init__.py
@@ -4,22 +4,28 @@ from gismo.memory.store import (
     MemoryItem,
     MemoryStore,
     append_event,
+    fetch_item_raw,
     get_item,
+    list_items_for_snapshot,
     policy_hash_for_path,
     put_item,
     record_event,
     search_items,
     tombstone_item,
+    upsert_item_with_timestamps,
 )
 
 __all__ = [
     "MemoryItem",
     "MemoryStore",
     "append_event",
+    "fetch_item_raw",
     "get_item",
+    "list_items_for_snapshot",
     "policy_hash_for_path",
     "put_item",
     "record_event",
     "search_items",
     "tombstone_item",
+    "upsert_item_with_timestamps",
 ]

--- a/gismo/memory/snapshot.py
+++ b/gismo/memory/snapshot.py
@@ -1,0 +1,210 @@
+"""Deterministic snapshot export/import helpers for memory."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from gismo.memory.store import MemoryItem, list_items_for_snapshot
+
+SNAPSHOT_SCHEMA_VERSION = 1
+_CANONICAL_KWARGS = {"ensure_ascii": False, "sort_keys": True, "separators": (",", ":")}
+
+
+@dataclass(frozen=True)
+class SnapshotItem:
+    namespace: str
+    key: str
+    kind: str
+    value: Any
+    value_json: str
+    confidence: str
+    source: str
+    tags: list[str]
+    created_at: str
+    updated_at: str
+    is_tombstoned: bool
+    item_hash: str
+
+
+def export_snapshot(
+    db_path: str,
+    *,
+    namespace_filter: str,
+) -> dict[str, object]:
+    namespace, namespace_prefix = _parse_namespace_filter(namespace_filter)
+    items = list_items_for_snapshot(
+        db_path,
+        namespace=namespace,
+        namespace_prefix=namespace_prefix,
+    )
+    snapshot_items = [_snapshot_item_from_memory(item) for item in items]
+    item_hashes = [item["item_hash"] for item in snapshot_items]
+    snapshot = {
+        "schema_version": SNAPSHOT_SCHEMA_VERSION,
+        "created_at": _utc_now().isoformat(),
+        "namespaces": sorted({item.namespace for item in items}),
+        "items": snapshot_items,
+        "snapshot_hash": _snapshot_hash(item_hashes),
+    }
+    return snapshot
+
+
+def load_snapshot(path: Path) -> dict[str, object]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def validate_snapshot(snapshot: dict[str, object]) -> tuple[list[SnapshotItem], str]:
+    if snapshot.get("schema_version") != SNAPSHOT_SCHEMA_VERSION:
+        raise ValueError("Unsupported schema_version in snapshot")
+    items_raw = snapshot.get("items")
+    if not isinstance(items_raw, list):
+        raise ValueError("Snapshot items must be a list")
+    snapshot_hash = snapshot.get("snapshot_hash")
+    if not isinstance(snapshot_hash, str):
+        raise ValueError("Snapshot snapshot_hash must be a string")
+    items: list[SnapshotItem] = []
+    computed_hashes: list[str] = []
+    for raw in items_raw:
+        if not isinstance(raw, dict):
+            raise ValueError("Snapshot item entries must be objects")
+        item = _snapshot_item_from_payload(raw)
+        items.append(item)
+        computed_hashes.append(item.item_hash)
+    computed_snapshot_hash = _snapshot_hash(computed_hashes)
+    if computed_snapshot_hash != snapshot_hash:
+        raise ValueError("Snapshot snapshot_hash mismatch")
+    return items, snapshot_hash
+
+
+def canonical_value_json(value: Any) -> str:
+    return json.dumps(value, **_CANONICAL_KWARGS)
+
+
+def canonical_json(payload: dict[str, object]) -> str:
+    return json.dumps(payload, **_CANONICAL_KWARGS)
+
+
+def _parse_namespace_filter(namespace_filter: str) -> tuple[str | None, str | None]:
+    if namespace_filter == "*":
+        return None, ""
+    if namespace_filter.endswith("*"):
+        return None, namespace_filter[:-1]
+    return namespace_filter, None
+
+
+def _snapshot_item_from_memory(item: MemoryItem) -> dict[str, object]:
+    payload = _normalized_payload(
+        namespace=item.namespace,
+        key=item.key,
+        kind=item.kind,
+        value=item.value,
+        confidence=item.confidence,
+        source=item.source,
+        tags=item.tags,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
+        is_tombstoned=item.is_tombstoned,
+    )
+    return {**payload, "item_hash": _item_hash(payload)}
+
+
+def _snapshot_item_from_payload(payload: dict[str, object]) -> SnapshotItem:
+    namespace = _require_str(payload.get("namespace"), "namespace")
+    key = _require_str(payload.get("key"), "key")
+    kind = _require_str(payload.get("kind"), "kind")
+    value_json = _require_str(payload.get("value_json"), "value_json")
+    confidence = _require_str(payload.get("confidence"), "confidence")
+    source = _require_str(payload.get("source"), "source")
+    created_at = _require_str(payload.get("created_at"), "created_at")
+    updated_at = _require_str(payload.get("updated_at"), "updated_at")
+    is_tombstoned = payload.get("is_tombstoned")
+    if not isinstance(is_tombstoned, bool):
+        raise ValueError("Snapshot item is_tombstoned must be a boolean")
+    tags = payload.get("tags", [])
+    if tags is None:
+        tags = []
+    if not isinstance(tags, list) or not all(isinstance(tag, str) for tag in tags):
+        raise ValueError("Snapshot item tags must be a list of strings")
+    item_hash = _require_str(payload.get("item_hash"), "item_hash")
+    try:
+        value = json.loads(value_json)
+    except json.JSONDecodeError as exc:
+        raise ValueError("Snapshot item value_json is not valid JSON") from exc
+    normalized_payload = _normalized_payload(
+        namespace=namespace,
+        key=key,
+        kind=kind,
+        value=value,
+        confidence=confidence,
+        source=source,
+        tags=tags,
+        created_at=created_at,
+        updated_at=updated_at,
+        is_tombstoned=is_tombstoned,
+    )
+    computed_hash = _item_hash(normalized_payload)
+    if computed_hash != item_hash:
+        raise ValueError(f"Snapshot item hash mismatch for {namespace}/{key}")
+    return SnapshotItem(
+        namespace=namespace,
+        key=key,
+        kind=kind,
+        value=value,
+        value_json=normalized_payload["value_json"],
+        confidence=confidence,
+        source=source,
+        tags=normalized_payload["tags"],
+        created_at=created_at,
+        updated_at=updated_at,
+        is_tombstoned=is_tombstoned,
+        item_hash=item_hash,
+    )
+
+
+def _normalized_payload(
+    *,
+    namespace: str,
+    key: str,
+    kind: str,
+    value: Any,
+    confidence: str,
+    source: str,
+    tags: Iterable[str],
+    created_at: str,
+    updated_at: str,
+    is_tombstoned: bool,
+) -> dict[str, object]:
+    return {
+        "namespace": namespace,
+        "key": key,
+        "kind": kind,
+        "value_json": canonical_value_json(value),
+        "confidence": confidence,
+        "source": source,
+        "tags": sorted(tags),
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "is_tombstoned": is_tombstoned,
+    }
+
+
+def _item_hash(payload: dict[str, object]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def _snapshot_hash(item_hashes: Iterable[str]) -> str:
+    return hashlib.sha256("".join(item_hashes).encode("utf-8")).hexdigest()
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _require_str(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Snapshot item {field} must be a non-empty string")
+    return value

--- a/gismo/memory/store.py
+++ b/gismo/memory/store.py
@@ -487,6 +487,156 @@ class MemoryStore:
             return None
         return _row_to_item(row)
 
+    def fetch_item_raw(self, *, namespace: str, key: str) -> MemoryItem | None:
+        with self._connection() as connection:
+            return self._fetch_item(
+                connection,
+                namespace=namespace,
+                key=key,
+                include_tombstoned=True,
+            )
+
+    def list_items_for_snapshot(
+        self,
+        *,
+        namespace: Optional[str],
+        namespace_prefix: Optional[str],
+    ) -> list[MemoryItem]:
+        filters: list[str] = []
+        params: list[Any] = []
+        if namespace:
+            filters.append("namespace = ?")
+            params.append(namespace)
+        elif namespace_prefix is not None:
+            filters.append("namespace LIKE ?")
+            params.append(f"{namespace_prefix}%")
+        where_clause = ""
+        if filters:
+            where_clause = "WHERE " + " AND ".join(filters)
+        sql = (
+            "SELECT * FROM memory_items "
+            f"{where_clause} "
+            "ORDER BY namespace ASC, key ASC"
+        )
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            rows = cursor.execute(sql, params).fetchall()
+            return [_row_to_item(row) for row in rows]
+
+    def upsert_item_with_timestamps(
+        self,
+        *,
+        namespace: str,
+        key: str,
+        kind: str,
+        value: Any,
+        tags: Optional[list[str]],
+        confidence: str,
+        source: str,
+        ttl_seconds: Optional[int],
+        is_tombstoned: bool,
+        created_at: str,
+        updated_at: str,
+        update_created_at: bool,
+        actor: str,
+        policy_hash: str,
+        operation: str,
+        result_meta_extra: Optional[dict[str, Any]] = None,
+        related_run_id: Optional[str] = None,
+        related_ask_event_id: Optional[str] = None,
+    ) -> MemoryItem:
+        value_json = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        tags_json = json.dumps(tags, ensure_ascii=False, sort_keys=True) if tags else None
+        new_id = str(uuid4())
+        update_created_clause = ", created_at = excluded.created_at" if update_created_at else ""
+        with self._connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                f"""
+                INSERT INTO memory_items (
+                    id,
+                    namespace,
+                    key,
+                    kind,
+                    value_json,
+                    tags_json,
+                    confidence,
+                    source,
+                    ttl_seconds,
+                    is_tombstoned,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(namespace, key)
+                DO UPDATE SET
+                    kind = excluded.kind,
+                    value_json = excluded.value_json,
+                    tags_json = excluded.tags_json,
+                    confidence = excluded.confidence,
+                    source = excluded.source,
+                    ttl_seconds = excluded.ttl_seconds,
+                    is_tombstoned = excluded.is_tombstoned,
+                    updated_at = excluded.updated_at
+                    {update_created_clause}
+                """,
+                (
+                    new_id,
+                    namespace,
+                    key,
+                    kind,
+                    value_json,
+                    tags_json,
+                    confidence,
+                    source,
+                    ttl_seconds,
+                    int(is_tombstoned),
+                    created_at,
+                    updated_at,
+                ),
+            )
+            connection.commit()
+            item = self._fetch_item(
+                connection,
+                namespace=namespace,
+                key=key,
+                include_tombstoned=True,
+            )
+            if item is None:
+                raise RuntimeError("Failed to load memory item after upsert")
+            request = {
+                "namespace": namespace,
+                "key": key,
+                "kind": kind,
+                "value_json": value_json,
+                "tags_json": tags_json,
+                "confidence": confidence,
+                "source": source,
+                "ttl_seconds": ttl_seconds,
+                "created_at": created_at,
+                "updated_at": updated_at,
+                "is_tombstoned": is_tombstoned,
+            }
+            result_meta = {
+                "item_id": item.id,
+                "updated_at": item.updated_at,
+                "is_tombstoned": item.is_tombstoned,
+            }
+            if result_meta_extra:
+                result_meta.update(result_meta_extra)
+            append_event(
+                connection,
+                operation=operation,
+                actor=actor,
+                policy_hash=policy_hash,
+                request=request,
+                result_meta=result_meta,
+                related_run_id=related_run_id,
+                related_ask_event_id=related_ask_event_id,
+            )
+            connection.commit()
+            return item
+
 
 def put_item(
     db_path: str,
@@ -576,6 +726,66 @@ def search_items(
     )
 
 
+def list_items_for_snapshot(
+    db_path: str,
+    *,
+    namespace: Optional[str],
+    namespace_prefix: Optional[str],
+) -> list[MemoryItem]:
+    return MemoryStore(db_path).list_items_for_snapshot(
+        namespace=namespace,
+        namespace_prefix=namespace_prefix,
+    )
+
+
+def fetch_item_raw(db_path: str, *, namespace: str, key: str) -> MemoryItem | None:
+    return MemoryStore(db_path).fetch_item_raw(namespace=namespace, key=key)
+
+
+def upsert_item_with_timestamps(
+    db_path: str,
+    *,
+    namespace: str,
+    key: str,
+    kind: str,
+    value: Any,
+    tags: Optional[list[str]],
+    confidence: str,
+    source: str,
+    ttl_seconds: Optional[int],
+    is_tombstoned: bool,
+    created_at: str,
+    updated_at: str,
+    update_created_at: bool,
+    actor: str,
+    policy_hash: str,
+    operation: str,
+    result_meta_extra: Optional[dict[str, Any]] = None,
+    related_run_id: Optional[str] = None,
+    related_ask_event_id: Optional[str] = None,
+) -> MemoryItem:
+    return MemoryStore(db_path).upsert_item_with_timestamps(
+        namespace=namespace,
+        key=key,
+        kind=kind,
+        value=value,
+        tags=tags,
+        confidence=confidence,
+        source=source,
+        ttl_seconds=ttl_seconds,
+        is_tombstoned=is_tombstoned,
+        created_at=created_at,
+        updated_at=updated_at,
+        update_created_at=update_created_at,
+        actor=actor,
+        policy_hash=policy_hash,
+        operation=operation,
+        result_meta_extra=result_meta_extra,
+        related_run_id=related_run_id,
+        related_ask_event_id=related_ask_event_id,
+    )
+
+
 def list_prompt_items(
     db_path: str,
     *,
@@ -609,6 +819,7 @@ def tombstone_item(
 def record_event(
     db_path: str,
     *,
+    event_id: Optional[str] = None,
     operation: str,
     actor: str,
     policy_hash: str,
@@ -616,11 +827,12 @@ def record_event(
     result_meta: dict[str, Any],
     related_run_id: Optional[str] = None,
     related_ask_event_id: Optional[str] = None,
-) -> None:
+) -> str:
     store = MemoryStore(db_path)
     with store._connection() as connection:
-        append_event(
+        event_id = append_event(
             connection,
+            event_id=event_id,
             operation=operation,
             actor=actor,
             policy_hash=policy_hash,
@@ -630,11 +842,13 @@ def record_event(
             related_ask_event_id=related_ask_event_id,
         )
         connection.commit()
+        return event_id
 
 
 def append_event(
     connection: sqlite3.Connection,
     *,
+    event_id: Optional[str] = None,
     operation: str,
     actor: str,
     policy_hash: str,
@@ -642,9 +856,9 @@ def append_event(
     result_meta: dict[str, Any],
     related_run_id: Optional[str],
     related_ask_event_id: Optional[str],
-) -> None:
+) -> str:
     timestamp = _utc_now().isoformat()
-    event_id = str(uuid4())
+    event_id = event_id or str(uuid4())
     request_json = _serialize_bounded_json(request)
     result_meta_json = _serialize_bounded_json(result_meta)
     cursor = connection.cursor()
@@ -675,6 +889,7 @@ def append_event(
             related_ask_event_id,
         ),
     )
+    return event_id
 
 
 def policy_hash_for_path(policy_path: str | None) -> str:

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -1,0 +1,397 @@
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.memory.snapshot import canonical_json, canonical_value_json
+
+
+def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _snapshot_path(base: Path, name: str) -> Path:
+    return base / name
+
+
+def _item_hash(item: dict[str, object]) -> str:
+    payload = {
+        "namespace": item["namespace"],
+        "key": item["key"],
+        "kind": item["kind"],
+        "value_json": item["value_json"],
+        "confidence": item["confidence"],
+        "source": item["source"],
+        "tags": item["tags"],
+        "created_at": item["created_at"],
+        "updated_at": item["updated_at"],
+        "is_tombstoned": item["is_tombstoned"],
+    }
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+class MemorySnapshotCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.db_path = Path(self.temp_dir.name) / "state.db"
+        self.policy_path = self.repo_root / "policy" / "dev-safe.json"
+        self.snapshot_dir = Path(self.temp_dir.name) / "snapshots"
+        self.snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _put_item(self, namespace: str, key: str, value: str) -> None:
+        result = _run_cli(
+            [
+                "memory",
+                "put",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                namespace,
+                "--key",
+                key,
+                "--kind",
+                "note",
+                "--value-text",
+                value,
+                "--confidence",
+                "high",
+                "--source",
+                "operator",
+                "--yes",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_snapshot_export_is_deterministic(self) -> None:
+        self._put_item("project:alpha", "b", "two")
+        self._put_item("global", "a", "one")
+        out_one = _snapshot_path(self.snapshot_dir, "one.json")
+        out_two = _snapshot_path(self.snapshot_dir, "two.json")
+
+        export_one = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_one),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export_one.returncode, 0, export_one.stderr)
+
+        export_two = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_two),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export_two.returncode, 0, export_two.stderr)
+
+        snapshot_one = json.loads(out_one.read_text(encoding="utf-8"))
+        snapshot_two = json.loads(out_two.read_text(encoding="utf-8"))
+        self.assertEqual(snapshot_one["items"], snapshot_two["items"])
+        self.assertEqual(snapshot_one["snapshot_hash"], snapshot_two["snapshot_hash"])
+
+        items = snapshot_one["items"]
+        ordered_keys = [(item["namespace"], item["key"]) for item in items]
+        self.assertEqual(sorted(ordered_keys), ordered_keys)
+        for item in items:
+            canonical_value = canonical_value_json(json.loads(item["value_json"]))
+            item["value_json"] = canonical_value
+            item["tags"] = sorted(item["tags"])
+            self.assertEqual(_item_hash(item), item["item_hash"])
+        computed_snapshot_hash = hashlib.sha256(
+            "".join(item["item_hash"] for item in items).encode("utf-8")
+        ).hexdigest()
+        self.assertEqual(snapshot_one["snapshot_hash"], computed_snapshot_hash)
+
+    def test_snapshot_import_rejects_tampered_payload(self) -> None:
+        self._put_item("global", "alpha", "one")
+        out_path = _snapshot_path(self.snapshot_dir, "tamper.json")
+        export = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export.returncode, 0, export.stderr)
+        snapshot = json.loads(out_path.read_text(encoding="utf-8"))
+        snapshot["items"][0]["value_json"] = json.dumps("tampered")
+        out_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+        fresh_db = Path(self.temp_dir.name) / "fresh.db"
+        import_result = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(fresh_db),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(import_result.returncode, 0)
+        self.assertIn("Invalid snapshot", import_result.stderr)
+
+    def test_snapshot_import_modes(self) -> None:
+        self._put_item("global", "alpha", "snapshot")
+        out_path = _snapshot_path(self.snapshot_dir, "modes.json")
+        export = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export.returncode, 0, export.stderr)
+        snapshot = json.loads(out_path.read_text(encoding="utf-8"))
+        snapshot_item = snapshot["items"][0]
+
+        merge_db = Path(self.temp_dir.name) / "merge.db"
+        self.db_path = merge_db
+        self._put_item("global", "alpha", "local")
+        local_item = json.loads(
+            _run_cli(
+                [
+                    "memory",
+                    "get",
+                    "--db",
+                    str(merge_db),
+                    "--policy",
+                    str(self.policy_path),
+                    "--namespace",
+                    "global",
+                    "--json",
+                    "alpha",
+                ],
+                cwd=self.repo_root,
+            ).stdout
+        )
+        merge_import = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(merge_db),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--mode",
+                "merge",
+                "--yes",
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(merge_import.returncode, 0, merge_import.stderr)
+        merged_item = json.loads(
+            _run_cli(
+                [
+                    "memory",
+                    "get",
+                    "--db",
+                    str(merge_db),
+                    "--policy",
+                    str(self.policy_path),
+                    "--namespace",
+                    "global",
+                    "--json",
+                    "alpha",
+                ],
+                cwd=self.repo_root,
+            ).stdout
+        )
+        self.assertEqual(merged_item["value"], "snapshot")
+        self.assertEqual(merged_item["created_at"], local_item["created_at"])
+
+        overwrite_db = Path(self.temp_dir.name) / "overwrite.db"
+        self.db_path = overwrite_db
+        self._put_item("global", "alpha", "local")
+        overwrite_import = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(overwrite_db),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--mode",
+                "overwrite",
+                "--yes",
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(overwrite_import.returncode, 0, overwrite_import.stderr)
+        overwritten_item = json.loads(
+            _run_cli(
+                [
+                    "memory",
+                    "get",
+                    "--db",
+                    str(overwrite_db),
+                    "--policy",
+                    str(self.policy_path),
+                    "--namespace",
+                    "global",
+                    "--json",
+                    "alpha",
+                ],
+                cwd=self.repo_root,
+            ).stdout
+        )
+        self.assertEqual(overwritten_item["value"], "snapshot")
+        self.assertEqual(overwritten_item["created_at"], snapshot_item["created_at"])
+
+        skip_db = Path(self.temp_dir.name) / "skip.db"
+        self.db_path = skip_db
+        self._put_item("global", "alpha", "local")
+        skip_import = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(skip_db),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--mode",
+                "skip-existing",
+                "--yes",
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(skip_import.returncode, 0, skip_import.stderr)
+        skipped_item = json.loads(
+            _run_cli(
+                [
+                    "memory",
+                    "get",
+                    "--db",
+                    str(skip_db),
+                    "--policy",
+                    str(self.policy_path),
+                    "--namespace",
+                    "global",
+                    "--json",
+                    "alpha",
+                ],
+                cwd=self.repo_root,
+            ).stdout
+        )
+        self.assertEqual(skipped_item["value"], "local")
+
+    def test_snapshot_import_requires_confirmation(self) -> None:
+        self._put_item("global", "alpha", "snapshot")
+        out_path = _snapshot_path(self.snapshot_dir, "confirm.json")
+        export = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export.returncode, 0, export.stderr)
+        fresh_db = Path(self.temp_dir.name) / "confirm.db"
+        import_result = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(fresh_db),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--mode",
+                "merge",
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(import_result.returncode, 0)
+        with sqlite3.connect(fresh_db) as connection:
+            count = connection.execute(
+                "SELECT COUNT(*) FROM memory_items"
+            ).fetchone()[0]
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide deterministic, auditable backup/restore for memory namespaces with integrity validation so operators can export/import memory safely. 
- Ensure imports are explicit, policy- and confirmation-gated and preserve/restore timestamps deterministically for operator profiles. 

### Description
- Added a new snapshot helper module `gismo/memory/snapshot.py` that produces a canonical JSON snapshot with per-item `item_hash` (SHA-256 over canonical payload) and `snapshot_hash` (SHA-256 over ordered item hashes). 
- Added CLI subcommands `gismo memory snapshot export --namespace <NS|prefix:*> --out <file.json>` and `gismo memory snapshot import --in <file.json> [--mode merge|overwrite|skip-existing] [--yes] [--non-interactive]` with validation, deterministic ordering, and documented import semantics. 
- Extended memory store with `list_items_for_snapshot`, `fetch_item_raw`, and `upsert_item_with_timestamps` plus event bookkeeping changes so imports emit a snapshot-level `snapshot_import` event and per-item `memory_events` linked to the snapshot event id. 
- Enforced existing memory policy/confirmation logic on every imported item (deny-by-default, `--non-interactive` fails closed), and preserved Windows handle cleanup behavior used by existing CLI tests. 

### Testing
- Ran `python scripts/verify.py` and it completed successfully (all required checks passed). 
- Ran the full test suite with `pytest -q` and it passed: `160 passed, 3 skipped`. 
- Added `tests/test_memory_snapshot.py` which verifies deterministic export ordering and hashes, tamper detection on import, import modes (`merge`/`overwrite`/`skip-existing`), and policy/confirmation gating; these tests passed under CI above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c2b5bd6f4833085ac859d3a9a5407)