### PR TITLE
Add agent roles with role-based memory profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,4 +147,9 @@ Leashed autonomy:
 - The `agent` CLI loop must only plan → enqueue → execute via the queue/daemon and keep confirmation gates intact.
 - Agent memory context injection and suggestion application are optional, gated behaviors; defaults remain read-only unless explicitly enabled.
 
+Agent roles:
+- Agent roles provide operator-defined identities tied to memory profiles.
+- Roles are sequential and do not add parallel execution or autonomy.
+- Creating/retiring roles requires policy allowance plus explicit confirmation.
+
 If a change breaks this, it is not acceptable without explicit approval.

--- a/Handoff.md
+++ b/Handoff.md
@@ -172,11 +172,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added memory selection traces and the `gismo memory explain` command to audit inclusion/exclusion reasons for ask/agent runs.
+- Added agent roles with policy/confirmation-gated lifecycle and role-based memory profile selection.
+- Run/show/export/memory explain now surface role context for audit.
 
 Next steps:
-- Decide whether to ship default policy entries for memory profile create/retire actions.
-- Gather operator feedback on the memory explain JSON schema and cap defaults.
+- Decide whether to ship default policy entries for agent role create/retire actions.
+- Gather operator feedback on role-based memory visibility workflows (planner vs executor).
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -193,14 +193,22 @@ Agent loop (leashed autonomy):
   gismo agent "Do X safely" --max-cycles 3 --yes
   gismo agent "Plan with memory context" --dry-run --memory
   gismo agent "Plan with operator memory profile" --dry-run --memory-profile operator
+  gismo agent --role planner "Plan as the planner role"
   gismo agent "Apply memory suggestions" --dry-run --apply-memory-suggestions \
     --policy policy/dev-safe.json --yes
+  gismo agent role list --policy policy/dev-safe.json
+  gismo agent role create --name planner --memory-profile operator \
+    --policy policy/dev-safe.json --yes
+  gismo agent role retire planner --policy policy/dev-safe.json --yes
 
 Agent notes:
 - The agent loop is leashed autonomy: it plans, enqueues, and executes only through the queue/daemon.
 - Confirmation is required for high-risk plans or any shell/write actions unless --yes is provided.
 - Memory context and suggestion handling mirror `ask`: suggestions are advisory unless
   --apply-memory-suggestions is set (policy/confirmation-gated; use --non-interactive to fail closed).
+- Agent roles provide sequential, operator-controlled identities; roles determine which memory profile
+  is injected and are recorded in audit logs. Roles cannot be used once retired.
+- Use either --role or --memory/--memory-profile; role selection is authoritative.
 
 Memory profiles (read-only selection):
 - Profiles define which namespaces/kinds are visible for memory injection; they do not write memory.
@@ -208,6 +216,14 @@ Memory profiles (read-only selection):
   - operator: include global preferences/facts with a max-items cap.
   - project: include project:<name> namespace kinds for task context.
   - minimal: no filters (empty profile yields no injected memory).
+
+Agent roles (multi-agent identities):
+- Roles bind a name + description to a memory profile and are immutable except for retirement.
+- Roles are sequential only; they do not enable parallel execution or autonomy.
+- Roles differ from memory profiles: profiles describe visibility rules, while roles bind those rules
+  to a named identity (e.g., planner vs executor).
+- Creating/retiring roles requires policy allowance for agent.role.create/agent.role.retire plus
+  explicit confirmation (use --yes or --non-interactive to fail closed).
 
 Planner behavior:
 - Produces enqueue-only plans under strict schema.

--- a/gismo/cli/agent_role.py
+++ b/gismo/cli/agent_role.py
@@ -1,0 +1,584 @@
+"""Agent role CLI handlers."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import sys
+
+from gismo.core.permissions import PermissionPolicy, load_policy
+from gismo.core.state import StateStore
+from gismo.memory.store import (
+    get_profile_by_selector as memory_get_profile_by_selector,
+    policy_hash_for_path,
+)
+
+
+@dataclass
+class RoleDecision:
+    action: str
+    allowed: bool
+    confirmation_required: bool
+    confirmation_provided: bool
+    confirmation_mode: str | None
+    reason: str | None
+
+
+def _is_interactive_tty() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _resolve_default_policy_path(policy_path: str | None, repo_root: Path) -> tuple[str | None, bool]:
+    if policy_path:
+        return policy_path, False
+    readonly_path = repo_root / "policy" / "readonly.json"
+    if readonly_path.exists():
+        return str(readonly_path), False
+    return None, True
+
+
+def _warn_missing_default_policy() -> None:
+    print(
+        "Warning: no policy provided and no policy/readonly.json found; "
+        "continuing with existing default tool allowances.",
+        file=sys.stderr,
+    )
+
+
+def _load_agent_policy(policy_path: str | None) -> tuple[PermissionPolicy, str | None]:
+    repo_root = Path(__file__).resolve().parents[2]
+    resolved_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
+    try:
+        policy = load_policy(resolved_path, repo_root=repo_root)
+    except (OSError, ValueError, PermissionError) as exc:
+        print(f"Policy file not valid: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    return policy, resolved_path
+
+
+def _policy_hash(policy_path: str | None) -> str:
+    try:
+        return policy_hash_for_path(policy_path)
+    except FileNotFoundError as exc:
+        print(f"Policy file not found: {policy_path}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+def _decision_path(*, yes: bool, non_interactive: bool) -> str:
+    if non_interactive or yes or not _is_interactive_tty():
+        return "non-interactive"
+    return "interactive"
+
+
+def _evaluate_policy(policy: PermissionPolicy, *, action: str) -> RoleDecision:
+    try:
+        policy.check_tool_allowed(action)
+    except PermissionError:
+        return RoleDecision(
+            action=action,
+            allowed=False,
+            confirmation_required=False,
+            confirmation_provided=False,
+            confirmation_mode=None,
+            reason="policy_denied",
+        )
+    return RoleDecision(
+        action=action,
+        allowed=True,
+        confirmation_required=True,
+        confirmation_provided=False,
+        confirmation_mode=None,
+        reason=None,
+    )
+
+
+def _policy_result_meta(decision: RoleDecision) -> dict[str, object]:
+    return {
+        "policy_action": decision.action,
+        "policy_decision": "allowed" if decision.allowed else "denied",
+        "policy_reason": decision.reason,
+        "confirmation": {
+            "required": decision.confirmation_required,
+            "provided": decision.confirmation_provided,
+            "mode": decision.confirmation_mode,
+        },
+    }
+
+
+def _serialize_role(
+    role,
+    *,
+    memory_profile_name: str | None = None,
+    memory_profile_status: str | None = None,
+) -> dict[str, object]:
+    payload = {
+        "role_id": role.role_id,
+        "name": role.name,
+        "description": role.description,
+        "memory_profile_id": role.memory_profile_id,
+        "created_at": role.created_at.isoformat(),
+        "retired_at": role.retired_at.isoformat() if role.retired_at else None,
+    }
+    if memory_profile_name is not None:
+        payload["memory_profile_name"] = memory_profile_name
+    if memory_profile_status is not None:
+        payload["memory_profile_status"] = memory_profile_status
+    return payload
+
+
+def _resolve_memory_profile(db_path: str, selector: str) -> tuple[str, str]:
+    profile = memory_get_profile_by_selector(db_path, selector)
+    if profile is None:
+        print(f"Memory profile not found: {selector}", file=sys.stderr)
+        raise SystemExit(2)
+    if profile.retired_at:
+        print(f"Memory profile is retired: {profile.name}", file=sys.stderr)
+        raise SystemExit(2)
+    return profile.profile_id, profile.name
+
+
+def _memory_profile_detail(db_path: str, profile_id: str | None) -> tuple[str | None, str | None]:
+    if not profile_id:
+        return None, None
+    profile = memory_get_profile_by_selector(db_path, profile_id)
+    if profile is None:
+        return None, "missing"
+    if profile.retired_at:
+        return profile.name, "retired"
+    return profile.name, "active"
+
+
+def _record_event(
+    *,
+    state_store: StateStore,
+    actor: str,
+    action: str,
+    request: dict[str, object],
+    result_meta: dict[str, object],
+) -> None:
+    state_store.record_event(
+        actor=actor,
+        event_type="agent_role",
+        message=f"Agent role {action}.",
+        json_payload={
+            "operation": action,
+            "request": request,
+            "result_meta": result_meta,
+        },
+    )
+
+
+def run_agent_role_list(args: argparse.Namespace) -> None:
+    actor = "operator"
+    _, resolved_policy_path = _load_agent_policy(args.policy)
+    policy_hash = _policy_hash(resolved_policy_path)
+    state_store = StateStore(args.db_path)
+    try:
+        roles = state_store.list_agent_roles(include_retired=not args.active_only)
+        result_meta = {
+            "count": len(roles),
+            "policy_path": resolved_policy_path,
+            "policy_hash": policy_hash,
+        }
+        _record_event(
+            state_store=state_store,
+            actor=actor,
+            action="agent.role.list",
+            request={"active_only": args.active_only},
+            result_meta=result_meta,
+        )
+        if args.json:
+            payload = []
+            for role in roles:
+                name, status = _memory_profile_detail(args.db_path, role.memory_profile_id)
+                payload.append(
+                    _serialize_role(
+                        role,
+                        memory_profile_name=name,
+                        memory_profile_status=status,
+                    )
+                )
+            print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+            return
+        if not roles:
+            print("(no roles)")
+            return
+        for role in roles:
+            status = "retired" if role.retired_at else "active"
+            profile_name, profile_status = _memory_profile_detail(
+                args.db_path,
+                role.memory_profile_id,
+            )
+            profile_text = "-"
+            if role.memory_profile_id:
+                profile_text = f"{profile_name or role.memory_profile_id}"
+                if profile_status == "retired":
+                    profile_text += " [retired]"
+                elif profile_status == "missing":
+                    profile_text += " [missing]"
+            print(f"- {role.name} ({role.role_id}) [{status}] profile={profile_text}")
+    finally:
+        state_store.close()
+
+
+def run_agent_role_show(args: argparse.Namespace) -> None:
+    actor = "operator"
+    _, resolved_policy_path = _load_agent_policy(args.policy)
+    policy_hash = _policy_hash(resolved_policy_path)
+    state_store = StateStore(args.db_path)
+    try:
+        role = state_store.get_agent_role_by_selector(args.selector)
+        result_meta = {
+            "found": role is not None,
+            "policy_path": resolved_policy_path,
+            "policy_hash": policy_hash,
+        }
+        _record_event(
+            state_store=state_store,
+            actor=actor,
+            action="agent.role.show",
+            request={"selector": args.selector},
+            result_meta=result_meta,
+        )
+        if role is None:
+            print(f"Agent role not found: {args.selector}")
+            raise SystemExit(2)
+        profile_name, profile_status = _memory_profile_detail(
+            args.db_path,
+            role.memory_profile_id,
+        )
+        if args.json:
+            payload = _serialize_role(
+                role,
+                memory_profile_name=profile_name,
+                memory_profile_status=profile_status,
+            )
+            print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+            return
+        print(f"Role: {role.name}")
+        print(f"ID: {role.role_id}")
+        print(f"Description: {role.description or '-'}")
+        print(f"Status: {'retired' if role.retired_at else 'active'}")
+        print(f"Created: {role.created_at.isoformat()}")
+        if role.retired_at:
+            print(f"Retired: {role.retired_at.isoformat()}")
+        if role.memory_profile_id:
+            profile_value = profile_name or role.memory_profile_id
+            if profile_status == "retired":
+                profile_value = f"{profile_value} (retired)"
+            elif profile_status == "missing":
+                profile_value = f"{profile_value} (missing)"
+            print(f"Memory profile: {profile_value}")
+        else:
+            print("Memory profile: -")
+    finally:
+        state_store.close()
+
+
+def run_agent_role_create(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy, resolved_policy_path = _load_agent_policy(args.policy)
+    policy_hash = _policy_hash(resolved_policy_path)
+    memory_profile_id = None
+    memory_profile_name = None
+    if args.memory_profile:
+        memory_profile_id, memory_profile_name = _resolve_memory_profile(
+            args.db_path,
+            args.memory_profile,
+        )
+    action = "agent.role.create"
+    decision = _evaluate_policy(policy, action=action)
+    request = {
+        "name": args.name,
+        "description": args.description,
+        "memory_profile_selector": args.memory_profile,
+        "memory_profile_id": memory_profile_id,
+        "memory_profile_name": memory_profile_name,
+    }
+    state_store = StateStore(args.db_path)
+    try:
+        if not decision.allowed:
+            result_meta = _policy_result_meta(decision)
+            result_meta.update(
+                {
+                    "policy_path": resolved_policy_path,
+                    "policy_hash": policy_hash,
+                }
+            )
+            _record_event(
+                state_store=state_store,
+                actor=actor,
+                action=action,
+                request=request,
+                result_meta=result_meta,
+            )
+            print("Agent role create blocked by policy.", file=sys.stderr)
+            raise SystemExit(2)
+        decision_path = _decision_path(yes=args.yes, non_interactive=args.non_interactive)
+        if decision.confirmation_required:
+            if args.yes:
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "yes-flag"
+            elif args.non_interactive or not _is_interactive_tty():
+                denied = RoleDecision(
+                    action=decision.action,
+                    allowed=False,
+                    confirmation_required=True,
+                    confirmation_provided=False,
+                    confirmation_mode=None,
+                    reason="confirmation_required",
+                )
+                result_meta = _policy_result_meta(denied)
+                result_meta.update(
+                    {
+                        "policy_path": resolved_policy_path,
+                        "policy_hash": policy_hash,
+                        "decision_path": decision_path,
+                    }
+                )
+                _record_event(
+                    state_store=state_store,
+                    actor=actor,
+                    action=action,
+                    request=request,
+                    result_meta=result_meta,
+                )
+                print(
+                    "Confirmation required for agent role create. Re-run with --yes to proceed.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(2)
+            else:
+                response = input(f"Create agent role {args.name}? [y/N]:")
+                if response.strip().lower() not in {"y", "yes"}:
+                    denied = RoleDecision(
+                        action=decision.action,
+                        allowed=False,
+                        confirmation_required=True,
+                        confirmation_provided=False,
+                        confirmation_mode=None,
+                        reason="confirmation_declined",
+                    )
+                    result_meta = _policy_result_meta(denied)
+                    result_meta.update(
+                        {
+                            "policy_path": resolved_policy_path,
+                            "policy_hash": policy_hash,
+                            "decision_path": decision_path,
+                        }
+                    )
+                    _record_event(
+                        state_store=state_store,
+                        actor=actor,
+                        action=action,
+                        request=request,
+                        result_meta=result_meta,
+                    )
+                    print("Confirmation declined; role not created.", file=sys.stderr)
+                    raise SystemExit(2)
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "prompt"
+        try:
+            role = state_store.create_agent_role(
+                name=args.name,
+                description=args.description,
+                memory_profile_id=memory_profile_id,
+            )
+        except ValueError as exc:
+            result_meta = _policy_result_meta(decision)
+            result_meta.update(
+                {
+                    "policy_path": resolved_policy_path,
+                    "policy_hash": policy_hash,
+                    "decision_path": decision_path,
+                    "error": str(exc),
+                }
+            )
+            _record_event(
+                state_store=state_store,
+                actor=actor,
+                action=action,
+                request=request,
+                result_meta=result_meta,
+            )
+            print(str(exc), file=sys.stderr)
+            raise SystemExit(2) from exc
+        result_meta = _policy_result_meta(decision)
+        result_meta.update(
+            {
+                "policy_path": resolved_policy_path,
+                "policy_hash": policy_hash,
+                "decision_path": decision_path,
+                "role_id": role.role_id,
+                "created_at": role.created_at.isoformat(),
+                "retired_at": role.retired_at.isoformat() if role.retired_at else None,
+            }
+        )
+        _record_event(
+            state_store=state_store,
+            actor=actor,
+            action=action,
+            request=request,
+            result_meta=result_meta,
+        )
+        if args.json:
+            profile_name, profile_status = _memory_profile_detail(
+                args.db_path,
+                role.memory_profile_id,
+            )
+            print(
+                json.dumps(
+                    _serialize_role(
+                        role,
+                        memory_profile_name=profile_name,
+                        memory_profile_status=profile_status,
+                    ),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+            )
+            return
+        print(f"Created agent role: {role.name} ({role.role_id})")
+    finally:
+        state_store.close()
+
+
+def run_agent_role_retire(args: argparse.Namespace) -> None:
+    actor = "operator"
+    policy, resolved_policy_path = _load_agent_policy(args.policy)
+    policy_hash = _policy_hash(resolved_policy_path)
+    action = "agent.role.retire"
+    decision = _evaluate_policy(policy, action=action)
+    state_store = StateStore(args.db_path)
+    try:
+        role = state_store.get_agent_role_by_selector(args.selector)
+        if role is None:
+            print(f"Agent role not found: {args.selector}")
+            raise SystemExit(2)
+        request = {"role_id": role.role_id, "name": role.name}
+        if not decision.allowed:
+            result_meta = _policy_result_meta(decision)
+            result_meta.update(
+                {
+                    "policy_path": resolved_policy_path,
+                    "policy_hash": policy_hash,
+                }
+            )
+            _record_event(
+                state_store=state_store,
+                actor=actor,
+                action=action,
+                request=request,
+                result_meta=result_meta,
+            )
+            print("Agent role retire blocked by policy.", file=sys.stderr)
+            raise SystemExit(2)
+        decision_path = _decision_path(yes=args.yes, non_interactive=args.non_interactive)
+        if decision.confirmation_required:
+            if args.yes:
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "yes-flag"
+            elif args.non_interactive or not _is_interactive_tty():
+                denied = RoleDecision(
+                    action=decision.action,
+                    allowed=False,
+                    confirmation_required=True,
+                    confirmation_provided=False,
+                    confirmation_mode=None,
+                    reason="confirmation_required",
+                )
+                result_meta = _policy_result_meta(denied)
+                result_meta.update(
+                    {
+                        "policy_path": resolved_policy_path,
+                        "policy_hash": policy_hash,
+                        "decision_path": decision_path,
+                    }
+                )
+                _record_event(
+                    state_store=state_store,
+                    actor=actor,
+                    action=action,
+                    request=request,
+                    result_meta=result_meta,
+                )
+                print(
+                    "Confirmation required for agent role retire. Re-run with --yes to proceed.",
+                    file=sys.stderr,
+                )
+                raise SystemExit(2)
+            else:
+                response = input(f"Retire agent role {role.name}? [y/N]:")
+                if response.strip().lower() not in {"y", "yes"}:
+                    denied = RoleDecision(
+                        action=decision.action,
+                        allowed=False,
+                        confirmation_required=True,
+                        confirmation_provided=False,
+                        confirmation_mode=None,
+                        reason="confirmation_declined",
+                    )
+                    result_meta = _policy_result_meta(denied)
+                    result_meta.update(
+                        {
+                            "policy_path": resolved_policy_path,
+                            "policy_hash": policy_hash,
+                            "decision_path": decision_path,
+                        }
+                    )
+                    _record_event(
+                        state_store=state_store,
+                        actor=actor,
+                        action=action,
+                        request=request,
+                        result_meta=result_meta,
+                    )
+                    print("Confirmation declined; role not retired.", file=sys.stderr)
+                    raise SystemExit(2)
+                decision.confirmation_provided = True
+                decision.confirmation_mode = "prompt"
+        role, changed = state_store.retire_agent_role(role_id=role.role_id)
+        result_meta = _policy_result_meta(decision)
+        result_meta.update(
+            {
+                "policy_path": resolved_policy_path,
+                "policy_hash": policy_hash,
+                "decision_path": decision_path,
+                "role_id": role.role_id,
+                "retired_at": role.retired_at.isoformat() if role.retired_at else None,
+                "changed": changed,
+            }
+        )
+        _record_event(
+            state_store=state_store,
+            actor=actor,
+            action=action,
+            request=request,
+            result_meta=result_meta,
+        )
+        if args.json:
+            profile_name, profile_status = _memory_profile_detail(
+                args.db_path,
+                role.memory_profile_id,
+            )
+            print(
+                json.dumps(
+                    _serialize_role(
+                        role,
+                        memory_profile_name=profile_name,
+                        memory_profile_status=profile_status,
+                    ),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+            )
+            return
+        if changed:
+            print(f"Retired agent role: {role.name} ({role.role_id})")
+        else:
+            print(f"Agent role already retired: {role.name} ({role.role_id})")
+    finally:
+        state_store.close()

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -18,6 +18,7 @@ from gismo.cli import memory_doctor as memory_doctor_cli
 from gismo.cli import memory_explain as memory_explain_cli
 from gismo.cli import memory_profile as memory_profile_cli
 from gismo.cli import memory_snapshot as memory_snapshot_cli
+from gismo.cli import agent_role as agent_role_cli
 from gismo.cli.operator import (
     make_idempotency_key,
     normalize_command,
@@ -1016,6 +1017,9 @@ def _serialize_run_show_payload(
             }
         )
     memory_payload = memory_provenance.to_dict()
+    agent_role = None
+    if isinstance(run.metadata_json, dict):
+        agent_role = run.metadata_json.get("agent_role")
     return {
         "run": {
             "id": run.id,
@@ -1028,6 +1032,7 @@ def _serialize_run_show_payload(
         "task_counts": counts,
         "tasks": task_payloads,
         "tool_calls": call_payloads,
+        "agent_role": agent_role,
         "memory_provenance": memory_payload,
     }
 
@@ -1154,6 +1159,14 @@ def run_show(db_path: str, run_id: str, *, json_output: bool = False) -> None:
             f"(pending={counts['pending']} running={counts['running']} "
             f"succeeded={counts['succeeded']} failed={counts['failed']})"
         )
+        agent_role = None
+        if isinstance(run.metadata_json, dict):
+            agent_role = run.metadata_json.get("agent_role")
+        if isinstance(agent_role, dict):
+            role_name = agent_role.get("role_name") or "-"
+            role_id = agent_role.get("role_id") or "-"
+            profile_id = agent_role.get("memory_profile_id") or "-"
+            print(f"Role:       {role_name} ({role_id}) profile={profile_id}")
         print("Tasks:")
         if not tasks:
             print("  (no tasks)")
@@ -2822,6 +2835,13 @@ class MemoryInjection:
     profile: dict[str, object] | None = None
 
 
+@dataclass(frozen=True)
+class AgentRoleContext:
+    role_id: str
+    role_name: str
+    memory_profile_id: str | None
+
+
 MEMORY_INJECTION_ITEM_CAP = 20
 MEMORY_INJECTION_BYTE_CAP = 8192
 
@@ -2975,6 +2995,52 @@ def _apply_memory_injection_payload(
     )
 
 
+def _apply_agent_role_payload(
+    payload: dict[str, object],
+    role_context: AgentRoleContext | None,
+) -> None:
+    if role_context is None:
+        return
+    payload["agent_role"] = {
+        "role_id": role_context.role_id,
+        "role_name": role_context.role_name,
+        "memory_profile_id": role_context.memory_profile_id,
+    }
+
+
+def _resolve_agent_role(db_path: str, selector: str) -> AgentRoleContext:
+    state_store = StateStore(db_path)
+    try:
+        role = state_store.get_agent_role_by_selector(selector)
+    finally:
+        state_store.close()
+    if role is None:
+        print(f"Agent role not found: {selector}", file=sys.stderr)
+        raise SystemExit(2)
+    if role.retired_at:
+        print(f"Agent role is retired: {role.name}", file=sys.stderr)
+        raise SystemExit(2)
+    if role.memory_profile_id:
+        profile = memory_get_profile_by_selector(db_path, role.memory_profile_id)
+        if profile is None:
+            print(
+                f"Agent role references missing memory profile: {role.memory_profile_id}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        if profile.retired_at:
+            print(
+                f"Agent role memory profile is retired: {profile.name}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+    return AgentRoleContext(
+        role_id=role.role_id,
+        role_name=role.name,
+        memory_profile_id=role.memory_profile_id,
+    )
+
+
 def _record_memory_profile_use(
     *,
     db_path: str,
@@ -3021,6 +3087,7 @@ def _request_llm_plan(
     debug: bool,
     actor: str,
     memory_injection: MemoryInjection | None = None,
+    role_context: AgentRoleContext | None = None,
     assessment_policy_path: str | None = None,
     record_event: bool = True,
 ) -> tuple[dict, PlanAssessment, StateStore, dict[str, object]]:
@@ -3055,6 +3122,7 @@ def _request_llm_plan(
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
             _apply_memory_injection_payload(payload, memory_injection)
+            _apply_agent_role_payload(payload, role_context)
             state_store.record_event(
                 actor=actor,
                 event_type=EVENT_TYPE_ASK_FAILED,
@@ -3091,6 +3159,7 @@ def _request_llm_plan(
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
                 _apply_memory_injection_payload(payload, memory_injection)
+                _apply_agent_role_payload(payload, role_context)
                 state_store.record_event(
                     actor=actor,
                     event_type=EVENT_TYPE_LLM_PLAN,
@@ -3120,6 +3189,7 @@ def _request_llm_plan(
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
             _apply_memory_injection_payload(payload, memory_injection)
+            _apply_agent_role_payload(payload, role_context)
             state_store.record_event(
                 actor=actor,
                 event_type=EVENT_TYPE_LLM_PLAN,
@@ -3150,6 +3220,7 @@ def _request_llm_plan(
                 "timestamp": datetime.now(timezone.utc).isoformat(),
             }
             _apply_memory_injection_payload(payload, memory_injection)
+            _apply_agent_role_payload(payload, role_context)
             state_store.record_event(
                 actor=actor,
                 event_type=EVENT_TYPE_LLM_PLAN,
@@ -3173,6 +3244,7 @@ def _request_llm_plan(
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         _apply_memory_injection_payload(payload, memory_injection)
+        _apply_agent_role_payload(payload, role_context)
         if record_event:
             state_store.record_event(
                 actor=actor,
@@ -3463,23 +3535,29 @@ def run_agent(
     memory_profile: str | None = None,
     apply_memory_suggestions: bool = False,
     non_interactive: bool = False,
+    role: str | None = None,
 ) -> None:
     if not goal_text or not goal_text.strip():
         raise ValueError("agent requires a goal description.")
+    if role and (use_memory or memory_profile):
+        print("ERROR: --role cannot be combined with --memory or --memory-profile.", file=sys.stderr)
+        raise SystemExit(2)
     cycles_limit = 1 if once else max(1, max_cycles)
     run_ids: list[str] = []
     final_status = "unknown"
     final_error: str | None = None
     last_assessment: PlanAssessment | None = None
     last_actions_count = 0
+    role_context = _resolve_agent_role(db_path, role) if role else None
+    role_profile_selector = role_context.memory_profile_id if role_context else None
     for cycle in range(1, cycles_limit + 1):
         print(f"=== Agent Cycle {cycle} ===")
         plan_event_id = str(uuid4())
         memory_injection = None
-        if use_memory or memory_profile:
+        if use_memory or memory_profile or role_profile_selector:
             memory_injection = _build_memory_injection(
                 db_path,
-                profile_selector=memory_profile,
+                profile_selector=role_profile_selector or memory_profile,
                 plan_id=plan_event_id,
             )
         plan, assessment, state_store, _payload = _request_llm_plan(
@@ -3496,6 +3574,7 @@ def run_agent(
             actor="agent",
             assessment_policy_path=policy_path,
             memory_injection=memory_injection,
+            role_context=role_context,
             record_event=False,
         )
         try:
@@ -3622,14 +3701,17 @@ def run_agent(
 
             _confirm_agent_assessment(assessment, actions, yes=yes)
 
+            run_metadata = {
+                "goal": goal_text,
+                "cycle": cycle,
+                "source": "agent",
+                "plan_event_id": plan_event_id,
+            }
+            if role_context:
+                _apply_agent_role_payload(run_metadata, role_context)
             run = state_store.create_run(
                 label="agent-cycle",
-                metadata={
-                    "goal": goal_text,
-                    "cycle": cycle,
-                    "source": "agent",
-                    "plan_event_id": plan_event_id,
-                },
+                metadata=run_metadata,
             )
             run_ids.append(run.id)
             memory_link_selection_traces_to_run(
@@ -3945,6 +4027,22 @@ def _handle_memory_profile_retire(args: argparse.Namespace) -> None:
     memory_profile_cli.run_memory_profile_retire(args)
 
 
+def _handle_agent_role_list(args: argparse.Namespace) -> None:
+    agent_role_cli.run_agent_role_list(args)
+
+
+def _handle_agent_role_show(args: argparse.Namespace) -> None:
+    agent_role_cli.run_agent_role_show(args)
+
+
+def _handle_agent_role_create(args: argparse.Namespace) -> None:
+    agent_role_cli.run_agent_role_create(args)
+
+
+def _handle_agent_role_retire(args: argparse.Namespace) -> None:
+    agent_role_cli.run_agent_role_retire(args)
+
+
 def _handle_memory_explain(args: argparse.Namespace) -> None:
     memory_explain_cli.run_memory_explain(args)
 
@@ -4042,6 +4140,7 @@ def _handle_agent(args: argparse.Namespace) -> None:
         memory_profile=args.memory_profile,
         apply_memory_suggestions=args.apply_memory_suggestions,
         non_interactive=args.non_interactive,
+        role=args.role,
     )
 
 
@@ -5693,6 +5792,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Inject memory using a named profile (read-only)",
     )
     agent_parser.add_argument(
+        "--role",
+        dest="role",
+        default=None,
+        help="Agent role name or id (determines memory profile)",
+    )
+    agent_parser.add_argument(
         "--apply-memory-suggestions",
         action="store_true",
         help="Apply memory suggestions from the plan (policy-gated)",
@@ -5713,6 +5818,131 @@ def build_parser() -> argparse.ArgumentParser:
         help="Goal statement for the agent loop",
     )
     agent_parser.set_defaults(handler=_handle_agent)
+
+    agent_role_parser = subparsers.add_parser(
+        "agent-role",
+        help="Manage agent roles (deterministic role identities)",
+        parents=[db_parent_optional],
+    )
+    agent_role_subparsers = agent_role_parser.add_subparsers(
+        dest="agent_role_command",
+    )
+    agent_role_list_parser = agent_role_subparsers.add_parser(
+        "list",
+        help="List agent roles",
+        parents=[db_parent_optional],
+    )
+    agent_role_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_role_list_parser.add_argument(
+        "--active-only",
+        action="store_true",
+        help="Show only active roles",
+    )
+    agent_role_list_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    agent_role_list_parser.set_defaults(handler=_handle_agent_role_list)
+
+    agent_role_show_parser = agent_role_subparsers.add_parser(
+        "show",
+        help="Show agent role details",
+        parents=[db_parent_optional],
+    )
+    agent_role_show_parser.add_argument(
+        "selector",
+        help="Role name or id",
+    )
+    agent_role_show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_role_show_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path for audit hashing",
+    )
+    agent_role_show_parser.set_defaults(handler=_handle_agent_role_show)
+
+    agent_role_create_parser = agent_role_subparsers.add_parser(
+        "create",
+        help="Create an agent role (requires confirmation)",
+        parents=[db_parent_optional],
+    )
+    agent_role_create_parser.add_argument(
+        "--name",
+        required=True,
+        help="Role name (unique)",
+    )
+    agent_role_create_parser.add_argument(
+        "--description",
+        default=None,
+        help="Optional role description",
+    )
+    agent_role_create_parser.add_argument(
+        "--memory-profile",
+        dest="memory_profile",
+        default=None,
+        help="Memory profile selector (name or id)",
+    )
+    agent_role_create_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
+    agent_role_create_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for create",
+    )
+    agent_role_create_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting",
+    )
+    agent_role_create_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_role_create_parser.set_defaults(handler=_handle_agent_role_create)
+
+    agent_role_retire_parser = agent_role_subparsers.add_parser(
+        "retire",
+        help="Retire an agent role (requires confirmation)",
+        parents=[db_parent_optional],
+    )
+    agent_role_retire_parser.add_argument(
+        "selector",
+        help="Role name or id",
+    )
+    agent_role_retire_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
+    agent_role_retire_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for retire",
+    )
+    agent_role_retire_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting",
+    )
+    agent_role_retire_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_role_retire_parser.set_defaults(handler=_handle_agent_role_retire)
 
     daemon_parser = subparsers.add_parser(
         "daemon",
@@ -6218,6 +6448,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main() -> None:
     parser = build_parser()
     argv = sys.argv[1:]
+    if len(argv) > 1 and argv[0] == "agent" and argv[1] == "role":
+        argv = ["agent-role", *argv[2:]]
     if _has_shell_prompt_paste(argv):
         print(
             "It looks like you pasted your shell prompt. "

--- a/gismo/cli/memory_explain.py
+++ b/gismo/cli/memory_explain.py
@@ -24,13 +24,22 @@ def run_memory_explain(args: argparse.Namespace) -> None:
         print("ERROR: --limit must be > 0.", file=sys.stderr)
         raise SystemExit(2)
     state_store = StateStore(args.db_path)
+    role_context = None
     try:
-        if run_id and state_store.get_run(run_id) is None:
-            print(f"ERROR: Run not found: {run_id}", file=sys.stderr)
-            raise SystemExit(2)
-        if plan_id and state_store.get_event(plan_id) is None:
-            print(f"ERROR: Plan not found: {plan_id}", file=sys.stderr)
-            raise SystemExit(2)
+        if run_id:
+            run = state_store.get_run(run_id)
+            if run is None:
+                print(f"ERROR: Run not found: {run_id}", file=sys.stderr)
+                raise SystemExit(2)
+            if isinstance(run.metadata_json, dict):
+                role_context = _extract_role_context(run.metadata_json)
+        if plan_id:
+            event = state_store.get_event(plan_id)
+            if event is None:
+                print(f"ERROR: Plan not found: {plan_id}", file=sys.stderr)
+                raise SystemExit(2)
+            if isinstance(event.json_payload, dict):
+                role_context = _extract_role_context(event.json_payload)
     finally:
         state_store.close()
     traces = list_selection_traces(
@@ -48,6 +57,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
             limit=args.limit,
             included=included,
             excluded=excluded,
+            role_context=role_context,
         )
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2))
         return
@@ -56,6 +66,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
         plan_id=plan_id,
         included=included,
         excluded=excluded,
+        role_context=role_context,
     )
 
 
@@ -66,12 +77,14 @@ def _build_json_payload(
     limit: int,
     included: list[MemorySelectionTrace],
     excluded: list[MemorySelectionTrace],
+    role_context: dict[str, object] | None,
 ) -> dict[str, object]:
     return {
         "schema_version": 1,
         "run_id": run_id,
         "plan_id": plan_id,
         "limit": limit,
+        "agent_role": role_context,
         "counts": {
             "included": len(included),
             "excluded": len(excluded),
@@ -87,6 +100,7 @@ def _print_human(
     plan_id: str | None,
     included: list[MemorySelectionTrace],
     excluded: list[MemorySelectionTrace],
+    role_context: dict[str, object] | None,
 ) -> None:
     title = "Memory selection explain"
     if run_id:
@@ -94,8 +108,29 @@ def _print_human(
     if plan_id:
         title = f"{title} (plan {plan_id})"
     print(title)
+    if role_context:
+        role_name = role_context.get("role_name") or "-"
+        role_id = role_context.get("role_id") or "-"
+        profile_id = role_context.get("memory_profile_id") or "-"
+        print(f"Role: {role_name} ({role_id}) profile={profile_id}")
     _print_trace_group("Included", included)
     _print_trace_group("Excluded", excluded)
+
+
+def _extract_role_context(payload: dict[str, object]) -> dict[str, object] | None:
+    role = payload.get("agent_role")
+    if not isinstance(role, dict):
+        return None
+    role_id = role.get("role_id")
+    role_name = role.get("role_name")
+    memory_profile_id = role.get("memory_profile_id")
+    if not role_id and not role_name and not memory_profile_id:
+        return None
+    return {
+        "role_id": role_id,
+        "role_name": role_name,
+        "memory_profile_id": memory_profile_id,
+    }
 
 
 def _print_trace_group(label: str, traces: list[MemorySelectionTrace]) -> None:

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -55,6 +55,16 @@ class Run:
 
 
 @dataclass
+class AgentRole:
+    name: str
+    description: Optional[str] = None
+    memory_profile_id: Optional[str] = None
+    role_id: str = field(default_factory=lambda: str(uuid4()))
+    created_at: datetime = field(default_factory=_utc_now)
+    retired_at: Optional[datetime] = None
+
+
+@dataclass
 class Task:
     run_id: str
     title: str

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Iterable, Optional
 from uuid import uuid4
 
 from gismo.core.models import (
+    AgentRole,
     DaemonHeartbeat,
     Event,
     FailureType,
@@ -128,6 +129,18 @@ class StateStore:
                     created_at TEXT NOT NULL,
                     label TEXT NOT NULL,
                     metadata_json TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_roles (
+                    role_id TEXT PRIMARY KEY,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT NULL,
+                    memory_profile_id TEXT NULL,
+                    created_at TEXT NOT NULL,
+                    retired_at TEXT NULL
                 )
                 """
             )
@@ -576,6 +589,93 @@ class StateStore:
             )
             connection.commit()
         return run
+
+    def create_agent_role(
+        self,
+        *,
+        name: str,
+        description: Optional[str],
+        memory_profile_id: Optional[str],
+    ) -> AgentRole:
+        if not name or not name.strip():
+            raise ValueError("Role name must be a non-empty string")
+        role = AgentRole(
+            name=name.strip(),
+            description=description,
+            memory_profile_id=memory_profile_id,
+        )
+        try:
+            with self._connection() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO agent_roles (
+                        role_id, name, description, memory_profile_id, created_at, retired_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        role.role_id,
+                        role.name,
+                        role.description,
+                        role.memory_profile_id,
+                        role.created_at.isoformat(),
+                        role.retired_at.isoformat() if role.retired_at else None,
+                    ),
+                )
+                connection.commit()
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"Agent role already exists: {name}") from exc
+        return role
+
+    def list_agent_roles(self, *, include_retired: bool = True) -> list[AgentRole]:
+        sql = "SELECT * FROM agent_roles"
+        params: tuple[object, ...] = ()
+        if not include_retired:
+            sql += " WHERE retired_at IS NULL"
+        sql += " ORDER BY name ASC"
+        with self._connection() as connection:
+            rows = connection.execute(sql, params).fetchall()
+        return [self._row_to_agent_role(row) for row in rows]
+
+    def get_agent_role_by_selector(self, selector: str) -> Optional[AgentRole]:
+        if not selector:
+            return None
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM agent_roles WHERE role_id = ? OR name = ?",
+                (selector, selector),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_agent_role(row)
+
+    def retire_agent_role(self, *, role_id: str) -> tuple[AgentRole, bool]:
+        if not role_id:
+            raise ValueError("Role id must be provided")
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM agent_roles WHERE role_id = ?",
+                (role_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"Agent role not found: {role_id}")
+            role = self._row_to_agent_role(row)
+            if role.retired_at:
+                return role, False
+            retired_at = _utc_now()
+            connection.execute(
+                "UPDATE agent_roles SET retired_at = ? WHERE role_id = ?",
+                (retired_at.isoformat(), role.role_id),
+            )
+            connection.commit()
+            role = AgentRole(
+                role_id=role.role_id,
+                name=role.name,
+                description=role.description,
+                memory_profile_id=role.memory_profile_id,
+                created_at=role.created_at,
+                retired_at=retired_at,
+            )
+            return role, True
 
     def create_task(
         self,
@@ -1407,6 +1507,16 @@ class StateStore:
             status_reason=row["status_reason"],
         )
         return task
+
+    def _row_to_agent_role(self, row: sqlite3.Row) -> AgentRole:
+        return AgentRole(
+            role_id=row["role_id"],
+            name=row["name"],
+            description=row["description"],
+            memory_profile_id=row["memory_profile_id"],
+            created_at=_parse_dt(row["created_at"]),
+            retired_at=_parse_dt(row["retired_at"]) if row["retired_at"] else None,
+        )
 
     def _row_to_run(self, row: sqlite3.Row) -> Run:
         return Run(

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,14 +1,18 @@
+import argparse
 import contextlib
+import gc
 import io
 import json
 import os
 import sqlite3
 import tempfile
 import unittest
+import warnings
 from pathlib import Path
 from unittest import mock
 
 from gismo.cli import main as cli_main
+from gismo.cli import memory_explain as memory_explain_cli
 from gismo.core.models import QueueStatus
 from gismo.core.state import StateStore
 from gismo.memory.store import (
@@ -293,6 +297,117 @@ class AgentCliTest(unittest.TestCase):
             request = json.loads(row[0])
             self.assertEqual(request.get("profile_id"), profile.profile_id)
 
+    def test_agent_role_selects_profile_and_records_role_context(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "recall",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_hash = memory_policy_hash_for_path(None)
+            memory_upsert_item_with_timestamps(
+                db_path,
+                namespace="global",
+                key="alpha",
+                kind="fact",
+                value="alpha",
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                is_tombstoned=False,
+                created_at="2024-01-01T00:00:00+00:00",
+                updated_at="2024-01-03T00:00:00+00:00",
+                update_created_at=True,
+                actor="test",
+                policy_hash=policy_hash,
+                operation="put",
+            )
+            memory_upsert_item_with_timestamps(
+                db_path,
+                namespace="global",
+                key="beta",
+                kind="note",
+                value="beta",
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                is_tombstoned=False,
+                created_at="2024-01-01T00:00:00+00:00",
+                updated_at="2024-01-02T00:00:00+00:00",
+                update_created_at=True,
+                actor="test",
+                policy_hash=policy_hash,
+                operation="put",
+            )
+            profile = memory_create_profile(
+                db_path,
+                name="role-profile",
+                description=None,
+                include_namespaces=["global"],
+                exclude_namespaces=None,
+                include_kinds=["fact"],
+                exclude_kinds=None,
+                max_items=1,
+            )
+            state_store = StateStore(db_path)
+            role = state_store.create_agent_role(
+                name="planner",
+                description="Planner role",
+                memory_profile_id=profile.profile_id,
+            )
+            state_store.close()
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    cli_main.run_agent(
+                        db_path,
+                        "recall context",
+                        policy_path=None,
+                        once=True,
+                        max_cycles=1,
+                        yes=True,
+                        dry_run=False,
+                        role=role.name,
+                    )
+            state_store = StateStore(db_path)
+            event = next(
+                (item for item in state_store.list_events() if item.json_payload),
+                None,
+            )
+            self.assertIsNotNone(event)
+            payload = event.json_payload or {}
+            injected_keys = payload.get("memory_injected_keys")
+            self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
+            role_payload = payload.get("agent_role") or {}
+            self.assertEqual(role_payload.get("role_id"), role.role_id)
+            self.assertEqual(role_payload.get("role_name"), role.name)
+            self.assertEqual(role_payload.get("memory_profile_id"), profile.profile_id)
+            runs = list(state_store.list_runs(limit=5))
+            self.assertEqual(len(runs), 1)
+            run_role = runs[0].metadata_json.get("agent_role", {})
+            self.assertEqual(run_role.get("role_id"), role.role_id)
+            state_store.close()
+
+            args = argparse.Namespace(
+                db_path=db_path,
+                run=None,
+                plan=event.id,
+                limit=memory_explain_cli.DEFAULT_EXPLAIN_LIMIT,
+                json=True,
+            )
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                memory_explain_cli.run_memory_explain(args)
+            explain_payload = json.loads(buffer.getvalue())
+            explain_role = explain_payload.get("agent_role") or {}
+            self.assertEqual(explain_role.get("role_id"), role.role_id)
+            self.assertEqual(explain_role.get("memory_profile_id"), profile.profile_id)
+
     def test_agent_apply_memory_suggestions_requires_confirmation(self) -> None:
         response = json.dumps(
             {
@@ -354,6 +469,43 @@ class AgentCliTest(unittest.TestCase):
             state_store = StateStore(db_path)
             event = state_store.list_events()[0]
             self.assertEqual(event.id, related_event_id)
+
+    def test_agent_role_dry_run_releases_db_handle(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "recall",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            state_store = StateStore(str(db_path))
+            role = state_store.create_agent_role(
+                name="planner",
+                description=None,
+                memory_profile_id=None,
+            )
+            state_store.close()
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                    with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                        cli_main.run_agent(
+                            str(db_path),
+                            "recall context",
+                            policy_path=None,
+                            once=True,
+                            max_cycles=1,
+                            yes=True,
+                            dry_run=True,
+                            role=role.name,
+                        )
+                gc.collect()
+                self.assertTrue(db_path.exists())
+                os.remove(db_path)
+                self.assertFalse(db_path.exists())
 
     def test_agent_apply_memory_suggestions_non_interactive_fails_closed(self) -> None:
         response = json.dumps(

--- a/tests/test_agent_roles_cli.py
+++ b/tests/test_agent_roles_cli.py
@@ -1,0 +1,132 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.memory.store import create_profile as memory_create_profile
+
+
+def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+class AgentRoleCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.db_path = Path(self.temp_dir.name) / "state.db"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write_policy(self, policy: dict) -> Path:
+        path = Path(self.temp_dir.name) / "policy.json"
+        path.write_text(json.dumps(policy), encoding="utf-8")
+        return path
+
+    def test_agent_role_create_show_list_and_retire(self) -> None:
+        profile = memory_create_profile(
+            str(self.db_path),
+            name="planner-profile",
+            description=None,
+            include_namespaces=["global"],
+            exclude_namespaces=None,
+            include_kinds=["fact"],
+            exclude_kinds=None,
+            max_items=None,
+        )
+        policy_path = self._write_policy(
+            {
+                "allowed_tools": ["agent.role.create", "agent.role.retire"],
+                "memory": {"allow": {}},
+            }
+        )
+        create = _run_cli(
+            [
+                "agent",
+                "role",
+                "create",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--name",
+                "planner",
+                "--description",
+                "Planner role",
+                "--memory-profile",
+                profile.name,
+                "--yes",
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+        created = json.loads(create.stdout)
+        self.assertEqual(created["name"], "planner")
+        self.assertEqual(created["memory_profile_id"], profile.profile_id)
+
+        listed = _run_cli(
+            [
+                "agent",
+                "role",
+                "list",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(listed.returncode, 0, listed.stderr)
+        payload = json.loads(listed.stdout)
+        self.assertEqual(len(payload), 1)
+        self.assertEqual(payload[0]["name"], "planner")
+
+        show = _run_cli(
+            [
+                "agent",
+                "role",
+                "show",
+                "planner",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(show.returncode, 0, show.stderr)
+        details = json.loads(show.stdout)
+        self.assertEqual(details["name"], "planner")
+        self.assertEqual(details["memory_profile_id"], profile.profile_id)
+
+        retire = _run_cli(
+            [
+                "agent",
+                "role",
+                "retire",
+                "planner",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--yes",
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(retire.returncode, 0, retire.stderr)
+        retired = json.loads(retire.stdout)
+        self.assertEqual(retired["name"], "planner")
+        self.assertIsNotNone(retired["retired_at"])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -72,6 +72,29 @@ class ExportTest(unittest.TestCase):
             self.assertIn(run_two.id, output_path.name)
             self.assertNotIn(run_one.id, output_path.name)
 
+    def test_export_includes_agent_role_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            run = state_store.create_run(
+                label="role-export",
+                metadata={
+                    "agent_role": {
+                        "role_id": "role-123",
+                        "role_name": "planner",
+                        "memory_profile_id": "profile-123",
+                    }
+                },
+            )
+            output_path = export_run_jsonl(state_store, run.id, base_dir=Path(tmpdir))
+            records = [
+                json.loads(line)
+                for line in output_path.read_text(encoding="utf-8").strip().splitlines()
+            ]
+            run_record = records[0]
+            metadata = run_record["metadata"].get("agent_role", {})
+            self.assertEqual(metadata.get("role_id"), "role-123")
+
     def test_export_redact_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")

--- a/tests/test_memory_explain_cli.py
+++ b/tests/test_memory_explain_cli.py
@@ -172,6 +172,7 @@ class MemoryExplainCliTest(unittest.TestCase):
         self.assertIn("included", payload)
         self.assertIn("excluded", payload)
         self.assertIn("limit", payload)
+        self.assertIn("agent_role", payload)
         self.assertEqual(payload["plan_id"], plan_id)
         self.assertIsNone(payload["run_id"])
         if payload["included"]:

--- a/tests/test_run_show_cli.py
+++ b/tests/test_run_show_cli.py
@@ -79,6 +79,33 @@ def test_run_show_outputs_summary(repo_root: Path, db_path: Path) -> None:
     assert "output:" in stdout
 
 
+def test_run_show_includes_agent_role_context(repo_root: Path, db_path: Path) -> None:
+    state_store = StateStore(str(db_path))
+    run = state_store.create_run(
+        label="role-run",
+        metadata={
+            "agent_role": {
+                "role_id": "role-123",
+                "role_name": "planner",
+                "memory_profile_id": "profile-123",
+            }
+        },
+    )
+    state_store.close()
+
+    proc = _run_cli(["run", "--db", str(db_path), "show", run.id], cwd=repo_root)
+    assert proc.returncode == 0, proc.stderr
+    stdout = proc.stdout
+    assert "Role:" in stdout
+    assert "planner" in stdout
+    assert "profile-123" in stdout
+
+    proc_json = _run_cli(["runs", "--db", str(db_path), "show", "--json", run.id], cwd=repo_root)
+    assert proc_json.returncode == 0, proc_json.stderr
+    payload = json.loads(proc_json.stdout)
+    assert payload["agent_role"]["role_id"] == "role-123"
+
+
 def test_run_show_includes_memory_provenance(repo_root: Path, db_path: Path) -> None:
     state_store = StateStore(str(db_path))
     plan_event_id = str(uuid4())


### PR DESCRIPTION
### Motivation
- Provide operator-defined, first-class agent identities that bind a memory profile to a role for sequential, deterministic multi-agent workflows.
- Preserve safety and auditability by making role lifecycle policy-gated and confirmation-required, and by failing closed when constraints are violated.
- Surface role context in existing provenance and export paths so runs and memory explain traces include which role executed the plan.

### Description
- Added `AgentRole` dataclass and `agent_roles` SQLite table plus state APIs `create_agent_role`, `list_agent_roles`, `get_agent_role_by_selector`, and `retire_agent_role` in `gismo/core/state.py` and model in `gismo/core/models.py`.
- Implemented CLI handlers in `gismo/cli/agent_role.py` and wired subcommands under `gismo agent role` (create/list/show/retire) with policy checks, confirmation flows, and audit events, and added argparse wiring in `gismo/cli/main.py`.
- Integrated role resolution into the agent loop: `--role` selects a role (mutually exclusive with `--memory`/`--memory-profile`), its `memory_profile` is used for prompt injection, and role context is recorded in plan events, run metadata, `runs show`/JSON export, and `memory explain` output.
- Added tests and doc updates: `tests/test_agent_roles_cli.py`, updates to agent/memory explain/export/run-show tests, and README/AGENTS.md/Handoff.md entries describing behavior and operator commands.

### Testing
- Ran the repository verification: `python scripts/verify.py` which completed successfully.
- Executed the full test suite: `pytest -q`, resulting in all tests passing (197 passed, 3 skipped).
- New CLI behaviors exercised by automated tests `tests/test_agent_roles_cli.py` and updated agent tests which validated role creation, retirement, memory-profile selection, audit metadata, and DB handle release.
- Manual smoke/demonstration commands are covered by the test-driven examples; reproduce with `python -m gismo.cli.main agent --role planner "Plan as the planner role" --dry-run`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c513b7c288330b673342ffa253600)