### PR TITLE
Add tool receipt audit trail and deterministic replay validation

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -172,12 +172,13 @@ Plan assessment gate:
 LATEST UPDATE (OPERATOR NOTES)
 
 Status:
-- Added supervised agent sessions for checkpoint/resume workflows with strict safety gates.
-- Run/show/export/memory explain now surface session linkage alongside role context.
+- Added tool receipts (canonical payloads + hashes) for every tool call with JSONL export support.
+- Added CLI tooling to list/show receipts and replay exports in dry-run validation mode.
+- Run/show now summarizes tool receipt counts and timestamps alongside session/role context.
 
 Next steps:
+- Consider policy-gated non-dry-run replay after operators validate audit workflows.
 - Extend session metrics (elapsed time per step) once operators validate workflow.
-- Review default policies for session resume use in readonly contexts.
 
 Tests run:
 - python scripts/verify.py
@@ -187,6 +188,9 @@ Operator examples:
 - python -m gismo.cli.main --db .\tmp\dev.db runs list
 - python -m gismo.cli.main --db .\tmp\dev.db runs show RUN_ID
 - python -m gismo.cli.main --db .\tmp\dev.db export RUN_ID
+- python -m gismo.cli.main --db .\tmp\dev.db tools receipts list --run RUN_ID
+- python -m gismo.cli.main --db .\tmp\dev.db tools receipts show RECEIPT_ID
+- python -m gismo.cli.main --db .\tmp\dev.db tools replay --run RUN_ID --from-export .\tmp\exports\RUN_ID.jsonl --dry-run
 - python -m gismo.cli.main --db .\tmp\dev.db agent "Summarize last 10 queue failures" --dry-run
 
 -------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Key Features and Principles:
   All operations are gated by security policies. Policies supported include readonly and dev-safe modes. Disallowed actions (like unapproved shell: commands) are blocked by default, logged, and safely marked failed.
 
 - Auditability:
-  Every action and decision is logged. GISMO produces detailed JSONL audit logs per run, capturing tool inputs/outputs and outcomes. Nothing happens silently.
+  Every action and decision is logged. GISMO produces detailed JSONL audit logs per run, capturing tool inputs/outputs, tool receipts (canonical payloads + hashes), and outcomes. Nothing happens silently.
 
 - Cross-Platform, Windows-First:
   GISMO is built to run reliably on Windows first, as well as Linux. It avoids Unix assumptions and handles Windows-specific concerns (paths, subprocess behavior, locking) explicitly.
@@ -119,6 +119,12 @@ Export audit logs:
 
   gismo export --latest
   gismo export --run RUN_ID
+
+Tool receipt audit + replay:
+
+  gismo tools receipts list --run RUN_ID
+  gismo tools receipts show RECEIPT_ID
+  gismo tools replay --run RUN_ID --from-export /path/to/export.jsonl --dry-run
 
 Memory management (policy-gated; confirmation required for high-risk namespaces):
 

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -44,6 +44,7 @@ from gismo.core.permissions import PermissionPolicy, load_policy
 from gismo.core.plan_assess import PlanAssessment, assess_plan, expanded_explanation
 from gismo.core.state import StateStore
 from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
+from gismo.core.tool_receipts import ToolReceiptReplayReport, replay_tool_receipts
 from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFileTool, WriteFileTool
 from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
 from gismo.llm.ollama import OllamaError, ollama_chat, resolve_ollama_config
@@ -749,6 +750,38 @@ def _task_status_counts(tasks: list) -> dict[str, int]:
     return counts
 
 
+def _tool_receipt_summary(receipts: list) -> dict[str, object]:
+    counts = {"total": len(receipts), "success": 0, "error": 0}
+    if not receipts:
+        return {
+            "counts": counts,
+            "first_started_at": None,
+            "last_finished_at": None,
+            "top_tools": [],
+        }
+    tool_counts: dict[str, int] = {}
+    started_times = []
+    finished_times = []
+    for receipt in receipts:
+        if receipt.status.value == "success":
+            counts["success"] += 1
+        else:
+            counts["error"] += 1
+        tool_counts[receipt.tool_name] = tool_counts.get(receipt.tool_name, 0) + 1
+        started_times.append(receipt.started_at)
+        finished_times.append(receipt.finished_at)
+    top_tools = sorted(
+        tool_counts.items(),
+        key=lambda item: (-item[1], item[0]),
+    )[:3]
+    return {
+        "counts": counts,
+        "first_started_at": min(started_times).isoformat() if started_times else None,
+        "last_finished_at": max(finished_times).isoformat() if finished_times else None,
+        "top_tools": [{"tool_name": name, "count": count} for name, count in top_tools],
+    }
+
+
 def _run_last_error(tasks: list, tool_calls: list) -> str | None:
     entries: list[tuple[datetime, str]] = []
     min_dt = datetime.min.replace(tzinfo=timezone.utc)
@@ -985,6 +1018,7 @@ def _serialize_run_show_payload(
     counts: dict[str, int],
     tasks: list,
     tool_calls: list,
+    tool_receipts: list,
     memory_provenance: object,
 ) -> dict[str, object]:
     task_payloads = []
@@ -1023,6 +1057,7 @@ def _serialize_run_show_payload(
     if isinstance(run.metadata_json, dict):
         agent_role = run.metadata_json.get("agent_role")
         agent_session = run.metadata_json.get("agent_session")
+    tool_receipt_summary = _tool_receipt_summary(tool_receipts)
     return {
         "run": {
             "id": run.id,
@@ -1035,6 +1070,7 @@ def _serialize_run_show_payload(
         "task_counts": counts,
         "tasks": task_payloads,
         "tool_calls": call_payloads,
+        "tool_receipts_summary": tool_receipt_summary,
         "agent_role": agent_role,
         "agent_session": agent_session,
         "memory_provenance": memory_payload,
@@ -1133,9 +1169,11 @@ def run_show(db_path: str, run_id: str, *, json_output: bool = False) -> None:
 
         tasks = list(state_store.list_tasks(run.id))
         tool_calls = list(state_store.list_tool_calls(run.id))
+        tool_receipts = list(state_store.list_tool_receipts(run.id))
         status = _run_status(tasks)
         start_time, end_time = _run_time_bounds(run, tasks, tool_calls)
         counts = _task_status_counts(tasks)
+        receipt_summary = _tool_receipt_summary(tool_receipts)
         memory_provenance = state_store.get_memory_provenance(run.id)
 
         if json_output:
@@ -1147,6 +1185,7 @@ def run_show(db_path: str, run_id: str, *, json_output: bool = False) -> None:
                 counts=counts,
                 tasks=tasks,
                 tool_calls=tool_calls,
+                tool_receipts=tool_receipts,
                 memory_provenance=memory_provenance,
             )
             print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
@@ -1163,6 +1202,20 @@ def run_show(db_path: str, run_id: str, *, json_output: bool = False) -> None:
             f"(pending={counts['pending']} running={counts['running']} "
             f"succeeded={counts['succeeded']} failed={counts['failed']})"
         )
+        receipt_counts = receipt_summary["counts"]
+        top_tools = receipt_summary["top_tools"]
+        top_tools_label = ", ".join(
+            f"{entry['tool_name']}({entry['count']})" for entry in top_tools
+        )
+        print(
+            "Tool Calls: "
+            f"{receipt_counts['total']} "
+            f"(success={receipt_counts['success']} error={receipt_counts['error']}) "
+            f"first={receipt_summary['first_started_at'] or '-'} "
+            f"last={receipt_summary['last_finished_at'] or '-'}"
+        )
+        if top_tools_label:
+            print(f"Top Tools:  {top_tools_label}")
         agent_role = None
         agent_session = None
         if isinstance(run.metadata_json, dict):
@@ -1254,6 +1307,162 @@ def run_list(db_path: str, limit: int, newest_first: bool) -> None:
     finally:
         state_store.close()
 
+
+def _serialize_tool_receipt(receipt) -> dict[str, object]:
+    return {
+        "id": receipt.id,
+        "run_id": receipt.run_id,
+        "session_id": receipt.session_id,
+        "role_id": receipt.role_id,
+        "role_name": receipt.role_name,
+        "plan_event_id": receipt.plan_event_id,
+        "tool_name": receipt.tool_name,
+        "tool_kind": receipt.tool_kind,
+        "request_payload_json": receipt.request_payload_json,
+        "response_payload_json": receipt.response_payload_json,
+        "status": receipt.status.value,
+        "started_at": receipt.started_at.isoformat(),
+        "finished_at": receipt.finished_at.isoformat(),
+        "duration_ms": receipt.duration_ms,
+        "request_sha256": receipt.request_sha256,
+        "response_sha256": receipt.response_sha256,
+        "error_type": receipt.error_type,
+        "error_message": receipt.error_message,
+        "policy_decision_id": receipt.policy_decision_id,
+        "policy_snapshot": receipt.policy_snapshot,
+    }
+
+
+def _serialize_replay_report(report: ToolReceiptReplayReport) -> dict[str, object]:
+    return {
+        "run_id": report.run_id,
+        "export_count": report.export_count,
+        "db_count": report.db_count,
+        "missing_in_export": report.missing_in_export,
+        "missing_in_db": report.missing_in_db,
+        "hash_mismatches": report.hash_mismatches,
+        "ordering_matches": report.ordering_matches,
+    }
+
+
+def run_tools_receipts_list(db_path: str, run_id: str, *, json_output: bool) -> None:
+    state_store = StateStore(db_path)
+    try:
+        receipts = list(state_store.list_tool_receipts(run_id))
+        if json_output:
+            payload = [_serialize_tool_receipt(receipt) for receipt in receipts]
+            print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+            return
+        print(f"Run: {run_id}")
+        print(f"Tool receipts: {len(receipts)}")
+        if not receipts:
+            return
+        header = (
+            f"{'RECEIPT ID':8}  {'TOOL':16}  {'STATUS':7}  {'STARTED':20}  "
+            f"{'DURATION_MS':11}  {'ERROR':40}"
+        )
+        print(header)
+        print("-" * len(header))
+        for receipt in receipts:
+            error_summary = _summarize_value(receipt.error_message, 40)
+            print(
+                f"{receipt.id[:8]:8}  {receipt.tool_name:16}  {receipt.status.value:7}  "
+                f"{_fmt_dt(receipt.started_at):20}  {receipt.duration_ms:11}  {error_summary:40}"
+            )
+    finally:
+        state_store.close()
+
+
+def run_tools_receipts_show(db_path: str, receipt_id: str, *, json_output: bool) -> None:
+    state_store = StateStore(db_path)
+    try:
+        receipt = state_store.get_tool_receipt(receipt_id)
+        if receipt is None:
+            print(f"Tool receipt not found: {receipt_id}")
+            raise SystemExit(2)
+        if json_output:
+            payload = _serialize_tool_receipt(receipt)
+            print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+            return
+        print("=== GISMO Tool Receipt ===")
+        print(f"Receipt ID: {receipt.id}")
+        print(f"Run ID:     {receipt.run_id}")
+        print(f"Tool:       {receipt.tool_name} ({receipt.tool_kind})")
+        print(f"Status:     {receipt.status.value}")
+        print(f"Started:    {_fmt_dt(receipt.started_at)}")
+        print(f"Finished:   {_fmt_dt(receipt.finished_at)}")
+        print(f"Duration:   {receipt.duration_ms}ms")
+        if receipt.session_id:
+            print(f"Session:    {receipt.session_id}")
+        if receipt.role_name or receipt.role_id:
+            print(f"Role:       {receipt.role_name or '-'} ({receipt.role_id or '-'})")
+        if receipt.plan_event_id:
+            print(f"Plan Event: {receipt.plan_event_id}")
+        print(f"Request:    {_summarize_value(receipt.request_payload_json, 200)}")
+        print(f"Response:   {_summarize_value(receipt.response_payload_json, 200)}")
+        print(f"Req Hash:   {receipt.request_sha256}")
+        print(f"Resp Hash:  {receipt.response_sha256}")
+        if receipt.error_type or receipt.error_message:
+            print(f"Error Type: {receipt.error_type or '-'}")
+            print(f"Error Msg:  {_summarize_value(receipt.error_message, 200)}")
+        if receipt.policy_snapshot:
+            print(f"Policy:     {_summarize_value(receipt.policy_snapshot, 200)}")
+    finally:
+        state_store.close()
+
+
+def run_tools_replay(
+    db_path: str,
+    *,
+    run_id: str,
+    export_path: str,
+    json_output: bool,
+) -> None:
+    state_store = StateStore(db_path)
+    try:
+        report = replay_tool_receipts(state_store, run_id=run_id, export_path=export_path)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        raise SystemExit(3)
+    finally:
+        state_store.close()
+
+    exit_code = 0
+    if report.missing_in_export or report.missing_in_db or report.hash_mismatches:
+        exit_code = 2
+    if not report.ordering_matches and report.export_count and report.db_count:
+        exit_code = 2
+
+    if json_output:
+        payload = _serialize_replay_report(report)
+        payload["exit_code"] = exit_code
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        raise SystemExit(exit_code)
+
+    print("=== GISMO Tool Receipt Replay ===")
+    print(f"Run ID:             {report.run_id}")
+    print(f"Receipts (export):  {report.export_count}")
+    print(f"Receipts (db):      {report.db_count}")
+    print(f"Ordering matches:   {report.ordering_matches}")
+    print(f"Missing in export:  {len(report.missing_in_export)}")
+    if report.missing_in_export:
+        for receipt_id in report.missing_in_export[:5]:
+            print(f"  - {receipt_id}")
+        if len(report.missing_in_export) > 5:
+            print(f"  +{len(report.missing_in_export) - 5} more")
+    print(f"Missing in db:      {len(report.missing_in_db)}")
+    if report.missing_in_db:
+        for receipt_id in report.missing_in_db[:5]:
+            print(f"  - {receipt_id}")
+        if len(report.missing_in_db) > 5:
+            print(f"  +{len(report.missing_in_db) - 5} more")
+    print(f"Hash mismatches:    {len(report.hash_mismatches)}")
+    if report.hash_mismatches:
+        for mismatch in report.hash_mismatches[:5]:
+            print(f"  - {mismatch['id']} field={mismatch['field']}")
+        if len(report.hash_mismatches) > 5:
+            print(f"  +{len(report.hash_mismatches) - 5} more")
+    raise SystemExit(exit_code)
 
 @dataclass
 class MemoryDecision:
@@ -3990,6 +4199,23 @@ def _handle_runs_show(args: argparse.Namespace) -> None:
     run_show(args.db_path, args.run_id, json_output=args.json)
 
 
+def _handle_tools_receipts_list(args: argparse.Namespace) -> None:
+    run_tools_receipts_list(args.db_path, args.run_id, json_output=args.json)
+
+
+def _handle_tools_receipts_show(args: argparse.Namespace) -> None:
+    run_tools_receipts_show(args.db_path, args.receipt_id, json_output=args.json)
+
+
+def _handle_tools_replay(args: argparse.Namespace) -> None:
+    run_tools_replay(
+        args.db_path,
+        run_id=args.run_id,
+        export_path=args.from_export,
+        json_output=args.json,
+    )
+
+
 def _handle_memory_put(args: argparse.Namespace) -> None:
     run_memory_put(args)
 
@@ -4904,6 +5130,85 @@ def build_parser() -> argparse.ArgumentParser:
         help="Redact file contents, shell output, and large tool outputs",
     )
     export_parser.set_defaults(handler=_handle_export)
+
+    tools_parser = subparsers.add_parser(
+        "tools",
+        help="Inspect tool receipts or replay exports",
+        parents=[db_parent_optional],
+    )
+    tools_subparsers = tools_parser.add_subparsers(dest="tools_command", required=True)
+
+    tools_receipts_parser = tools_subparsers.add_parser(
+        "receipts",
+        help="Inspect tool receipts",
+        parents=[db_parent_optional],
+    )
+    tools_receipts_subparsers = tools_receipts_parser.add_subparsers(
+        dest="tools_receipts_command",
+        required=True,
+    )
+    tools_receipts_list_parser = tools_receipts_subparsers.add_parser(
+        "list",
+        help="List tool receipts for a run",
+        parents=[db_parent_optional],
+    )
+    tools_receipts_list_parser.add_argument(
+        "--run",
+        dest="run_id",
+        required=True,
+        help="Run ID to list receipts for",
+    )
+    tools_receipts_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    tools_receipts_list_parser.set_defaults(handler=_handle_tools_receipts_list)
+
+    tools_receipts_show_parser = tools_receipts_subparsers.add_parser(
+        "show",
+        help="Show a single tool receipt",
+        parents=[db_parent_optional],
+    )
+    tools_receipts_show_parser.add_argument(
+        "receipt_id",
+        help="Tool receipt ID",
+    )
+    tools_receipts_show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    tools_receipts_show_parser.set_defaults(handler=_handle_tools_receipts_show)
+
+    tools_replay_parser = tools_subparsers.add_parser(
+        "replay",
+        help="Validate tool receipts against a JSONL export",
+        parents=[db_parent_optional],
+    )
+    tools_replay_parser.add_argument(
+        "--run",
+        dest="run_id",
+        required=True,
+        help="Run ID to validate",
+    )
+    tools_replay_parser.add_argument(
+        "--from-export",
+        dest="from_export",
+        required=True,
+        help="JSONL export path containing tool_receipt records",
+    )
+    tools_replay_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate without executing tool calls (default)",
+    )
+    tools_replay_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    tools_replay_parser.set_defaults(handler=_handle_tools_replay)
 
     memory_parser = subparsers.add_parser(
         "memory",

--- a/gismo/core/export.py
+++ b/gismo/core/export.py
@@ -1,4 +1,4 @@
-"""Audit export utilities for runs, tasks, and tool calls."""
+"""Audit export utilities for runs, tasks, tool calls, and tool receipts."""
 from __future__ import annotations
 
 import json
@@ -6,7 +6,7 @@ from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
-from gismo.core.models import AgentSession, Run, Task, ToolCall
+from gismo.core.models import AgentSession, Run, Task, ToolCall, ToolReceipt
 from gismo.core.paths import resolve_exports_dir
 from gismo.core.state import MemoryEventRecord, MemoryProvenance, StateStore
 
@@ -30,6 +30,7 @@ def export_run_jsonl(
     resolved_out = _resolve_output_path(run_id, out_path, exports_dir)
     tasks = list(state_store.list_tasks(run_id))
     tool_calls = list(state_store.list_tool_calls(run_id))
+    tool_receipts = list(state_store.list_tool_receipts(run_id))
     memory_provenance = state_store.get_memory_provenance(run.id)
     plan_event_id = None
     session: AgentSession | None = None
@@ -56,6 +57,7 @@ def export_run_jsonl(
         run,
         tasks,
         tool_calls,
+        tool_receipts,
         agent_session=session,
         session_events=session_events,
         memory_provenance=memory_provenance,
@@ -107,6 +109,7 @@ def _build_records(
     run: Run,
     tasks: list[Task],
     tool_calls: list[ToolCall],
+    tool_receipts: list[ToolReceipt],
     *,
     agent_session: AgentSession | None,
     session_events: list[Any],
@@ -117,6 +120,7 @@ def _build_records(
 ) -> list[dict[str, Any]]:
     sorted_tasks = sorted(tasks, key=lambda task: task.created_at)
     sorted_calls = sorted(tool_calls, key=lambda call: (call.started_at, call.attempt_number))
+    sorted_receipts = sorted(tool_receipts, key=lambda receipt: (receipt.started_at, receipt.id))
     records = [_serialize_run(run, memory_provenance)]
     if agent_session is not None:
         records.append(_serialize_agent_session(agent_session))
@@ -135,6 +139,7 @@ def _build_records(
         )
     records.extend(_serialize_task(task, redact=redact) for task in sorted_tasks)
     records.extend(_serialize_tool_call(call, redact=redact) for call in sorted_calls)
+    records.extend(_serialize_tool_receipt(receipt) for receipt in sorted_receipts)
     return records
 
 
@@ -273,6 +278,32 @@ def _serialize_tool_call(call: ToolCall, *, redact: bool) -> dict[str, Any]:
         "attempt_number": call.attempt_number,
         "started_at": call.started_at.isoformat(),
         "finished_at": call.finished_at.isoformat() if call.finished_at else None,
+    }
+
+
+def _serialize_tool_receipt(receipt: ToolReceipt) -> dict[str, Any]:
+    return {
+        "record_type": "tool_receipt",
+        "id": receipt.id,
+        "run_id": receipt.run_id,
+        "session_id": receipt.session_id,
+        "role_id": receipt.role_id,
+        "role_name": receipt.role_name,
+        "plan_event_id": receipt.plan_event_id,
+        "tool_name": receipt.tool_name,
+        "tool_kind": receipt.tool_kind,
+        "request_payload_json": receipt.request_payload_json,
+        "response_payload_json": receipt.response_payload_json,
+        "status": receipt.status.value,
+        "started_at": receipt.started_at.isoformat(),
+        "finished_at": receipt.finished_at.isoformat(),
+        "duration_ms": receipt.duration_ms,
+        "request_sha256": receipt.request_sha256,
+        "response_sha256": receipt.response_sha256,
+        "error_type": receipt.error_type,
+        "error_message": receipt.error_message,
+        "policy_decision_id": receipt.policy_decision_id,
+        "policy_snapshot": receipt.policy_snapshot,
     }
 
 

--- a/gismo/core/models.py
+++ b/gismo/core/models.py
@@ -34,6 +34,11 @@ class ToolCallStatus(str, Enum):
     SKIPPED = "SKIPPED"
 
 
+class ToolReceiptStatus(str, Enum):
+    SUCCESS = "success"
+    ERROR = "error"
+
+
 class QueueStatus(str, Enum):
     QUEUED = "QUEUED"
     IN_PROGRESS = "IN_PROGRESS"
@@ -162,6 +167,30 @@ class ToolCall:
         self.error = error
         self.failure_type = failure_type
         self.finished_at = _utc_now()
+
+
+@dataclass
+class ToolReceipt:
+    run_id: str
+    tool_name: str
+    tool_kind: str
+    request_payload_json: str
+    response_payload_json: str
+    status: ToolReceiptStatus
+    started_at: datetime
+    finished_at: datetime
+    duration_ms: int
+    request_sha256: str
+    response_sha256: str
+    id: str = field(default_factory=lambda: str(uuid4()))
+    session_id: Optional[str] = None
+    role_id: Optional[str] = None
+    role_name: Optional[str] = None
+    plan_event_id: Optional[str] = None
+    error_type: Optional[str] = None
+    error_message: Optional[str] = None
+    policy_decision_id: Optional[str] = None
+    policy_snapshot: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/gismo/core/orchestrator.py
+++ b/gismo/core/orchestrator.py
@@ -10,10 +10,25 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Tuple, Type
 
 from gismo.core.agent import Agent
-from gismo.core.models import FailureType, Task, TaskStatus, ToolCall, ToolCallStatus
+from gismo.core.models import (
+    FailureType,
+    Task,
+    TaskStatus,
+    ToolCall,
+    ToolCallStatus,
+    ToolReceipt,
+    ToolReceiptStatus,
+)
 from gismo.core.permissions import PermissionPolicy
 from gismo.core.state import StateStore
 from gismo.core.tools import ToolRegistry
+from gismo.core.tool_receipts import (
+    build_policy_snapshot,
+    canonical_json,
+    redact_payload,
+    sha256_payload,
+    tool_kind_for_name,
+)
 
 
 @dataclass
@@ -37,6 +52,7 @@ class Orchestrator:
     ) -> Task:
         normalized_input = _normalize_input(tool_input)
         task.input_hash = _stable_hash(normalized_input)
+        run_context = _receipt_run_context(self.state_store, run_id)
 
         prior = self.state_store.find_succeeded_task_by_idempotency(
             task.idempotency_key,
@@ -59,8 +75,23 @@ class Orchestrator:
             )
             tool_call.finished_at = _utc_now()
             tool_call.failure_type = FailureType.NONE
+            receipt = _build_tool_receipt(
+                tool_call=tool_call,
+                run_context=run_context,
+                tool_input=tool_input,
+                response_payload={
+                    "skipped": True,
+                    "reason": skip_message,
+                    "output": output,
+                },
+                status=ToolReceiptStatus.SUCCESS,
+                policy_snapshot=None,
+                error_type=None,
+                error_message=None,
+            )
             with self.state_store.transaction() as connection:
                 self.state_store.record_tool_call(tool_call, connection=connection)
+                self.state_store.record_tool_receipt(receipt, connection=connection)
                 self.state_store.update_task(task, connection=connection)
             return task
 
@@ -88,9 +119,28 @@ class Orchestrator:
             except Exception as exc:  # noqa: BLE001 - fail fast with explicit exception
                 failure_type, can_retry = _classify_exception(exc, retryable)
                 error_message = _safe_error_message(exc)
+                policy_snapshot = build_policy_snapshot(
+                    self.policy,
+                    tool_name,
+                    allowed=not isinstance(exc, PermissionError),
+                )
                 tool_call.mark_failed(error_message, failure_type)
+                receipt = _build_tool_receipt(
+                    tool_call=tool_call,
+                    run_context=run_context,
+                    tool_input=tool_input,
+                    response_payload={
+                        "error": error_message,
+                        "error_type": exc.__class__.__name__,
+                    },
+                    status=ToolReceiptStatus.ERROR,
+                    policy_snapshot=policy_snapshot,
+                    error_type=exc.__class__.__name__,
+                    error_message=error_message,
+                )
                 with self.state_store.transaction() as connection:
                     self.state_store.update_tool_call(tool_call, connection=connection)
+                    self.state_store.record_tool_receipt(receipt, connection=connection)
                     task.error = error_message
                     task.failure_type = failure_type
                     task.updated_at = _utc_now()
@@ -107,8 +157,23 @@ class Orchestrator:
                 return task
 
             tool_call.mark_succeeded(output)
+            receipt = _build_tool_receipt(
+                tool_call=tool_call,
+                run_context=run_context,
+                tool_input=tool_input,
+                response_payload=output,
+                status=ToolReceiptStatus.SUCCESS,
+                policy_snapshot=build_policy_snapshot(
+                    self.policy,
+                    tool_name,
+                    allowed=True,
+                ),
+                error_type=None,
+                error_message=None,
+            )
             with self.state_store.transaction() as connection:
                 self.state_store.update_tool_call(tool_call, connection=connection)
+                self.state_store.record_tool_receipt(receipt, connection=connection)
                 task.mark_succeeded(output)
                 self.state_store.update_task(task, connection=connection)
             return task
@@ -218,6 +283,82 @@ def _classify_exception(
 def _safe_error_message(exc: BaseException) -> str:
     message = str(exc)
     return message or exc.__class__.__name__
+
+
+@dataclass(frozen=True)
+class ToolReceiptContext:
+    run_id: str
+    session_id: Optional[str]
+    role_id: Optional[str]
+    role_name: Optional[str]
+    plan_event_id: Optional[str]
+
+
+def _receipt_run_context(state_store: StateStore, run_id: str) -> ToolReceiptContext:
+    run = state_store.get_run(run_id)
+    session_id = None
+    role_id = None
+    role_name = None
+    plan_event_id = None
+    if run and isinstance(run.metadata_json, dict):
+        plan_event_id = run.metadata_json.get("plan_event_id")
+        agent_session = run.metadata_json.get("agent_session")
+        if isinstance(agent_session, dict):
+            session_id = agent_session.get("session_id")
+        agent_role = run.metadata_json.get("agent_role")
+        if isinstance(agent_role, dict):
+            role_id = agent_role.get("role_id")
+            role_name = agent_role.get("role_name")
+    return ToolReceiptContext(
+        run_id=run_id,
+        session_id=session_id,
+        role_id=role_id,
+        role_name=role_name,
+        plan_event_id=plan_event_id,
+    )
+
+
+def _build_tool_receipt(
+    *,
+    tool_call: ToolCall,
+    run_context: ToolReceiptContext,
+    tool_input: Dict[str, Any],
+    response_payload: Dict[str, Any],
+    status: ToolReceiptStatus,
+    policy_snapshot: Optional[Dict[str, Any]],
+    error_type: Optional[str],
+    error_message: Optional[str],
+) -> ToolReceipt:
+    started_at = tool_call.started_at
+    finished_at = tool_call.finished_at or _utc_now()
+    duration_ms = max(
+        0,
+        int((finished_at - started_at).total_seconds() * 1000),
+    )
+    redacted_request = redact_payload(tool_input)
+    redacted_response = redact_payload(response_payload)
+    request_payload_json = canonical_json(redacted_request)
+    response_payload_json = canonical_json(redacted_response)
+    return ToolReceipt(
+        run_id=run_context.run_id,
+        session_id=run_context.session_id,
+        role_id=run_context.role_id,
+        role_name=run_context.role_name,
+        plan_event_id=run_context.plan_event_id,
+        tool_name=tool_call.tool_name,
+        tool_kind=tool_kind_for_name(tool_call.tool_name),
+        request_payload_json=request_payload_json,
+        response_payload_json=response_payload_json,
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        duration_ms=duration_ms,
+        request_sha256=sha256_payload(request_payload_json),
+        response_sha256=sha256_payload(response_payload_json),
+        error_type=error_type,
+        error_message=error_message,
+        policy_snapshot=policy_snapshot,
+    )
 
 
 def _utc_now() -> datetime:

--- a/gismo/core/state.py
+++ b/gismo/core/state.py
@@ -24,6 +24,8 @@ from gismo.core.models import (
     TaskStatus,
     ToolCall,
     ToolCallStatus,
+    ToolReceipt,
+    ToolReceiptStatus,
 )
 
 
@@ -210,6 +212,33 @@ class StateStore:
             )
             cursor.execute(
                 """
+                CREATE TABLE IF NOT EXISTS tool_receipts (
+                    id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    session_id TEXT NULL,
+                    role_id TEXT NULL,
+                    role_name TEXT NULL,
+                    plan_event_id TEXT NULL,
+                    tool_name TEXT NOT NULL,
+                    tool_kind TEXT NOT NULL,
+                    request_payload_json TEXT NOT NULL,
+                    response_payload_json TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    finished_at TEXT NOT NULL,
+                    duration_ms INTEGER NOT NULL,
+                    request_sha256 TEXT NOT NULL,
+                    response_sha256 TEXT NOT NULL,
+                    error_type TEXT NULL,
+                    error_message TEXT NULL,
+                    policy_decision_id TEXT NULL,
+                    policy_snapshot_json TEXT NULL,
+                    FOREIGN KEY (run_id) REFERENCES runs(id)
+                )
+                """
+            )
+            cursor.execute(
+                """
                 CREATE TABLE IF NOT EXISTS queue_items (
                     id TEXT PRIMARY KEY,
                     run_id TEXT,
@@ -367,6 +396,18 @@ class StateStore:
                 """
                 CREATE INDEX IF NOT EXISTS idx_memory_selection_traces_plan
                 ON memory_selection_traces (plan_id)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tool_receipts_run
+                ON tool_receipts (run_id)
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_tool_receipts_started_at
+                ON tool_receipts (started_at)
                 """
             )
             self._ensure_columns(connection)
@@ -964,6 +1005,74 @@ class StateStore:
                 tool_call.id,
             ),
         )
+
+    def record_tool_receipt(
+        self,
+        receipt: ToolReceipt,
+        connection: Optional[sqlite3.Connection] = None,
+    ) -> None:
+        if connection is None:
+            with self._connection() as connection:
+                self.record_tool_receipt(receipt, connection=connection)
+                connection.commit()
+                return
+        connection.execute(
+            """
+            INSERT INTO tool_receipts (
+                id, run_id, session_id, role_id, role_name, plan_event_id,
+                tool_name, tool_kind, request_payload_json, response_payload_json,
+                status, started_at, finished_at, duration_ms, request_sha256,
+                response_sha256, error_type, error_message, policy_decision_id,
+                policy_snapshot_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                receipt.id,
+                receipt.run_id,
+                receipt.session_id,
+                receipt.role_id,
+                receipt.role_name,
+                receipt.plan_event_id,
+                receipt.tool_name,
+                receipt.tool_kind,
+                receipt.request_payload_json,
+                receipt.response_payload_json,
+                receipt.status.value,
+                receipt.started_at.isoformat(),
+                receipt.finished_at.isoformat(),
+                receipt.duration_ms,
+                receipt.request_sha256,
+                receipt.response_sha256,
+                receipt.error_type,
+                receipt.error_message,
+                receipt.policy_decision_id,
+                json.dumps(receipt.policy_snapshot)
+                if receipt.policy_snapshot is not None
+                else None,
+            ),
+        )
+
+    def list_tool_receipts(self, run_id: str) -> Iterable[ToolReceipt]:
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM tool_receipts
+                WHERE run_id = ?
+                ORDER BY started_at ASC, id ASC
+                """,
+                (run_id,),
+            ).fetchall()
+        return [self._row_to_tool_receipt(row) for row in rows]
+
+    def get_tool_receipt(self, receipt_id: str) -> Optional[ToolReceipt]:
+        with self._connection() as connection:
+            row = connection.execute(
+                "SELECT * FROM tool_receipts WHERE id = ?",
+                (receipt_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_to_tool_receipt(row)
 
     def list_tasks(self, run_id: str) -> Iterable[Task]:
         with self._connection() as connection:
@@ -1711,6 +1820,33 @@ class StateStore:
             failure_type=FailureType(row["failure_type"]) if row["failure_type"] else FailureType.NONE,
         )
         return tool_call
+
+    def _row_to_tool_receipt(self, row: sqlite3.Row) -> ToolReceipt:
+        policy_snapshot = (
+            json.loads(row["policy_snapshot_json"]) if row["policy_snapshot_json"] else None
+        )
+        return ToolReceipt(
+            id=row["id"],
+            run_id=row["run_id"],
+            session_id=row["session_id"],
+            role_id=row["role_id"],
+            role_name=row["role_name"],
+            plan_event_id=row["plan_event_id"],
+            tool_name=row["tool_name"],
+            tool_kind=row["tool_kind"],
+            request_payload_json=row["request_payload_json"],
+            response_payload_json=row["response_payload_json"],
+            status=ToolReceiptStatus(row["status"]),
+            started_at=_parse_dt(row["started_at"]),
+            finished_at=_parse_dt(row["finished_at"]),
+            duration_ms=int(row["duration_ms"]),
+            request_sha256=row["request_sha256"],
+            response_sha256=row["response_sha256"],
+            error_type=row["error_type"],
+            error_message=row["error_message"],
+            policy_decision_id=row["policy_decision_id"],
+            policy_snapshot=policy_snapshot,
+        )
 
     def _row_to_queue_item(self, row: sqlite3.Row) -> QueueItem:
         max_retries = row["max_retries"] if "max_retries" in row.keys() else None

--- a/gismo/core/tool_receipts.py
+++ b/gismo/core/tool_receipts.py
@@ -1,0 +1,178 @@
+"""Tool receipt utilities for audit and replay."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from gismo.core.permissions import PermissionPolicy
+from gismo.core.state import StateStore
+
+
+REDACTED_VALUE = "[REDACTED]"
+SENSITIVE_KEYS = {
+    "api_key",
+    "authorization",
+    "token",
+    "access_token",
+    "refresh_token",
+    "secret",
+    "password",
+}
+
+
+def redact_payload(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        redacted: dict[str, Any] = {}
+        for key, value in payload.items():
+            normalized_key = key.lower().replace("-", "_")
+            if _is_sensitive_key(normalized_key):
+                redacted[key] = REDACTED_VALUE
+            else:
+                redacted[key] = redact_payload(value)
+        return redacted
+    if isinstance(payload, list):
+        return [redact_payload(item) for item in payload]
+    return payload
+
+
+def canonical_json(payload: Any) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def sha256_payload(canonical_payload: str) -> str:
+    return hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
+
+
+def tool_kind_for_name(tool_name: str) -> str:
+    mapping = {
+        "run_shell": "shell",
+        "read_file": "fs",
+        "write_file": "fs",
+        "list_dir": "fs",
+        "echo": "builtin",
+        "write_note": "state",
+    }
+    return mapping.get(tool_name, "tool")
+
+
+def build_policy_snapshot(policy: PermissionPolicy, tool_name: str, *, allowed: bool) -> dict[str, Any]:
+    return {
+        "tool_name": tool_name,
+        "allowed": allowed,
+        "allowed_tools": sorted(policy.allowed_tools),
+    }
+
+
+@dataclass(frozen=True)
+class ToolReceiptReplayReport:
+    run_id: str
+    export_count: int
+    db_count: int
+    missing_in_export: list[str]
+    missing_in_db: list[str]
+    hash_mismatches: list[dict[str, str]]
+    ordering_matches: bool
+
+
+def replay_tool_receipts(
+    state_store: StateStore,
+    *,
+    run_id: str,
+    export_path: str | Path,
+) -> ToolReceiptReplayReport:
+    export_records = _load_tool_receipt_export(export_path, run_id=run_id)
+    export_ids = [record["id"] for record in export_records]
+    db_receipts = list(state_store.list_tool_receipts(run_id))
+    db_ids = [receipt.id for receipt in db_receipts]
+    missing_in_db = [receipt_id for receipt_id in export_ids if receipt_id not in db_ids]
+    missing_in_export = [receipt_id for receipt_id in db_ids if receipt_id not in export_ids]
+    hash_mismatches: list[dict[str, str]] = []
+    export_lookup = {record["id"]: record for record in export_records}
+    for receipt in db_receipts:
+        exported = export_lookup.get(receipt.id)
+        if not exported:
+            continue
+        if exported["request_sha256"] != receipt.request_sha256:
+            hash_mismatches.append(
+                {"id": receipt.id, "field": "request_sha256"}
+            )
+        if exported["response_sha256"] != receipt.response_sha256:
+            hash_mismatches.append(
+                {"id": receipt.id, "field": "response_sha256"}
+            )
+    ordering_matches = export_ids == db_ids
+    return ToolReceiptReplayReport(
+        run_id=run_id,
+        export_count=len(export_records),
+        db_count=len(db_receipts),
+        missing_in_export=missing_in_export,
+        missing_in_db=missing_in_db,
+        hash_mismatches=hash_mismatches,
+        ordering_matches=ordering_matches,
+    )
+
+
+def _is_sensitive_key(normalized_key: str) -> bool:
+    if normalized_key in SENSITIVE_KEYS:
+        return True
+    if normalized_key.endswith("_token"):
+        return True
+    return False
+
+
+def _load_tool_receipt_export(
+    export_path: str | Path,
+    *,
+    run_id: str,
+) -> list[dict[str, Any]]:
+    path = Path(export_path).expanduser()
+    if not path.exists():
+        raise ValueError(f"Export file not found: {path}")
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                record = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSONL at line {line_number}: {exc}") from exc
+            if record.get("record_type") != "tool_receipt":
+                continue
+            if record.get("run_id") != run_id:
+                continue
+            _validate_receipt_record(record, line_number)
+            records.append(record)
+    return records
+
+
+def _validate_receipt_record(record: dict[str, Any], line_number: int) -> None:
+    required_fields = [
+        "id",
+        "run_id",
+        "tool_name",
+        "tool_kind",
+        "request_payload_json",
+        "response_payload_json",
+        "status",
+        "started_at",
+        "finished_at",
+        "duration_ms",
+        "request_sha256",
+        "response_sha256",
+    ]
+    missing = [field for field in required_fields if field not in record]
+    if missing:
+        raise ValueError(f"Missing fields in tool_receipt at line {line_number}: {missing}")
+    request_payload_json = record["request_payload_json"]
+    response_payload_json = record["response_payload_json"]
+    if not isinstance(request_payload_json, str) or not isinstance(response_payload_json, str):
+        raise ValueError(f"Invalid payload JSON strings at line {line_number}.")
+    if sha256_payload(request_payload_json) != record["request_sha256"]:
+        raise ValueError(f"Request hash mismatch at line {line_number}.")
+    if sha256_payload(response_payload_json) != record["response_sha256"]:
+        raise ValueError(f"Response hash mismatch at line {line_number}.")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -58,7 +58,9 @@ class ExportTest(unittest.TestCase):
             record_types = [record["record_type"] for record in records]
             self.assertIn("task", record_types)
             self.assertIn("tool_call", record_types)
+            self.assertIn("tool_receipt", record_types)
             self.assertGreater(record_types.index("tool_call"), record_types.index("task"))
+            self.assertGreater(record_types.index("tool_receipt"), record_types.index("tool_call"))
 
     def test_export_latest_run(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_run_show_cli.py
+++ b/tests/test_run_show_cli.py
@@ -73,6 +73,7 @@ def test_run_show_outputs_summary(repo_root: Path, db_path: Path) -> None:
     assert "=== GISMO Run Summary ===" in stdout
     assert f"Run ID:     {run.id}" in stdout
     assert "Status:     failed" in stdout
+    assert "Tool Calls: 0" in stdout
     assert task_ok.id in stdout
     assert task_fail.id in stdout
     assert "tool=echo" in stdout

--- a/tests/test_tool_receipts.py
+++ b/tests/test_tool_receipts.py
@@ -1,0 +1,164 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.agent import SimpleAgent
+from gismo.core.export import export_run_jsonl
+from gismo.core.orchestrator import Orchestrator
+from gismo.core.permissions import PermissionPolicy
+from gismo.core.state import StateStore
+from gismo.core.tool_receipts import canonical_json, redact_payload, sha256_payload
+from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
+
+
+class ToolReceiptTest(unittest.TestCase):
+    def _build_orchestrator(self, db_path: str, policy: PermissionPolicy) -> Orchestrator:
+        state_store = StateStore(db_path)
+        registry = ToolRegistry()
+        registry.register(EchoTool())
+        registry.register(WriteNoteTool(state_store))
+        agent = SimpleAgent(registry=registry)
+        return Orchestrator(
+            state_store=state_store,
+            registry=registry,
+            policy=policy,
+            agent=agent,
+        )
+
+    def test_receipt_records_success_and_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy = PermissionPolicy(allowed_tools={"echo"})
+            orchestrator = self._build_orchestrator(db_path, policy)
+            state_store = orchestrator.state_store
+            run = state_store.create_run(label="receipts", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Echo",
+                description="Echo",
+                input_json={"tool": "echo", "payload": {"message": "hi"}},
+            )
+
+            orchestrator.run_tool(run.id, task, "echo", {"message": "hi"})
+            receipts = list(state_store.list_tool_receipts(run.id))
+            state_store.close()
+
+            self.assertEqual(len(receipts), 1)
+            receipt = receipts[0]
+            expected_request = canonical_json(redact_payload({"message": "hi"}))
+            expected_response = canonical_json(
+                redact_payload({"echo": {"message": "hi"}})
+            )
+            self.assertEqual(receipt.request_payload_json, expected_request)
+            self.assertEqual(receipt.request_sha256, sha256_payload(expected_request))
+            self.assertEqual(receipt.response_payload_json, expected_response)
+            self.assertEqual(receipt.response_sha256, sha256_payload(expected_response))
+
+    def test_receipt_redaction_is_deterministic(self) -> None:
+        payload = {
+            "api_key": "secret",
+            "nested": {"token": "hidden", "value": "ok"},
+            "list": [{"authorization": "bearer"}],
+        }
+        first = redact_payload(payload)
+        second = redact_payload(payload)
+        self.assertEqual(first, second)
+        expected = {
+            "api_key": "[REDACTED]",
+            "nested": {"token": "[REDACTED]", "value": "ok"},
+            "list": [{"authorization": "[REDACTED]"}],
+        }
+        self.assertEqual(first, expected)
+        first_json = canonical_json(first)
+        second_json = canonical_json(second)
+        self.assertEqual(first_json, second_json)
+        self.assertEqual(sha256_payload(first_json), sha256_payload(second_json))
+
+    def test_receipt_records_policy_denied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy = PermissionPolicy(allowed_tools=set())
+            orchestrator = self._build_orchestrator(db_path, policy)
+            state_store = orchestrator.state_store
+            run = state_store.create_run(label="policy", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Echo",
+                description="Echo",
+                input_json={"tool": "echo", "payload": {"message": "hi"}},
+            )
+
+            orchestrator.run_tool(run.id, task, "echo", {"message": "hi"})
+            receipts = list(state_store.list_tool_receipts(run.id))
+            state_store.close()
+
+            self.assertEqual(len(receipts), 1)
+            receipt = receipts[0]
+            self.assertEqual(receipt.status.value, "error")
+            self.assertIsNotNone(receipt.policy_snapshot)
+            self.assertFalse(receipt.policy_snapshot["allowed"])
+
+
+class ToolReceiptReplayCLITest(unittest.TestCase):
+    def test_replay_detects_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp_path = Path(tmpdir)
+            db_path = tmp_path / "state.db"
+            policy = PermissionPolicy(allowed_tools={"echo"})
+            state_store = StateStore(str(db_path))
+            registry = ToolRegistry()
+            registry.register(EchoTool())
+            agent = SimpleAgent(registry=registry)
+            orchestrator = Orchestrator(
+                state_store=state_store,
+                registry=registry,
+                policy=policy,
+                agent=agent,
+            )
+            run = state_store.create_run(label="replay", metadata={})
+            task = state_store.create_task(
+                run_id=run.id,
+                title="Echo",
+                description="Echo",
+                input_json={"tool": "echo", "payload": {"message": "hi"}},
+            )
+            orchestrator.run_tool(run.id, task, "echo", {"message": "hi"})
+            export_path = export_run_jsonl(state_store, run.id, base_dir=tmp_path)
+            state_store.close()
+
+            cmd = [
+                sys.executable,
+                "-m",
+                "gismo.cli.main",
+                "tools",
+                "replay",
+                "--db",
+                str(db_path),
+                "--run",
+                run.id,
+                "--from-export",
+                str(export_path),
+            ]
+            ok_proc = subprocess.run(cmd, capture_output=True, text=True)
+            self.assertEqual(ok_proc.returncode, 0, ok_proc.stderr)
+
+            lines = export_path.read_text(encoding="utf-8").splitlines()
+            records = [json.loads(line) for line in lines if line.strip()]
+            for record in records:
+                if record.get("record_type") == "tool_receipt":
+                    response_payload = json.loads(record["response_payload_json"])
+                    response_payload["tampered"] = True
+                    response_payload_json = canonical_json(response_payload)
+                    record["response_payload_json"] = response_payload_json
+                    record["response_sha256"] = sha256_payload(response_payload_json)
+                    break
+            export_path.write_text(
+                "\n".join(json.dumps(record, ensure_ascii=False) for record in records) + "\n",
+                encoding="utf-8",
+            )
+
+            mismatch_proc = subprocess.run(cmd, capture_output=True, text=True)
+            self.assertEqual(mismatch_proc.returncode, 2, mismatch_proc.stderr)


### PR DESCRIPTION
### Motivation
- Close the audit chain by recording first-class tool receipts for every tool invocation so inputs/outputs/status and canonical hashes are persisted and exportable.
- Provide a deterministic, CLI-first replay/validation path from JSONL exports so operators can verify run fidelity without executing side effects.
- Maintain Windows-safe DB handle semantics and deterministic ordering for reproducible audits.
- Ensure secrets are not leaked by applying deterministic redaction before hashing and storage.

### Description
- Added a new `ToolReceipt` model and `tool_receipts` SQLite table with fields including canonical payload JSON, sha256 hashes, timestamps, duration, role/session/plan linkage, status, and optional policy snapshot.
- Implemented redaction, canonical JSON, and hashing helpers in `gismo/core/tool_receipts.py` and wired receipt creation into the orchestrator so receipts are recorded for idempotent skips, successes, and errors.
- Extended `export_run_jsonl` to include `tool_receipt` records and added CLI commands `tools receipts list --run RUN_ID`, `tools receipts show RECEIPT_ID`, and `tools replay --run RUN_ID --from-export FILE.jsonl` (replay is validation-only / dry-run by design).
- Added tests `tests/test_tool_receipts.py`, updated `tests/test_export.py` and `tests/test_run_show_cli.py`, and updated `README.md` and `Handoff.md` to document the new audit and replay features.

### Testing
- Ran the repository verification script with `python scripts/verify.py`, which completed successfully (no errors).
- Ran the full unit test suite with `pytest -q`, resulting in all tests passing (`209 passed, 3 skipped`).
- Added focused tests that assert receipts are recorded, redaction and canonical JSON hashing are stable, exports include `tool_receipt` records, and `tools replay --dry-run` detects tampering (mismatch exit code 2).
- Verified Windows DB handle guardrails remain intact by running the existing DB handle tests in the suite (they passed as part of `pytest`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c601804508330ad3ab4ff304c19a4)