### PR TITLE
Add supervised agent sessions with checkpoint/resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,6 +146,7 @@ The default “proof of life” for GISMO is a CLI demo that:
 Leashed autonomy:
 - The `agent` CLI loop must only plan → enqueue → execute via the queue/daemon and keep confirmation gates intact.
 - Agent memory context injection and suggestion application are optional, gated behaviors; defaults remain read-only unless explicitly enabled.
+- Agent sessions are operator-controlled checkpoints; each resume runs a single bounded iteration with no background loops.
 
 Agent roles:
 - Agent roles provide operator-defined identities tied to memory profiles.

--- a/Handoff.md
+++ b/Handoff.md
@@ -172,12 +172,12 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added agent roles with policy/confirmation-gated lifecycle and role-based memory profile selection.
-- Run/show/export/memory explain now surface role context for audit.
+- Added supervised agent sessions for checkpoint/resume workflows with strict safety gates.
+- Run/show/export/memory explain now surface session linkage alongside role context.
 
 Next steps:
-- Decide whether to ship default policy entries for agent role create/retire actions.
-- Gather operator feedback on role-based memory visibility workflows (planner vs executor).
+- Extend session metrics (elapsed time per step) once operators validate workflow.
+- Review default policies for session resume use in readonly contexts.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ Agent loop (leashed autonomy):
     --policy policy/dev-safe.json --yes
   gismo agent role retire planner --policy policy/dev-safe.json --yes
 
+Agent sessions (operator-controlled checkpointing, no background autonomy):
+
+  gismo agent session start --goal "Prepare incident summary" --role planner
+  gismo agent session list
+  gismo agent session show SESSION_ID --json
+  gismo agent session resume SESSION_ID --yes
+  gismo agent session pause SESSION_ID --yes
+  gismo agent session resume SESSION_ID --dry-run
+  gismo agent session cancel SESSION_ID --yes
+
+Session notes:
+- Each resume runs a single bounded iteration (no daemons, no timers, no parallelism).
+- Confirmation gates and policy checks still apply; non-interactive mode fails closed.
+
 Agent notes:
 - The agent loop is leashed autonomy: it plans, enqueues, and executes only through the queue/daemon.
 - Confirmation is required for high-risk plans or any shell/write actions unless --yes is provided.

--- a/gismo/cli/agent_session.py
+++ b/gismo/cli/agent_session.py
@@ -1,0 +1,615 @@
+"""Agent session CLI handlers."""
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, replace
+import json
+import sys
+from typing import Callable
+from uuid import uuid4
+
+from gismo.core.models import AgentSession, AgentSessionStatus, EVENT_TYPE_LLM_PLAN, QueueStatus
+from gismo.core.state import StateStore
+from gismo.memory.store import get_profile_by_selector as memory_get_profile_by_selector
+
+
+@dataclass(frozen=True)
+class SessionRoleContext:
+    role_id: str
+    role_name: str
+    memory_profile_id: str | None
+
+
+@dataclass(frozen=True)
+class AgentSessionDependencies:
+    request_llm_plan: Callable[..., tuple[dict, object, StateStore, dict[str, object]]]
+    build_memory_injection: Callable[..., object]
+    record_memory_profile_use: Callable[..., None]
+    confirm_agent_assessment: Callable[..., None]
+    enqueue_plan_actions: Callable[..., tuple[list[str], list[str]]]
+    drain_queue_items: Callable[..., list[QueueStatus]]
+    queue_status_summary: Callable[..., tuple[str, QueueStatus | None]]
+    apply_agent_role_payload: Callable[..., None]
+    link_selection_traces_to_run: Callable[..., None]
+    memory_decision_path: Callable[..., str]
+
+
+def run_agent_session_start(args: argparse.Namespace) -> None:
+    role_context = _resolve_role_context(args.db_path, args.role) if args.role else None
+    profile_id = role_context.memory_profile_id if role_context else None
+    profile_name = None
+    if profile_id:
+        profile_name = _resolve_profile_name(args.db_path, profile_id)
+    state_store = StateStore(args.db_path)
+    try:
+        session = state_store.create_agent_session(
+            goal=args.goal,
+            role_id=role_context.role_id if role_context else None,
+            role_name=role_context.role_name if role_context else None,
+            profile_id=profile_id,
+            profile_name=profile_name,
+            max_steps=args.max_steps,
+            notes=None,
+        )
+        _record_session_event(
+            state_store=state_store,
+            actor="operator",
+            operation="start",
+            session=session,
+            request={
+                "goal": session.goal,
+                "role": args.role,
+                "max_steps": session.max_steps,
+            },
+            result_meta={"status": "success"},
+        )
+    finally:
+        state_store.close()
+    if args.json:
+        print(json.dumps(_session_payload(session), ensure_ascii=False, sort_keys=True, indent=2))
+        return
+    print(f"Created agent session: {session.session_id}")
+
+
+def run_agent_session_show(args: argparse.Namespace) -> None:
+    state_store = StateStore(args.db_path)
+    try:
+        session = state_store.get_agent_session(args.session_id)
+        if session is None:
+            print(f"Agent session not found: {args.session_id}", file=sys.stderr)
+            raise SystemExit(2)
+    finally:
+        state_store.close()
+    if args.json:
+        print(json.dumps(_session_payload(session), ensure_ascii=False, sort_keys=True, indent=2))
+        return
+    _print_session_detail(session)
+
+
+def run_agent_session_list(args: argparse.Namespace) -> None:
+    state_store = StateStore(args.db_path)
+    try:
+        sessions = state_store.list_agent_sessions()
+    finally:
+        state_store.close()
+    if args.json:
+        payload = {
+            "schema_version": 1,
+            "sessions": [_serialize_session(session) for session in sessions],
+        }
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2))
+        return
+    if not sessions:
+        print("(no sessions)")
+        return
+    for session in sessions:
+        print(_format_session_line(session))
+
+
+def run_agent_session_pause(args: argparse.Namespace) -> None:
+    state_store = StateStore(args.db_path)
+    try:
+        session = _require_session(state_store, args.session_id)
+        if session.status == AgentSessionStatus.PAUSED:
+            print(f"Session already paused: {session.session_id}")
+            return
+        if session.status in {
+            AgentSessionStatus.COMPLETED,
+            AgentSessionStatus.CANCELED,
+            AgentSessionStatus.FAILED,
+        }:
+            print(f"Session is {session.status.value}; cannot pause.", file=sys.stderr)
+            raise SystemExit(2)
+        _confirm_operator_action("Pause agent session?", yes=args.yes, non_interactive=args.non_interactive)
+        session = state_store.update_agent_session(
+            replace(session, status=AgentSessionStatus.PAUSED)
+        )
+        _record_session_event(
+            state_store=state_store,
+            actor="operator",
+            operation="pause",
+            session=session,
+            request={"session_id": session.session_id},
+            result_meta={"status": "success"},
+        )
+    finally:
+        state_store.close()
+    print(f"Paused agent session: {session.session_id}")
+
+
+def run_agent_session_cancel(args: argparse.Namespace) -> None:
+    state_store = StateStore(args.db_path)
+    try:
+        session = _require_session(state_store, args.session_id)
+        if session.status == AgentSessionStatus.CANCELED:
+            print(f"Session already canceled: {session.session_id}")
+            return
+        if session.status == AgentSessionStatus.COMPLETED:
+            print("Session already completed; cannot cancel.", file=sys.stderr)
+            raise SystemExit(2)
+        _confirm_operator_action("Cancel agent session?", yes=args.yes, non_interactive=args.non_interactive)
+        session = state_store.update_agent_session(
+            replace(session, status=AgentSessionStatus.CANCELED)
+        )
+        _record_session_event(
+            state_store=state_store,
+            actor="operator",
+            operation="cancel",
+            session=session,
+            request={"session_id": session.session_id},
+            result_meta={"status": "success"},
+        )
+    finally:
+        state_store.close()
+    print(f"Canceled agent session: {session.session_id}")
+
+
+def run_agent_session_resume(args: argparse.Namespace, deps: AgentSessionDependencies) -> None:
+    initial_store = StateStore(args.db_path)
+    try:
+        session = _require_session(initial_store, args.session_id)
+        _ensure_session_resumable(session)
+        _validate_profile_snapshot(args.db_path, session)
+    finally:
+        initial_store.close()
+
+    plan_event_id = str(uuid4())
+    memory_injection = None
+    if session.profile_id or session.profile_name:
+        memory_injection = deps.build_memory_injection(
+            args.db_path,
+            profile_selector=session.profile_id or session.profile_name,
+            plan_id=plan_event_id,
+        )
+    role_context = None
+    if session.role_id and session.role_name:
+        role_context = SessionRoleContext(
+            role_id=session.role_id,
+            role_name=session.role_name,
+            memory_profile_id=session.profile_id,
+        )
+
+    plan, assessment, state_store, payload = deps.request_llm_plan(
+        args.db_path,
+        session.goal,
+        model=None,
+        host=None,
+        timeout_s=None,
+        enqueue=not args.dry_run,
+        dry_run=args.dry_run,
+        max_actions=10,
+        explain=False,
+        debug=False,
+        actor="agent_session",
+        memory_injection=memory_injection,
+        role_context=role_context,
+        assessment_policy_path=args.policy,
+        record_event=False,
+    )
+    try:
+        deps.record_memory_profile_use(
+            db_path=args.db_path,
+            memory_injection=memory_injection,
+            actor="agent_session",
+            related_event_id=plan_event_id,
+        )
+        next_step = session.step_count + 1
+        _apply_session_payload(payload, session, step_count=next_step)
+        payload.update(
+            {
+                "apply_memory_suggestions_requested": False,
+                "apply_memory_suggestions_result": {
+                    "applied": 0,
+                    "skipped": 0,
+                    "denied": 0,
+                },
+                "apply_memory_suggestions_applied": [],
+                "apply_memory_policy_path": None,
+                "apply_memory_yes": args.yes,
+                "apply_memory_non_interactive": args.non_interactive,
+                "apply_memory_decision_path": deps.memory_decision_path(
+                    yes=args.yes,
+                    non_interactive=args.non_interactive,
+                ),
+            }
+        )
+        state_store.record_event(
+            actor="agent_session",
+            event_type=EVENT_TYPE_LLM_PLAN,
+            message="LLM plan generated.",
+            json_payload=payload,
+            event_id=plan_event_id,
+        )
+
+        actions = plan.get("actions", [])
+        updated_session = replace(
+            session,
+            last_plan_event_id=plan_event_id,
+            step_count=next_step,
+            status=AgentSessionStatus.ACTIVE,
+        )
+
+        if args.dry_run:
+            updated_session = _finalize_session_status(updated_session, actions)
+            updated_session = state_store.update_agent_session(updated_session)
+            _record_session_event(
+                state_store=state_store,
+                actor="agent_session",
+                operation="resume",
+                session=updated_session,
+                request={"dry_run": True},
+                result_meta={
+                    "status": updated_session.status.value,
+                    "plan_event_id": plan_event_id,
+                    "run_id": None,
+                    "queue_status": "dry-run",
+                },
+            )
+            print(f"Dry-run completed for session {session.session_id}")
+            return
+
+        if actions and args.non_interactive:
+            updated_session = state_store.update_agent_session(
+                replace(updated_session, status=AgentSessionStatus.PAUSED)
+            )
+            _record_session_event(
+                state_store=state_store,
+                actor="agent_session",
+                operation="resume",
+                session=updated_session,
+                request={"non_interactive": True},
+                result_meta={
+                    "status": "blocked",
+                    "plan_event_id": plan_event_id,
+                    "run_id": None,
+                    "queue_status": "blocked",
+                    "reason": "non_interactive",
+                },
+            )
+            print(
+                "Refusing to enqueue in non-interactive mode. Use --yes to override.",
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+
+        try:
+            deps.confirm_agent_assessment(assessment, actions, yes=args.yes)
+        except SystemExit:
+            updated_session = state_store.update_agent_session(
+                replace(updated_session, status=AgentSessionStatus.PAUSED)
+            )
+            _record_session_event(
+                state_store=state_store,
+                actor="agent_session",
+                operation="resume",
+                session=updated_session,
+                request={"confirmation": "declined"},
+                result_meta={
+                    "status": "blocked",
+                    "plan_event_id": plan_event_id,
+                    "run_id": None,
+                    "queue_status": "blocked",
+                    "reason": "confirmation_declined",
+                },
+            )
+            raise
+
+        if not actions:
+            updated_session = _finalize_session_status(updated_session, actions)
+            updated_session = state_store.update_agent_session(updated_session)
+            _record_session_event(
+                state_store=state_store,
+                actor="agent_session",
+                operation="resume",
+                session=updated_session,
+                request={},
+                result_meta={
+                    "status": updated_session.status.value,
+                    "plan_event_id": plan_event_id,
+                    "run_id": None,
+                    "queue_status": "no-actions",
+                },
+            )
+            print(f"No actions to enqueue for session {session.session_id}")
+            return
+
+        run_metadata: dict[str, object] = {
+            "goal": session.goal,
+            "source": "agent_session",
+            "plan_event_id": plan_event_id,
+        }
+        if role_context:
+            deps.apply_agent_role_payload(run_metadata, role_context)
+        _apply_session_payload(run_metadata, session, step_count=next_step)
+        run = state_store.create_run(
+            label="agent-session",
+            metadata=run_metadata,
+        )
+        deps.link_selection_traces_to_run(
+            args.db_path,
+            plan_id=plan_event_id,
+            run_id=run.id,
+        )
+
+        enqueued_ids, skipped = deps.enqueue_plan_actions(state_store, plan, run_id=run.id)
+        if skipped:
+            print("Enqueue notes:")
+            for note in skipped:
+                print(f"- {note}")
+        if not enqueued_ids:
+            updated_session = _finalize_session_status(updated_session, actions)
+            updated_session = state_store.update_agent_session(updated_session)
+            _record_session_event(
+                state_store=state_store,
+                actor="agent_session",
+                operation="resume",
+                session=updated_session,
+                request={},
+                result_meta={
+                    "status": updated_session.status.value,
+                    "plan_event_id": plan_event_id,
+                    "run_id": run.id,
+                    "queue_status": "no-actions",
+                },
+            )
+            print("No enqueue actions were generated.")
+            return
+
+        statuses = deps.drain_queue_items(args.db_path, args.policy, enqueued_ids)
+        status_label, _ = deps.queue_status_summary(statuses)
+        if status_label == "succeeded":
+            updated_session = replace(updated_session, last_run_id=run.id)
+            updated_session = _finalize_session_status(updated_session, actions)
+        elif status_label == "failed":
+            updated_session = replace(
+                updated_session,
+                last_run_id=run.id,
+                status=AgentSessionStatus.FAILED,
+            )
+        else:
+            updated_session = replace(
+                updated_session,
+                last_run_id=run.id,
+                status=AgentSessionStatus.PAUSED,
+            )
+        updated_session = state_store.update_agent_session(updated_session)
+        _record_session_event(
+            state_store=state_store,
+            actor="agent_session",
+            operation="resume",
+            session=updated_session,
+            request={},
+            result_meta={
+                "status": updated_session.status.value,
+                "plan_event_id": plan_event_id,
+                "run_id": run.id,
+                "queue_status": status_label,
+            },
+        )
+        print(
+            "Session resume completed: "
+            f"status={updated_session.status.value} "
+            f"run_id={run.id} queue_status={status_label}"
+        )
+    finally:
+        state_store.close()
+
+
+def _apply_session_payload(
+    payload: dict[str, object],
+    session: AgentSession,
+    *,
+    step_count: int,
+) -> None:
+    payload["agent_session"] = {
+        "session_id": session.session_id,
+        "role_id": session.role_id,
+        "role_name": session.role_name,
+        "profile_id": session.profile_id,
+        "profile_name": session.profile_name,
+        "goal": session.goal,
+        "step_count": step_count,
+        "max_steps": session.max_steps,
+        "status": session.status.value,
+    }
+
+
+def _finalize_session_status(
+    session: AgentSession,
+    actions: list[dict[str, object]],
+) -> AgentSession:
+    status = session.status
+    if not actions:
+        status = AgentSessionStatus.COMPLETED
+    if session.step_count >= session.max_steps:
+        status = AgentSessionStatus.COMPLETED
+    return replace(session, status=status)
+
+
+def _record_session_event(
+    *,
+    state_store: StateStore,
+    actor: str,
+    operation: str,
+    session: AgentSession,
+    request: dict[str, object],
+    result_meta: dict[str, object],
+) -> None:
+    payload = {
+        "operation": operation,
+        "session_id": session.session_id,
+        "goal": session.goal,
+        "role_name": session.role_name,
+        "profile_name": session.profile_name,
+        "step_count": session.step_count,
+        "max_steps": session.max_steps,
+        "request": request,
+        "result_meta": result_meta,
+    }
+    state_store.record_event(
+        actor=actor,
+        event_type="agent_session",
+        message=f"Agent session {operation}.",
+        json_payload=payload,
+    )
+
+
+def _ensure_session_resumable(session: AgentSession) -> None:
+    if session.status in {
+        AgentSessionStatus.COMPLETED,
+        AgentSessionStatus.CANCELED,
+        AgentSessionStatus.FAILED,
+    }:
+        print(f"Session is {session.status.value}; cannot resume.", file=sys.stderr)
+        raise SystemExit(2)
+    if session.step_count >= session.max_steps:
+        print("Session max steps reached; cannot resume.", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def _validate_profile_snapshot(db_path: str, session: AgentSession) -> None:
+    selector = session.profile_id or session.profile_name
+    if not selector:
+        return
+    profile = memory_get_profile_by_selector(db_path, selector)
+    if profile is None:
+        print(f"Session profile missing: {selector}", file=sys.stderr)
+        raise SystemExit(2)
+    if profile.retired_at:
+        print(f"Session profile is retired: {profile.name}", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def _resolve_profile_name(db_path: str, selector: str) -> str:
+    profile = memory_get_profile_by_selector(db_path, selector)
+    if profile is None:
+        print(f"Memory profile not found: {selector}", file=sys.stderr)
+        raise SystemExit(2)
+    if profile.retired_at:
+        print(f"Memory profile is retired: {profile.name}", file=sys.stderr)
+        raise SystemExit(2)
+    return profile.name
+
+
+def _resolve_role_context(db_path: str, selector: str) -> SessionRoleContext:
+    state_store = StateStore(db_path)
+    try:
+        role = state_store.get_agent_role_by_selector(selector)
+    finally:
+        state_store.close()
+    if role is None:
+        print(f"Agent role not found: {selector}", file=sys.stderr)
+        raise SystemExit(2)
+    if role.retired_at:
+        print(f"Agent role is retired: {role.name}", file=sys.stderr)
+        raise SystemExit(2)
+    if role.memory_profile_id:
+        _resolve_profile_name(db_path, role.memory_profile_id)
+    return SessionRoleContext(
+        role_id=role.role_id,
+        role_name=role.name,
+        memory_profile_id=role.memory_profile_id,
+    )
+
+
+def _confirm_operator_action(prompt: str, *, yes: bool, non_interactive: bool) -> None:
+    if yes:
+        return
+    if non_interactive or not _is_interactive_tty():
+        print("Confirmation required. Use --yes in non-interactive mode.", file=sys.stderr)
+        raise SystemExit(2)
+    response = input(f"{prompt} [y/N]:")
+    if response.strip().lower() not in {"y", "yes"}:
+        print("Confirmation declined.", file=sys.stderr)
+        raise SystemExit(2)
+
+
+def _require_session(state_store: StateStore, session_id: str) -> AgentSession:
+    session = state_store.get_agent_session(session_id)
+    if session is None:
+        print(f"Agent session not found: {session_id}", file=sys.stderr)
+        raise SystemExit(2)
+    return session
+
+
+def _is_interactive_tty() -> bool:
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _session_payload(session: AgentSession) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "session": _serialize_session(session),
+    }
+
+
+def _serialize_session(session: AgentSession) -> dict[str, object]:
+    return {
+        "session_id": session.session_id,
+        "role_id": session.role_id,
+        "role_name": session.role_name,
+        "profile_id": session.profile_id,
+        "profile_name": session.profile_name,
+        "goal": session.goal,
+        "status": session.status.value,
+        "created_at": session.created_at.isoformat(),
+        "updated_at": session.updated_at.isoformat(),
+        "last_plan_event_id": session.last_plan_event_id,
+        "last_run_id": session.last_run_id,
+        "step_count": session.step_count,
+        "max_steps": session.max_steps,
+        "notes": session.notes,
+    }
+
+
+def _format_session_line(session: AgentSession) -> str:
+    role = session.role_name or "-"
+    profile = session.profile_name or "-"
+    goal = _truncate(session.goal, 60)
+    return (
+        f"- {session.session_id} status={session.status.value} "
+        f"steps={session.step_count}/{session.max_steps} "
+        f"role={role} profile={profile} goal={goal}"
+    )
+
+
+def _print_session_detail(session: AgentSession) -> None:
+    print("=== GISMO Agent Session ===")
+    print(f"Session ID:    {session.session_id}")
+    print(f"Status:        {session.status.value}")
+    print(f"Goal:          {session.goal}")
+    print(f"Role:          {session.role_name or '-'}")
+    print(f"Profile:       {session.profile_name or '-'}")
+    print(f"Steps:         {session.step_count}/{session.max_steps}")
+    print(f"Last plan:     {session.last_plan_event_id or '-'}")
+    print(f"Last run:      {session.last_run_id or '-'}")
+    print(f"Created:       {session.created_at.isoformat()}")
+    print(f"Updated:       {session.updated_at.isoformat()}")
+    if session.notes:
+        print(f"Notes:         {session.notes}")
+
+
+def _truncate(value: str, max_len: int) -> str:
+    if len(value) <= max_len:
+        return value
+    return value[: max(0, max_len - 1)] + "…"

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -19,6 +19,7 @@ from gismo.cli import memory_explain as memory_explain_cli
 from gismo.cli import memory_profile as memory_profile_cli
 from gismo.cli import memory_snapshot as memory_snapshot_cli
 from gismo.cli import agent_role as agent_role_cli
+from gismo.cli import agent_session as agent_session_cli
 from gismo.cli.operator import (
     make_idempotency_key,
     normalize_command,
@@ -1018,8 +1019,10 @@ def _serialize_run_show_payload(
         )
     memory_payload = memory_provenance.to_dict()
     agent_role = None
+    agent_session = None
     if isinstance(run.metadata_json, dict):
         agent_role = run.metadata_json.get("agent_role")
+        agent_session = run.metadata_json.get("agent_session")
     return {
         "run": {
             "id": run.id,
@@ -1033,6 +1036,7 @@ def _serialize_run_show_payload(
         "tasks": task_payloads,
         "tool_calls": call_payloads,
         "agent_role": agent_role,
+        "agent_session": agent_session,
         "memory_provenance": memory_payload,
     }
 
@@ -1160,13 +1164,21 @@ def run_show(db_path: str, run_id: str, *, json_output: bool = False) -> None:
             f"succeeded={counts['succeeded']} failed={counts['failed']})"
         )
         agent_role = None
+        agent_session = None
         if isinstance(run.metadata_json, dict):
             agent_role = run.metadata_json.get("agent_role")
+            agent_session = run.metadata_json.get("agent_session")
         if isinstance(agent_role, dict):
             role_name = agent_role.get("role_name") or "-"
             role_id = agent_role.get("role_id") or "-"
             profile_id = agent_role.get("memory_profile_id") or "-"
             print(f"Role:       {role_name} ({role_id}) profile={profile_id}")
+        if isinstance(agent_session, dict):
+            session_id = agent_session.get("session_id") or "-"
+            step_count = agent_session.get("step_count")
+            max_steps = agent_session.get("max_steps")
+            step_label = f"{step_count}/{max_steps}" if step_count is not None else "-"
+            print(f"Session:    {session_id} steps={step_label}")
         print("Tasks:")
         if not tasks:
             print("  (no tasks)")
@@ -3938,6 +3950,21 @@ def _snapshot_dependencies() -> memory_snapshot_cli.SnapshotDependencies:
     )
 
 
+def _agent_session_dependencies() -> agent_session_cli.AgentSessionDependencies:
+    return agent_session_cli.AgentSessionDependencies(
+        request_llm_plan=_request_llm_plan,
+        build_memory_injection=_build_memory_injection,
+        record_memory_profile_use=_record_memory_profile_use,
+        confirm_agent_assessment=_confirm_agent_assessment,
+        enqueue_plan_actions=_enqueue_plan_actions,
+        drain_queue_items=_drain_queue_items,
+        queue_status_summary=_queue_status_summary,
+        apply_agent_role_payload=_apply_agent_role_payload,
+        link_selection_traces_to_run=memory_link_selection_traces_to_run,
+        memory_decision_path=_memory_decision_path,
+    )
+
+
 def _handle_demo(args: argparse.Namespace) -> None:
     run_demo(args.db_path, args.policy)
 
@@ -4041,6 +4068,30 @@ def _handle_agent_role_create(args: argparse.Namespace) -> None:
 
 def _handle_agent_role_retire(args: argparse.Namespace) -> None:
     agent_role_cli.run_agent_role_retire(args)
+
+
+def _handle_agent_session_start(args: argparse.Namespace) -> None:
+    agent_session_cli.run_agent_session_start(args)
+
+
+def _handle_agent_session_show(args: argparse.Namespace) -> None:
+    agent_session_cli.run_agent_session_show(args)
+
+
+def _handle_agent_session_list(args: argparse.Namespace) -> None:
+    agent_session_cli.run_agent_session_list(args)
+
+
+def _handle_agent_session_pause(args: argparse.Namespace) -> None:
+    agent_session_cli.run_agent_session_pause(args)
+
+
+def _handle_agent_session_resume(args: argparse.Namespace) -> None:
+    agent_session_cli.run_agent_session_resume(args, _agent_session_dependencies())
+
+
+def _handle_agent_session_cancel(args: argparse.Namespace) -> None:
+    agent_session_cli.run_agent_session_cancel(args)
 
 
 def _handle_memory_explain(args: argparse.Namespace) -> None:
@@ -5944,6 +5995,143 @@ def build_parser() -> argparse.ArgumentParser:
     )
     agent_role_retire_parser.set_defaults(handler=_handle_agent_role_retire)
 
+    agent_session_parser = subparsers.add_parser(
+        "agent-session",
+        help="Manage supervised agent sessions",
+        parents=[db_parent_optional],
+    )
+    agent_session_subparsers = agent_session_parser.add_subparsers(
+        dest="agent_session_command",
+    )
+    agent_session_start_parser = agent_session_subparsers.add_parser(
+        "start",
+        help="Start a new agent session",
+        parents=[db_parent_optional],
+    )
+    agent_session_start_parser.add_argument(
+        "--goal",
+        required=True,
+        help="Goal statement for the session",
+    )
+    agent_session_start_parser.add_argument(
+        "--role",
+        default=None,
+        help="Agent role name or id (determines memory profile)",
+    )
+    agent_session_start_parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=12,
+        help="Maximum number of session steps (default: 12)",
+    )
+    agent_session_start_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_session_start_parser.set_defaults(handler=_handle_agent_session_start)
+
+    agent_session_show_parser = agent_session_subparsers.add_parser(
+        "show",
+        help="Show a session",
+        parents=[db_parent_optional],
+    )
+    agent_session_show_parser.add_argument(
+        "session_id",
+        help="Session id",
+    )
+    agent_session_show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_session_show_parser.set_defaults(handler=_handle_agent_session_show)
+
+    agent_session_list_parser = agent_session_subparsers.add_parser(
+        "list",
+        help="List sessions",
+        parents=[db_parent_optional],
+    )
+    agent_session_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    agent_session_list_parser.set_defaults(handler=_handle_agent_session_list)
+
+    agent_session_pause_parser = agent_session_subparsers.add_parser(
+        "pause",
+        help="Pause a session",
+        parents=[db_parent_optional],
+    )
+    agent_session_pause_parser.add_argument(
+        "session_id",
+        help="Session id",
+    )
+    agent_session_pause_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    agent_session_pause_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting",
+    )
+    agent_session_pause_parser.set_defaults(handler=_handle_agent_session_pause)
+
+    agent_session_resume_parser = agent_session_subparsers.add_parser(
+        "resume",
+        help="Resume a session (one iteration)",
+        parents=[db_parent_optional],
+    )
+    agent_session_resume_parser.add_argument(
+        "session_id",
+        help="Session id",
+    )
+    agent_session_resume_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Path to a JSON policy file",
+    )
+    agent_session_resume_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompts for high-risk plans",
+    )
+    agent_session_resume_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting",
+    )
+    agent_session_resume_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show the plan and assessment without enqueueing",
+    )
+    agent_session_resume_parser.set_defaults(handler=_handle_agent_session_resume)
+
+    agent_session_cancel_parser = agent_session_subparsers.add_parser(
+        "cancel",
+        help="Cancel a session",
+        parents=[db_parent_optional],
+    )
+    agent_session_cancel_parser.add_argument(
+        "session_id",
+        help="Session id",
+    )
+    agent_session_cancel_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    agent_session_cancel_parser.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Fail closed instead of prompting",
+    )
+    agent_session_cancel_parser.set_defaults(handler=_handle_agent_session_cancel)
+
     daemon_parser = subparsers.add_parser(
         "daemon",
         help="Run the GISMO daemon loop",
@@ -6450,6 +6638,8 @@ def main() -> None:
     argv = sys.argv[1:]
     if len(argv) > 1 and argv[0] == "agent" and argv[1] == "role":
         argv = ["agent-role", *argv[2:]]
+    if len(argv) > 1 and argv[0] == "agent" and argv[1] == "session":
+        argv = ["agent-session", *argv[2:]]
     if _has_shell_prompt_paste(argv):
         print(
             "It looks like you pasted your shell prompt. "

--- a/gismo/cli/memory_explain.py
+++ b/gismo/cli/memory_explain.py
@@ -25,6 +25,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
         raise SystemExit(2)
     state_store = StateStore(args.db_path)
     role_context = None
+    session_context = None
     try:
         if run_id:
             run = state_store.get_run(run_id)
@@ -33,6 +34,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
                 raise SystemExit(2)
             if isinstance(run.metadata_json, dict):
                 role_context = _extract_role_context(run.metadata_json)
+                session_context = _extract_session_context(run.metadata_json)
         if plan_id:
             event = state_store.get_event(plan_id)
             if event is None:
@@ -40,6 +42,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
                 raise SystemExit(2)
             if isinstance(event.json_payload, dict):
                 role_context = _extract_role_context(event.json_payload)
+                session_context = _extract_session_context(event.json_payload)
     finally:
         state_store.close()
     traces = list_selection_traces(
@@ -58,6 +61,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
             included=included,
             excluded=excluded,
             role_context=role_context,
+            session_context=session_context,
         )
         print(json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2))
         return
@@ -67,6 +71,7 @@ def run_memory_explain(args: argparse.Namespace) -> None:
         included=included,
         excluded=excluded,
         role_context=role_context,
+        session_context=session_context,
     )
 
 
@@ -78,6 +83,7 @@ def _build_json_payload(
     included: list[MemorySelectionTrace],
     excluded: list[MemorySelectionTrace],
     role_context: dict[str, object] | None,
+    session_context: dict[str, object] | None,
 ) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -85,6 +91,7 @@ def _build_json_payload(
         "plan_id": plan_id,
         "limit": limit,
         "agent_role": role_context,
+        "agent_session": session_context,
         "counts": {
             "included": len(included),
             "excluded": len(excluded),
@@ -101,6 +108,7 @@ def _print_human(
     included: list[MemorySelectionTrace],
     excluded: list[MemorySelectionTrace],
     role_context: dict[str, object] | None,
+    session_context: dict[str, object] | None,
 ) -> None:
     title = "Memory selection explain"
     if run_id:
@@ -113,6 +121,12 @@ def _print_human(
         role_id = role_context.get("role_id") or "-"
         profile_id = role_context.get("memory_profile_id") or "-"
         print(f"Role: {role_name} ({role_id}) profile={profile_id}")
+    if session_context:
+        session_id = session_context.get("session_id") or "-"
+        step_count = session_context.get("step_count")
+        max_steps = session_context.get("max_steps")
+        step_label = f"{step_count}/{max_steps}" if step_count is not None else "-"
+        print(f"Session: {session_id} steps={step_label}")
     _print_trace_group("Included", included)
     _print_trace_group("Excluded", excluded)
 
@@ -130,6 +144,22 @@ def _extract_role_context(payload: dict[str, object]) -> dict[str, object] | Non
         "role_id": role_id,
         "role_name": role_name,
         "memory_profile_id": memory_profile_id,
+    }
+
+
+def _extract_session_context(payload: dict[str, object]) -> dict[str, object] | None:
+    session = payload.get("agent_session")
+    if not isinstance(session, dict):
+        return None
+    session_id = session.get("session_id")
+    step_count = session.get("step_count")
+    max_steps = session.get("max_steps")
+    if not session_id and step_count is None and max_steps is None:
+        return None
+    return {
+        "session_id": session_id,
+        "step_count": step_count,
+        "max_steps": max_steps,
     }
 
 

--- a/gismo/core/export.py
+++ b/gismo/core/export.py
@@ -6,7 +6,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from gismo.core.models import Run, Task, ToolCall
+from gismo.core.models import AgentSession, Run, Task, ToolCall
 from gismo.core.paths import resolve_exports_dir
 from gismo.core.state import MemoryEventRecord, MemoryProvenance, StateStore
 
@@ -32,8 +32,21 @@ def export_run_jsonl(
     tool_calls = list(state_store.list_tool_calls(run_id))
     memory_provenance = state_store.get_memory_provenance(run.id)
     plan_event_id = None
+    session: AgentSession | None = None
+    session_events: list[Any] = []
     if isinstance(run.metadata_json, dict):
         plan_event_id = run.metadata_json.get("plan_event_id")
+        session_context = run.metadata_json.get("agent_session")
+        if isinstance(session_context, dict):
+            session_id = session_context.get("session_id")
+            if session_id:
+                session = state_store.get_agent_session(session_id)
+                session_events = [
+                    event
+                    for event in state_store.list_events_by_type("agent_session")
+                    if isinstance(event.json_payload, dict)
+                    and event.json_payload.get("session_id") == session_id
+                ]
     plan_event = state_store.get_event(plan_event_id) if plan_event_id else None
     memory_events = state_store.list_memory_events(
         related_run_id=run.id,
@@ -43,6 +56,8 @@ def export_run_jsonl(
         run,
         tasks,
         tool_calls,
+        agent_session=session,
+        session_events=session_events,
         memory_provenance=memory_provenance,
         plan_event=plan_event,
         memory_events=memory_events,
@@ -93,6 +108,8 @@ def _build_records(
     tasks: list[Task],
     tool_calls: list[ToolCall],
     *,
+    agent_session: AgentSession | None,
+    session_events: list[Any],
     memory_provenance: MemoryProvenance,
     plan_event: Any | None,
     memory_events: list[MemoryEventRecord],
@@ -101,6 +118,13 @@ def _build_records(
     sorted_tasks = sorted(tasks, key=lambda task: task.created_at)
     sorted_calls = sorted(tool_calls, key=lambda call: (call.started_at, call.attempt_number))
     records = [_serialize_run(run, memory_provenance)]
+    if agent_session is not None:
+        records.append(_serialize_agent_session(agent_session))
+    if session_events:
+        records.extend(
+            _serialize_event(event, memory_provenance=memory_provenance, redact=redact)
+            for event in session_events
+        )
     if plan_event is not None:
         records.append(
             _serialize_event(plan_event, memory_provenance=memory_provenance, redact=redact)
@@ -126,6 +150,26 @@ def _serialize_run(run: Run, memory_provenance: MemoryProvenance) -> dict[str, A
         "status": "CREATED",
         "failure_type": "NONE",
         "memory_provenance": memory_provenance.to_dict(),
+    }
+
+
+def _serialize_agent_session(session: AgentSession) -> dict[str, Any]:
+    return {
+        "record_type": "agent_session",
+        "session_id": session.session_id,
+        "role_id": session.role_id,
+        "role_name": session.role_name,
+        "profile_id": session.profile_id,
+        "profile_name": session.profile_name,
+        "goal": session.goal,
+        "status": session.status.value,
+        "created_at": session.created_at.isoformat(),
+        "updated_at": session.updated_at.isoformat(),
+        "last_plan_event_id": session.last_plan_event_id,
+        "last_run_id": session.last_run_id,
+        "step_count": session.step_count,
+        "max_steps": session.max_steps,
+        "notes": session.notes,
     }
 
 

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -42,6 +42,14 @@ class QueueStatus(str, Enum):
     CANCELLED = "CANCELLED"
 
 
+class AgentSessionStatus(str, Enum):
+    ACTIVE = "ACTIVE"
+    PAUSED = "PAUSED"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    CANCELED = "CANCELED"
+
+
 EVENT_TYPE_LLM_PLAN = "llm_plan"
 EVENT_TYPE_ASK_FAILED = "ask_failed"
 
@@ -62,6 +70,24 @@ class AgentRole:
     role_id: str = field(default_factory=lambda: str(uuid4()))
     created_at: datetime = field(default_factory=_utc_now)
     retired_at: Optional[datetime] = None
+
+
+@dataclass
+class AgentSession:
+    goal: str
+    session_id: str = field(default_factory=lambda: str(uuid4()))
+    role_id: Optional[str] = None
+    role_name: Optional[str] = None
+    profile_id: Optional[str] = None
+    profile_name: Optional[str] = None
+    status: AgentSessionStatus = AgentSessionStatus.ACTIVE
+    created_at: datetime = field(default_factory=_utc_now)
+    updated_at: datetime = field(default_factory=_utc_now)
+    last_plan_event_id: Optional[str] = None
+    last_run_id: Optional[str] = None
+    step_count: int = 0
+    max_steps: int = 12
+    notes: Optional[str] = None
 
 
 @dataclass

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -11,6 +11,8 @@ from typing import Any, Dict, Iterable, Optional
 from uuid import uuid4
 
 from gismo.core.models import (
+    AgentSession,
+    AgentSessionStatus,
     AgentRole,
     DaemonHeartbeat,
     Event,
@@ -141,6 +143,26 @@ class StateStore:
                     memory_profile_id TEXT NULL,
                     created_at TEXT NOT NULL,
                     retired_at TEXT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS agent_sessions (
+                    session_id TEXT PRIMARY KEY,
+                    role_id TEXT NULL,
+                    role_name TEXT NULL,
+                    profile_id TEXT NULL,
+                    profile_name TEXT NULL,
+                    goal TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    last_plan_event_id TEXT NULL,
+                    last_run_id TEXT NULL,
+                    step_count INTEGER NOT NULL DEFAULT 0,
+                    max_steps INTEGER NOT NULL DEFAULT 12,
+                    notes TEXT NULL
                 )
                 """
             )
@@ -483,6 +505,16 @@ class StateStore:
             ).fetchall()
         return [self._row_to_event(row) for row in rows]
 
+    def list_events_by_type(self, event_type: str) -> list[Event]:
+        if not event_type:
+            return []
+        with self._connection() as connection:
+            rows = connection.execute(
+                "SELECT * FROM events WHERE event_type = ? ORDER BY ts ASC, id ASC",
+                (event_type,),
+            ).fetchall()
+        return [self._row_to_event(row) for row in rows]
+
     def get_event(self, event_id: str) -> Optional[Event]:
         with self._connection() as connection:
             row = connection.execute(
@@ -626,6 +658,59 @@ class StateStore:
             raise ValueError(f"Agent role already exists: {name}") from exc
         return role
 
+    def create_agent_session(
+        self,
+        *,
+        goal: str,
+        role_id: Optional[str],
+        role_name: Optional[str],
+        profile_id: Optional[str],
+        profile_name: Optional[str],
+        max_steps: int = 12,
+        notes: Optional[str] = None,
+    ) -> AgentSession:
+        if not goal or not goal.strip():
+            raise ValueError("Session goal must be a non-empty string")
+        if max_steps <= 0:
+            raise ValueError("max_steps must be > 0")
+        session = AgentSession(
+            goal=goal.strip(),
+            role_id=role_id,
+            role_name=role_name,
+            profile_id=profile_id,
+            profile_name=profile_name,
+            max_steps=max_steps,
+            notes=notes,
+        )
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO agent_sessions (
+                    session_id, role_id, role_name, profile_id, profile_name,
+                    goal, status, created_at, updated_at,
+                    last_plan_event_id, last_run_id, step_count, max_steps, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session.session_id,
+                    session.role_id,
+                    session.role_name,
+                    session.profile_id,
+                    session.profile_name,
+                    session.goal,
+                    session.status.value,
+                    session.created_at.isoformat(),
+                    session.updated_at.isoformat(),
+                    session.last_plan_event_id,
+                    session.last_run_id,
+                    session.step_count,
+                    session.max_steps,
+                    session.notes,
+                ),
+            )
+            connection.commit()
+        return session
+
     def list_agent_roles(self, *, include_retired: bool = True) -> list[AgentRole]:
         sql = "SELECT * FROM agent_roles"
         params: tuple[object, ...] = ()
@@ -635,6 +720,13 @@ class StateStore:
         with self._connection() as connection:
             rows = connection.execute(sql, params).fetchall()
         return [self._row_to_agent_role(row) for row in rows]
+
+    def list_agent_sessions(self) -> list[AgentSession]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                "SELECT * FROM agent_sessions ORDER BY created_at ASC, session_id ASC"
+            ).fetchall()
+        return [self._row_to_agent_session(row) for row in rows]
 
     def get_agent_role_by_selector(self, selector: str) -> Optional[AgentRole]:
         if not selector:
@@ -647,6 +739,65 @@ class StateStore:
         if row is None:
             return None
         return self._row_to_agent_role(row)
+
+    def get_agent_session(self, session_id: str) -> Optional[AgentSession]:
+        if not session_id:
+            return None
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM agent_sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_agent_session(row)
+
+    def update_agent_session(self, session: AgentSession) -> AgentSession:
+        updated = AgentSession(
+            session_id=session.session_id,
+            goal=session.goal,
+            role_id=session.role_id,
+            role_name=session.role_name,
+            profile_id=session.profile_id,
+            profile_name=session.profile_name,
+            status=session.status,
+            created_at=session.created_at,
+            updated_at=_utc_now(),
+            last_plan_event_id=session.last_plan_event_id,
+            last_run_id=session.last_run_id,
+            step_count=session.step_count,
+            max_steps=session.max_steps,
+            notes=session.notes,
+        )
+        with self._connection() as connection:
+            connection.execute(
+                """
+                UPDATE agent_sessions
+                SET role_id = ?, role_name = ?, profile_id = ?, profile_name = ?,
+                    goal = ?, status = ?, created_at = ?, updated_at = ?,
+                    last_plan_event_id = ?, last_run_id = ?, step_count = ?,
+                    max_steps = ?, notes = ?
+                WHERE session_id = ?
+                """,
+                (
+                    updated.role_id,
+                    updated.role_name,
+                    updated.profile_id,
+                    updated.profile_name,
+                    updated.goal,
+                    updated.status.value,
+                    updated.created_at.isoformat(),
+                    updated.updated_at.isoformat(),
+                    updated.last_plan_event_id,
+                    updated.last_run_id,
+                    updated.step_count,
+                    updated.max_steps,
+                    updated.notes,
+                    updated.session_id,
+                ),
+            )
+            connection.commit()
+        return updated
 
     def retire_agent_role(self, *, role_id: str) -> tuple[AgentRole, bool]:
         if not role_id:
@@ -1516,6 +1667,24 @@ class StateStore:
             memory_profile_id=row["memory_profile_id"],
             created_at=_parse_dt(row["created_at"]),
             retired_at=_parse_dt(row["retired_at"]) if row["retired_at"] else None,
+        )
+
+    def _row_to_agent_session(self, row: sqlite3.Row) -> AgentSession:
+        return AgentSession(
+            session_id=row["session_id"],
+            role_id=row["role_id"],
+            role_name=row["role_name"],
+            profile_id=row["profile_id"],
+            profile_name=row["profile_name"],
+            goal=row["goal"],
+            status=AgentSessionStatus(row["status"]),
+            created_at=_parse_dt(row["created_at"]),
+            updated_at=_parse_dt(row["updated_at"]),
+            last_plan_event_id=row["last_plan_event_id"],
+            last_run_id=row["last_run_id"],
+            step_count=int(row["step_count"]),
+            max_steps=int(row["max_steps"]),
+            notes=row["notes"],
         )
 
     def _row_to_run(self, row: sqlite3.Row) -> Run:

--- a/tests/test_agent_session_cli.py
+++ b/tests/test_agent_session_cli.py
@@ -1,0 +1,201 @@
+import argparse
+import contextlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gismo.cli import agent_session as agent_session_cli
+from gismo.cli import main as cli_main
+from gismo.core.models import AgentSessionStatus
+from gismo.core.state import StateStore
+
+
+class AgentSessionCliTest(unittest.TestCase):
+    def _mock_env(self) -> dict[str, str]:
+        return {
+            "GISMO_OLLAMA_MODEL": "",
+            "GISMO_OLLAMA_TIMEOUT_S": "",
+            "GISMO_OLLAMA_URL": "",
+            "GISMO_LLM_MODEL": "",
+            "OLLAMA_HOST": "",
+        }
+
+    def _start_session(self, db_path: str, goal: str) -> str:
+        args = argparse.Namespace(
+            db_path=db_path,
+            goal=goal,
+            role=None,
+            max_steps=3,
+            json=True,
+        )
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            agent_session_cli.run_agent_session_start(args)
+        payload = json.loads(buffer.getvalue())
+        return payload["session"]["session_id"]
+
+    def test_agent_session_start_list_show_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            session_id = self._start_session(db_path, "plan a report")
+
+            list_args = argparse.Namespace(db_path=db_path, json=True)
+            list_buffer = io.StringIO()
+            with contextlib.redirect_stdout(list_buffer):
+                agent_session_cli.run_agent_session_list(list_args)
+            list_payload = json.loads(list_buffer.getvalue())
+            self.assertEqual(list_payload["schema_version"], 1)
+            self.assertEqual(list_payload["sessions"][0]["session_id"], session_id)
+
+            show_args = argparse.Namespace(
+                db_path=db_path,
+                session_id=session_id,
+                json=True,
+            )
+            show_buffer = io.StringIO()
+            with contextlib.redirect_stdout(show_buffer):
+                agent_session_cli.run_agent_session_show(show_args)
+            show_payload = json.loads(show_buffer.getvalue())
+            self.assertEqual(show_payload["session"]["session_id"], session_id)
+
+    def test_session_resume_non_interactive_fails_closed(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "queue",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "echo: queued",
+                        "timeout_seconds": 15,
+                        "retries": 0,
+                        "why": "record",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            session_id = self._start_session(db_path, "enqueue a note")
+            args = argparse.Namespace(
+                db_path=db_path,
+                session_id=session_id,
+                policy=None,
+                yes=False,
+                non_interactive=True,
+                dry_run=False,
+            )
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with self.assertRaises(SystemExit) as exc:
+                        agent_session_cli.run_agent_session_resume(
+                            args,
+                            cli_main._agent_session_dependencies(),
+                        )
+            self.assertEqual(exc.exception.code, 2)
+            state_store = StateStore(db_path)
+            try:
+                self.assertEqual(state_store.list_queue_items(limit=10), [])
+                session = state_store.get_agent_session(session_id)
+                assert session is not None
+                self.assertEqual(session.status, AgentSessionStatus.PAUSED)
+                self.assertEqual(session.step_count, 1)
+                self.assertIsNotNone(session.last_plan_event_id)
+            finally:
+                state_store.close()
+
+    def test_session_resume_confirmation_declined(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "risky",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "shell: echo risky",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "test",
+                        "risk": "high",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            session_id = self._start_session(db_path, "do risky thing")
+            args = argparse.Namespace(
+                db_path=db_path,
+                session_id=session_id,
+                policy=None,
+                yes=False,
+                non_interactive=False,
+                dry_run=False,
+            )
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch.object(cli_main, "_is_interactive_tty", return_value=True):
+                        with mock.patch("builtins.input", return_value="n"):
+                            with self.assertRaises(SystemExit) as exc:
+                                agent_session_cli.run_agent_session_resume(
+                                    args,
+                                    cli_main._agent_session_dependencies(),
+                                )
+            self.assertEqual(exc.exception.code, 2)
+            state_store = StateStore(db_path)
+            try:
+                self.assertEqual(state_store.list_queue_items(limit=10), [])
+                session = state_store.get_agent_session(session_id)
+                assert session is not None
+                self.assertEqual(session.status, AgentSessionStatus.PAUSED)
+            finally:
+                state_store.close()
+
+    def test_session_resume_completes_without_actions(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "done",
+                "assumptions": [],
+                "actions": [],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            session_id = self._start_session(db_path, "no actions")
+            args = argparse.Namespace(
+                db_path=db_path,
+                session_id=session_id,
+                policy=None,
+                yes=True,
+                non_interactive=False,
+                dry_run=False,
+            )
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    buffer = io.StringIO()
+                    with contextlib.redirect_stdout(buffer):
+                        agent_session_cli.run_agent_session_resume(
+                            args,
+                            cli_main._agent_session_dependencies(),
+                        )
+            state_store = StateStore(db_path)
+            try:
+                session = state_store.get_agent_session(session_id)
+                assert session is not None
+                self.assertEqual(session.status, AgentSessionStatus.COMPLETED)
+                self.assertEqual(session.step_count, 1)
+                self.assertEqual(state_store.list_queue_items(limit=10), [])
+            finally:
+                state_store.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -74,6 +74,13 @@ class CliMainParserTest(unittest.TestCase):
         self.assertIs(args.handler, cli_main._handle_agent)
         self.assertEqual(args.goal, ["do", "thing"])
 
+    def test_agent_session_subcommand_routes(self) -> None:
+        parser = cli_main.build_parser()
+        args = parser.parse_args(["agent-session", "list"])
+
+        self.assertEqual(args.command, "agent-session")
+        self.assertIs(args.handler, cli_main._handle_agent_session_list)
+
     def test_daemon_subcommand_routes_to_daemon(self) -> None:
         parser = cli_main.build_parser()
         args = parser.parse_args(["daemon", "--once"])

--- a/tests/test_db_handle_guardrails.py
+++ b/tests/test_db_handle_guardrails.py
@@ -190,6 +190,23 @@ class DbHandleGuardrailsTest(unittest.TestCase):
                 gc.collect()
                 self._assert_db_deletable(db_path)
 
+    def test_agent_session_list_releases_db_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", ResourceWarning)
+                self._run_cli(
+                    [
+                        "agent",
+                        "session",
+                        "list",
+                        "--db",
+                        str(db_path),
+                    ]
+                )
+                gc.collect()
+                self._assert_db_deletable(db_path)
+
     def test_ask_apply_memory_suggestions_releases_db_handle(self) -> None:
         response = json.dumps(
             {

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -95,6 +95,39 @@ class ExportTest(unittest.TestCase):
             metadata = run_record["metadata"].get("agent_role", {})
             self.assertEqual(metadata.get("role_id"), "role-123")
 
+    def test_export_includes_agent_session_record(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            state_store = StateStore(db_path)
+            session = state_store.create_agent_session(
+                goal="export session",
+                role_id=None,
+                role_name=None,
+                profile_id=None,
+                profile_name=None,
+                max_steps=5,
+                notes=None,
+            )
+            run = state_store.create_run(
+                label="session-export",
+                metadata={
+                    "agent_session": {
+                        "session_id": session.session_id,
+                        "step_count": 1,
+                        "max_steps": 5,
+                    }
+                },
+            )
+            output_path = export_run_jsonl(state_store, run.id, base_dir=Path(tmpdir))
+            records = [
+                json.loads(line)
+                for line in output_path.read_text(encoding="utf-8").strip().splitlines()
+            ]
+            session_record = next(
+                record for record in records if record["record_type"] == "agent_session"
+            )
+            self.assertEqual(session_record["session_id"], session.session_id)
+
     def test_export_redact_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")

--- a/tests/test_memory_explain_cli.py
+++ b/tests/test_memory_explain_cli.py
@@ -173,6 +173,7 @@ class MemoryExplainCliTest(unittest.TestCase):
         self.assertIn("excluded", payload)
         self.assertIn("limit", payload)
         self.assertIn("agent_role", payload)
+        self.assertIn("agent_session", payload)
         self.assertEqual(payload["plan_id"], plan_id)
         self.assertIsNone(payload["run_id"])
         if payload["included"]:

--- a/tests/test_run_show_cli.py
+++ b/tests/test_run_show_cli.py
@@ -106,6 +106,41 @@ def test_run_show_includes_agent_role_context(repo_root: Path, db_path: Path) ->
     assert payload["agent_role"]["role_id"] == "role-123"
 
 
+def test_run_show_includes_agent_session_context(repo_root: Path, db_path: Path) -> None:
+    state_store = StateStore(str(db_path))
+    session = state_store.create_agent_session(
+        goal="session goal",
+        role_id=None,
+        role_name=None,
+        profile_id=None,
+        profile_name=None,
+        max_steps=4,
+        notes=None,
+    )
+    run = state_store.create_run(
+        label="session-run",
+        metadata={
+            "agent_session": {
+                "session_id": session.session_id,
+                "step_count": 1,
+                "max_steps": 4,
+            }
+        },
+    )
+    state_store.close()
+
+    proc = _run_cli(["run", "--db", str(db_path), "show", run.id], cwd=repo_root)
+    assert proc.returncode == 0, proc.stderr
+    stdout = proc.stdout
+    assert "Session:" in stdout
+    assert session.session_id in stdout
+
+    proc_json = _run_cli(["runs", "--db", str(db_path), "show", "--json", run.id], cwd=repo_root)
+    assert proc_json.returncode == 0, proc_json.stderr
+    payload = json.loads(proc_json.stdout)
+    assert payload["agent_session"]["session_id"] == session.session_id
+
+
 def test_run_show_includes_memory_provenance(repo_root: Path, db_path: Path) -> None:
     state_store = StateStore(str(db_path))
     plan_event_id = str(uuid4())


### PR DESCRIPTION
### Motivation
- Introduce an operator-controlled `AgentSession` concept to support deterministic, resumable multi-step agent workflows without adding background autonomy.  
- Persist session state in the existing SQLite `StateStore` so sessions are auditable and queryable.  
- Ensure every resume step enforces existing policy/confirmation gates and keeps memory injection read-only by default.  
- Provide CLI ergonomics for start/show/list/pause/resume/cancel and wire session context into introspection/export paths for auditability.

### Description
- Added `AgentSession` dataclass and `AgentSessionStatus` enum in `gismo/core/models.py` and created the `agent_sessions` table plus CRUD helpers in `gismo/core/state.py` (`create_agent_session`, `list_agent_sessions`, `get_agent_session`, `update_agent_session`, `_row_to_agent_session`).
- New CLI module `gismo/cli/agent_session.py` implements `run_agent_session_start`, `run_agent_session_show`, `run_agent_session_list`, `run_agent_session_pause`, `run_agent_session_resume`, and `run_agent_session_cancel` with strict confirmation gates (`--yes` / `--non-interactive`) and single-iteration resume behavior.  
- Wired CLI entrypoints and dependency plumbing in `gismo/cli/main.py` (parser, `_agent_session_dependencies()` and handlers) and surfaced session context in `runs show`, `memory explain`, and JSONL export (added agent_session record and linked session events) in `gismo/core/export.py` and `gismo/cli/memory_explain.py`.  
- Tests and docs: added `tests/test_agent_session_cli.py`, updated multiple tests (export/run-show/memory-explain/CLI routing/DB handle guardrails), and updated `README.md`, `AGENTS.md`, and `Handoff.md` to document operator-controlled sessions and safety guarantees.

### Testing
- Ran full verification: `python scripts/verify.py` and all checks succeeded.  
- Ran unit test suite: `pytest -q` and all tests passed (`205 passed, 3 skipped`).  
- Exercise CLI smoke: create and inspect a session with `gismo agent-session start --goal "..." --json`, list with `gismo agent-session list`, and run a single iteration via `gismo agent-session resume SESSION_ID --yes` (confirmation and `--non-interactive` failure behaviour are covered by tests).  
- Export integration validated by `tests/test_export.py` which confirms session records and session-linked events are present in JSONL exports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c585a4abc833091221bba2ad04751)