### PR TITLE
Add gismo memory snapshot diff and import dry-run preview

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -172,12 +172,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added deterministic memory snapshot export/import with policy-gated restores and hash validation.
-- Snapshot imports write per-item memory events linked to a snapshot import audit entry.
+- Added snapshot diff CLI with hash-based change classification.
+- Added dry-run snapshot import that audits without writing memory items.
 
 Next steps:
-- Validate snapshot import flows with larger namespace exports in operator workflows.
-- Consider operator-facing docs for snapshot retention practices if needed.
+- Validate dry-run snapshot workflows in operator playbooks.
+- Consider operator-facing docs for snapshot retention/diff review practices if needed.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -127,7 +127,11 @@ Memory management (policy-gated; confirmation required for high-risk namespaces)
   gismo memory delete --namespace global key --policy policy/dev-safe.json --yes
   gismo memory snapshot export --namespace project:* --out snapshots/project.json \
     --policy policy/dev-safe.json
+  gismo memory snapshot diff --in snapshots/project.json --db .gismo/state.db \
+    --policy policy/dev-safe.json
   gismo memory snapshot import --in snapshots/project.json --mode merge \
+    --policy policy/dev-safe.json --yes --non-interactive
+  gismo memory snapshot import --in snapshots/project.json --mode merge --dry-run \
     --policy policy/dev-safe.json --yes --non-interactive
 
 Notes:

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -58,6 +58,7 @@ from gismo.memory.snapshot import (
     SnapshotItem,
     export_snapshot,
     load_snapshot,
+    memory_item_hash,
     validate_snapshot,
 )
 
@@ -1133,6 +1134,17 @@ class MemoryApplyResult:
     decision_path: str | None = None
 
 
+@dataclass(frozen=True)
+class SnapshotDiffEntry:
+    namespace: str
+    key: str
+    action: str
+    snapshot_hash: str
+    existing_hash: str | None
+    snapshot_tombstoned: bool
+    existing_tombstoned: bool | None
+
+
 def _memory_policy_hash(policy_path: str | None) -> str:
     try:
         return policy_hash_for_path(policy_path)
@@ -1223,6 +1235,46 @@ def _validate_snapshot_namespace_filter(namespace_filter: str) -> None:
 
 def _snapshot_item_action(item: SnapshotItem) -> str:
     return "memory.delete" if item.is_tombstoned else "memory.put"
+
+
+def _record_snapshot_import_audit(
+    *,
+    db_path: str,
+    event_id: str,
+    actor: str,
+    policy_hash: str,
+    request: dict[str, object],
+    result_meta: dict[str, object],
+    dry_run: bool,
+) -> None:
+    if dry_run:
+        state_store = StateStore(db_path)
+        try:
+            state_store.record_event(
+                actor=actor,
+                event_type="memory.snapshot_import",
+                message="Dry-run memory snapshot import",
+                json_payload={
+                    "event_id": event_id,
+                    "operation": "snapshot_import",
+                    "policy_hash": policy_hash,
+                    "request": request,
+                    "result_meta": result_meta,
+                    "dry_run": True,
+                },
+            )
+        finally:
+            state_store.close()
+        return
+    memory_record_event(
+        db_path,
+        event_id=event_id,
+        operation="snapshot_import",
+        actor=actor,
+        policy_hash=policy_hash,
+        request=request,
+        result_meta=result_meta,
+    )
 
 
 def _apply_memory_suggestions(
@@ -1720,12 +1772,23 @@ def run_memory_snapshot_export(args: argparse.Namespace) -> None:
     print(f"Items: {len(snapshot['items'])}")
 
 
-def run_memory_snapshot_import(args: argparse.Namespace) -> None:
+def _snapshot_diff_entry_payload(entry: SnapshotDiffEntry) -> dict[str, object]:
+    return {
+        "namespace": entry.namespace,
+        "key": entry.key,
+        "snapshot_hash": entry.snapshot_hash,
+        "existing_hash": entry.existing_hash,
+        "snapshot_tombstoned": entry.snapshot_tombstoned,
+        "existing_tombstoned": entry.existing_tombstoned,
+    }
+
+
+def run_memory_snapshot_diff(args: argparse.Namespace) -> None:
     actor = "operator"
-    policy, resolved_policy_path = _load_memory_policy(args.policy)
+    _, resolved_policy_path = _load_memory_policy(args.policy)
     policy_hash = _memory_policy_hash(resolved_policy_path)
-    snapshot_event_id = str(uuid4())
     snapshot_path = Path(args.in_path)
+    snapshot_event_id = str(uuid4())
     try:
         snapshot_payload = load_snapshot(snapshot_path)
         items, snapshot_hash = validate_snapshot(snapshot_payload)
@@ -1733,7 +1796,127 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
         memory_record_event(
             args.db_path,
             event_id=snapshot_event_id,
-            operation="snapshot_import",
+            operation="snapshot_diff",
+            actor=actor,
+            policy_hash=policy_hash,
+            request={
+                "in_path": str(snapshot_path),
+            },
+            result_meta={
+                "status": "failed",
+                "error": str(exc),
+            },
+        )
+        print(f"Invalid snapshot: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    entries: list[SnapshotDiffEntry] = []
+    for item in items:
+        existing = fetch_item_raw(args.db_path, namespace=item.namespace, key=item.key)
+        existing_hash = memory_item_hash(existing) if existing else None
+        if existing_hash == item.item_hash:
+            action = "unchanged"
+        elif item.is_tombstoned:
+            action = "tombstone"
+        elif existing is None:
+            action = "add"
+        else:
+            action = "update"
+        entries.append(
+            SnapshotDiffEntry(
+                namespace=item.namespace,
+                key=item.key,
+                action=action,
+                snapshot_hash=item.item_hash,
+                existing_hash=existing_hash,
+                snapshot_tombstoned=item.is_tombstoned,
+                existing_tombstoned=existing.is_tombstoned if existing else None,
+            )
+        )
+
+    entries.sort(key=lambda entry: (entry.namespace, entry.key))
+    grouped: dict[str, dict[str, list[SnapshotDiffEntry]]] = {}
+    for entry in entries:
+        grouped.setdefault(entry.namespace, {}).setdefault(entry.action, []).append(entry)
+
+    summary = {
+        "adds": len([entry for entry in entries if entry.action == "add"]),
+        "updates": len([entry for entry in entries if entry.action == "update"]),
+        "tombstones": len([entry for entry in entries if entry.action == "tombstone"]),
+        "unchanged": len([entry for entry in entries if entry.action == "unchanged"]),
+    }
+
+    if args.json:
+        payload = {
+            "adds": [_snapshot_diff_entry_payload(entry) for entry in entries if entry.action == "add"],
+            "updates": [_snapshot_diff_entry_payload(entry) for entry in entries if entry.action == "update"],
+            "tombstones": [
+                _snapshot_diff_entry_payload(entry)
+                for entry in entries
+                if entry.action == "tombstone"
+            ],
+            "unchanged": [
+                _snapshot_diff_entry_payload(entry)
+                for entry in entries
+                if entry.action == "unchanged"
+            ],
+            "summary": summary,
+        }
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2))
+    else:
+        print(f"Snapshot diff for {snapshot_path}")
+        print(f"DB: {args.db_path}")
+        for namespace in sorted(grouped):
+            print(f"Namespace: {namespace}")
+            for label, action in (
+                ("ADD", "add"),
+                ("UPDATE", "update"),
+                ("TOMBSTONE", "tombstone"),
+                ("UNCHANGED", "unchanged"),
+            ):
+                items_for_action = grouped[namespace].get(action, [])
+                print(f"  {label} ({len(items_for_action)})")
+                for entry in items_for_action:
+                    print(f"    - {entry.key}")
+        print(
+            "Summary: "
+            f"adds={summary['adds']} "
+            f"updates={summary['updates']} "
+            f"tombstones={summary['tombstones']} "
+            f"unchanged={summary['unchanged']}"
+        )
+
+    memory_record_event(
+        args.db_path,
+        event_id=snapshot_event_id,
+        operation="snapshot_diff",
+        actor=actor,
+        policy_hash=policy_hash,
+        request={
+            "in_path": str(snapshot_path),
+            "snapshot_hash": snapshot_hash,
+        },
+        result_meta={
+            "status": "completed",
+            "summary": summary,
+        },
+    )
+
+
+def run_memory_snapshot_import(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy, resolved_policy_path = _load_memory_policy(args.policy)
+    policy_hash = _memory_policy_hash(resolved_policy_path)
+    snapshot_event_id = str(uuid4())
+    snapshot_path = Path(args.in_path)
+    dry_run = bool(getattr(args, "dry_run", False))
+    try:
+        snapshot_payload = load_snapshot(snapshot_path)
+        items, snapshot_hash = validate_snapshot(snapshot_payload)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        _record_snapshot_import_audit(
+            db_path=args.db_path,
+            event_id=snapshot_event_id,
             actor=actor,
             policy_hash=policy_hash,
             request={
@@ -1741,6 +1924,7 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
                 "mode": args.mode,
                 "yes": args.yes,
                 "non_interactive": args.non_interactive,
+                "dry_run": dry_run,
             },
             result_meta={
                 "status": "failed",
@@ -1750,7 +1934,9 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
                 "skipped": 0,
                 "denied": 0,
                 "mode": args.mode,
+                "dry_run": dry_run,
             },
+            dry_run=dry_run,
         )
         print(f"Invalid snapshot: {exc}", file=sys.stderr)
         raise SystemExit(2) from exc
@@ -1772,21 +1958,22 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
         decision = _evaluate_memory_policy(policy, action, item.namespace)
         request = _memory_request_from_snapshot_item(item)
         if not decision.allowed:
-            meta = _memory_policy_result_meta(decision)
-            meta.update(
-                {
-                    "snapshot_import_event_id": snapshot_event_id,
-                    "snapshot_mode": args.mode,
-                }
-            )
-            memory_record_event(
-                args.db_path,
-                operation="delete" if item.is_tombstoned else "put",
-                actor=actor,
-                policy_hash=policy_hash,
-                request=request,
-                result_meta=meta,
-            )
+            if not dry_run:
+                meta = _memory_policy_result_meta(decision)
+                meta.update(
+                    {
+                        "snapshot_import_event_id": snapshot_event_id,
+                        "snapshot_mode": args.mode,
+                    }
+                )
+                memory_record_event(
+                    args.db_path,
+                    operation="delete" if item.is_tombstoned else "put",
+                    actor=actor,
+                    policy_hash=policy_hash,
+                    request=request,
+                    result_meta=meta,
+                )
             denied += 1
             exit_code = 2
             continue
@@ -1803,21 +1990,22 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
                     confirmation_mode=None,
                     reason="confirmation_required",
                 )
-                meta = _memory_policy_result_meta(denied_decision)
-                meta.update(
-                    {
-                        "snapshot_import_event_id": snapshot_event_id,
-                        "snapshot_mode": args.mode,
-                    }
-                )
-                memory_record_event(
-                    args.db_path,
-                    operation="delete" if item.is_tombstoned else "put",
-                    actor=actor,
-                    policy_hash=policy_hash,
-                    request=request,
-                    result_meta=meta,
-                )
+                if not dry_run:
+                    meta = _memory_policy_result_meta(denied_decision)
+                    meta.update(
+                        {
+                            "snapshot_import_event_id": snapshot_event_id,
+                            "snapshot_mode": args.mode,
+                        }
+                    )
+                    memory_record_event(
+                        args.db_path,
+                        operation="delete" if item.is_tombstoned else "put",
+                        actor=actor,
+                        policy_hash=policy_hash,
+                        request=request,
+                        result_meta=meta,
+                    )
                 denied += 1
                 exit_code = 2
                 continue
@@ -1834,21 +2022,22 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
                         confirmation_mode=None,
                         reason="confirmation_declined",
                     )
-                    meta = _memory_policy_result_meta(denied_decision)
-                    meta.update(
-                        {
-                            "snapshot_import_event_id": snapshot_event_id,
-                            "snapshot_mode": args.mode,
-                        }
-                    )
-                    memory_record_event(
-                        args.db_path,
-                        operation="delete" if item.is_tombstoned else "put",
-                        actor=actor,
-                        policy_hash=policy_hash,
-                        request=request,
-                        result_meta=meta,
-                    )
+                    if not dry_run:
+                        meta = _memory_policy_result_meta(denied_decision)
+                        meta.update(
+                            {
+                                "snapshot_import_event_id": snapshot_event_id,
+                                "snapshot_mode": args.mode,
+                            }
+                        )
+                        memory_record_event(
+                            args.db_path,
+                            operation="delete" if item.is_tombstoned else "put",
+                            actor=actor,
+                            policy_hash=policy_hash,
+                            request=request,
+                            result_meta=meta,
+                        )
                     denied += 1
                     exit_code = 2
                     continue
@@ -1861,31 +2050,31 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
                 "snapshot_mode": args.mode,
             }
         )
-        upsert_item_with_timestamps(
-            args.db_path,
-            namespace=item.namespace,
-            key=item.key,
-            kind=item.kind,
-            value=item.value,
-            tags=item.tags,
-            confidence=item.confidence,
-            source=item.source,
-            ttl_seconds=None,
-            is_tombstoned=item.is_tombstoned,
-            created_at=item.created_at,
-            updated_at=item.updated_at,
-            update_created_at=update_created_at,
-            actor=actor,
-            policy_hash=policy_hash,
-            operation="delete" if item.is_tombstoned else "put",
-            result_meta_extra=result_meta_extra,
-        )
+        if not dry_run:
+            upsert_item_with_timestamps(
+                args.db_path,
+                namespace=item.namespace,
+                key=item.key,
+                kind=item.kind,
+                value=item.value,
+                tags=item.tags,
+                confidence=item.confidence,
+                source=item.source,
+                ttl_seconds=None,
+                is_tombstoned=item.is_tombstoned,
+                created_at=item.created_at,
+                updated_at=item.updated_at,
+                update_created_at=update_created_at,
+                actor=actor,
+                policy_hash=policy_hash,
+                operation="delete" if item.is_tombstoned else "put",
+                result_meta_extra=result_meta_extra,
+            )
         applied += 1
 
-    memory_record_event(
-        args.db_path,
+    _record_snapshot_import_audit(
+        db_path=args.db_path,
         event_id=snapshot_event_id,
-        operation="snapshot_import",
         actor=actor,
         policy_hash=policy_hash,
         request={
@@ -1895,6 +2084,7 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
             "yes": args.yes,
             "non_interactive": args.non_interactive,
             "decision_path": decision_path,
+            "dry_run": dry_run,
         },
         result_meta={
             "status": "completed",
@@ -1903,7 +2093,9 @@ def run_memory_snapshot_import(args: argparse.Namespace) -> None:
             "skipped": skipped,
             "denied": denied,
             "mode": args.mode,
+            "dry_run": dry_run,
         },
+        dry_run=dry_run,
     )
     print(
         "Snapshot import summary: "
@@ -2909,6 +3101,10 @@ def _handle_memory_delete(args: argparse.Namespace) -> None:
 
 def _handle_memory_snapshot_export(args: argparse.Namespace) -> None:
     run_memory_snapshot_export(args)
+
+
+def _handle_memory_snapshot_diff(args: argparse.Namespace) -> None:
+    run_memory_snapshot_diff(args)
 
 
 def _handle_memory_snapshot_import(args: argparse.Namespace) -> None:
@@ -3929,6 +4125,29 @@ def build_parser() -> argparse.ArgumentParser:
     )
     memory_snapshot_export_parser.set_defaults(handler=_handle_memory_snapshot_export)
 
+    memory_snapshot_diff_parser = memory_snapshot_subparsers.add_parser(
+        "diff",
+        help="Diff a snapshot against the current memory store",
+        parents=[db_parent_optional],
+    )
+    memory_snapshot_diff_parser.add_argument(
+        "--in",
+        dest="in_path",
+        required=True,
+        help="Input snapshot file path",
+    )
+    memory_snapshot_diff_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON",
+    )
+    memory_snapshot_diff_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    memory_snapshot_diff_parser.set_defaults(handler=_handle_memory_snapshot_diff)
+
     memory_snapshot_import_parser = memory_snapshot_subparsers.add_parser(
         "import",
         help="Import memory items from a snapshot",
@@ -3945,6 +4164,11 @@ def build_parser() -> argparse.ArgumentParser:
         choices=["merge", "overwrite", "skip-existing"],
         default="merge",
         help="Import mode (default: merge)",
+    )
+    memory_snapshot_import_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report without writing memory items",
     )
     memory_snapshot_import_parser.add_argument(
         "--yes",

--- a/gismo/memory/snapshot.py
+++ b/gismo/memory/snapshot.py
@@ -88,6 +88,22 @@ def canonical_json(payload: dict[str, object]) -> str:
     return json.dumps(payload, **_CANONICAL_KWARGS)
 
 
+def memory_item_hash(item: MemoryItem) -> str:
+    payload = _normalized_payload(
+        namespace=item.namespace,
+        key=item.key,
+        kind=item.kind,
+        value=item.value,
+        confidence=item.confidence,
+        source=item.source,
+        tags=item.tags,
+        created_at=item.created_at,
+        updated_at=item.updated_at,
+        is_tombstoned=item.is_tombstoned,
+    )
+    return _item_hash(payload)
+
+
 def _parse_namespace_filter(namespace_filter: str) -> tuple[str | None, str | None]:
     if namespace_filter == "*":
         return None, ""

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -391,6 +392,186 @@ class MemorySnapshotCliTest(unittest.TestCase):
                 "SELECT COUNT(*) FROM memory_items"
             ).fetchone()[0]
         self.assertEqual(count, 0)
+
+    def test_snapshot_diff_classifies_changes(self) -> None:
+        self._put_item("global", "alpha", "same")
+        self._put_item("global", "bravo", "old")
+        self._put_item("global", "tomb", "live")
+        out_path = _snapshot_path(self.snapshot_dir, "diff.json")
+        export = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export.returncode, 0, export.stderr)
+
+        snapshot = json.loads(out_path.read_text(encoding="utf-8"))
+        items = snapshot["items"]
+        alpha = next(item for item in items if item["key"] == "alpha")
+        bravo = next(item for item in items if item["key"] == "bravo")
+        tomb = next(item for item in items if item["key"] == "tomb")
+
+        bravo["value_json"] = canonical_value_json("new")
+        bravo["item_hash"] = _item_hash(bravo)
+
+        tomb["is_tombstoned"] = True
+        tomb["item_hash"] = _item_hash(tomb)
+
+        added = dict(alpha)
+        added["key"] = "charlie"
+        added["value_json"] = canonical_value_json("fresh")
+        added["item_hash"] = _item_hash(added)
+        items.append(added)
+
+        items.sort(key=lambda item: (item["namespace"], item["key"]))
+        snapshot["snapshot_hash"] = hashlib.sha256(
+            "".join(item["item_hash"] for item in items).encode("utf-8")
+        ).hexdigest()
+        out_path.write_text(json.dumps(snapshot), encoding="utf-8")
+
+        diff_result = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "diff",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(diff_result.returncode, 0, diff_result.stderr)
+        payload = json.loads(diff_result.stdout)
+        self.assertEqual(payload["summary"], {
+            "adds": 1,
+            "updates": 1,
+            "tombstones": 1,
+            "unchanged": 1,
+        })
+        self.assertEqual({item["key"] for item in payload["adds"]}, {"charlie"})
+        self.assertEqual({item["key"] for item in payload["updates"]}, {"bravo"})
+        self.assertEqual({item["key"] for item in payload["tombstones"]}, {"tomb"})
+        self.assertEqual({item["key"] for item in payload["unchanged"]}, {"alpha"})
+
+    def test_snapshot_import_dry_run_records_audit_only(self) -> None:
+        self._put_item("global", "alpha", "snapshot")
+        out_path = _snapshot_path(self.snapshot_dir, "dry-run.json")
+        export = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export.returncode, 0, export.stderr)
+
+        dry_run_db = Path(self.temp_dir.name) / "dry-run.db"
+        dry_run = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(dry_run_db),
+                "--policy",
+                str(self.policy_path),
+                "--in",
+                str(out_path),
+                "--mode",
+                "merge",
+                "--yes",
+                "--non-interactive",
+                "--dry-run",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(dry_run.returncode, 0, dry_run.stderr)
+        with sqlite3.connect(dry_run_db) as connection:
+            memory_event_count = connection.execute(
+                "SELECT COUNT(*) FROM memory_events"
+            ).fetchone()[0]
+            item_count = connection.execute(
+                "SELECT COUNT(*) FROM memory_items"
+            ).fetchone()[0]
+            events = connection.execute(
+                "SELECT json_payload FROM events"
+            ).fetchall()
+        self.assertEqual(memory_event_count, 0)
+        self.assertEqual(item_count, 0)
+        self.assertEqual(len(events), 1)
+        payload = json.loads(events[0][0])
+        self.assertTrue(payload["dry_run"])
+
+        os.remove(dry_run_db)
+        self.assertFalse(dry_run_db.exists())
+
+    def test_snapshot_import_dry_run_denies_policy(self) -> None:
+        self._put_item("global", "alpha", "snapshot")
+        out_path = _snapshot_path(self.snapshot_dir, "deny.json")
+        export = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "export",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(self.policy_path),
+                "--namespace",
+                "*",
+                "--out",
+                str(out_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(export.returncode, 0, export.stderr)
+
+        readonly_policy = self.repo_root / "policy" / "readonly.json"
+        dry_run = _run_cli(
+            [
+                "memory",
+                "snapshot",
+                "import",
+                "--db",
+                str(Path(self.temp_dir.name) / "deny.db"),
+                "--policy",
+                str(readonly_policy),
+                "--in",
+                str(out_path),
+                "--mode",
+                "merge",
+                "--yes",
+                "--non-interactive",
+                "--dry-run",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(dry_run.returncode, 0)
+        self.assertIn("denied=1", dry_run.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Operators need a deterministic, auditable preview of memory snapshot imports so they can review adds, updates, deletes, and tombstones before applying changes.
- Dry-run imports must perform full validation and policy checks and must be guaranteed to produce the same result as a real import while writing no memory items.
- The change centralizes a deterministic, hash-based comparison mechanism to avoid timestamp-based diff flakiness.

### Description
- Add a new CLI command `gismo memory snapshot diff --in <snapshot.json> --db <db>` that compares a snapshot to the current DB and classifies items by `add`, `update`, `tombstone`, or `unchanged`, emitting either grouped human output or a deterministic JSON payload matching the requested schema.
- Add `--dry-run` to `gismo memory snapshot import` so imports run full validation and policy/confirmation logic but do not write memory items, instead writing a single audit `events` record with `"dry_run": true` while keeping `memory_events` empty.
- Implemented helper `memory_item_hash`, `SnapshotDiffEntry`, `_record_snapshot_import_audit`, parser wiring for `snapshot diff` and `--dry-run`, plus README and Handoff updates and new tests exercising diff classification and dry-run behavior.
- Risks/limitations: diff classification is hash-based and includes canonicalized timestamps so an unchanged classification requires a full hash match, and dry-run audit data is recorded in the generic `events` table (intentional to avoid polluting `memory_events`).

### Testing
- Ran `python scripts/verify.py` which completed successfully.
- Ran `pytest -q` which completed successfully (tests: all new and existing tests passed: 163 passed, 3 skipped).
- Added unit tests in `tests/test_memory_snapshot.py` covering diff classification, dry-run audit-only behavior, policy-denial in dry-run, and ensuring the DB file can be deleted after a dry-run.
- Test commands used: `python scripts/verify.py` and `pytest -q` (both reported success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c2f56654083309908418d2b656b2b)