### PR TITLE
Add deterministic memory injection trace and `gismo memory preview`

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -155,15 +155,19 @@ INTENTIONAL LIMITATIONS (NOT BUGS)
 
 RECENT NOTABLE CHANGE (LATEST WORK)
 
-Phase 2 close-out (risk + confirmations + explain artifacts + policy-aware prompt):
-- Added deterministic risk classification (LOW/MEDIUM/HIGH) with stable flags/rationale.
-- Centralized confirmation gating for ask/agent/agent-session plans.
-- Explain artifacts are first-class and recorded in audit events (JSON, stable ordering).
-- Planner prompt now includes policy summaries (allowed tools, shell allowlist, write permissions).
-- Updated docs and tests to reflect Windows-first, audit-only dry runs.
+Phase 3 kickoff (memory injection trace + preview):
+- Added deterministic memory injection trace artifacts (hash + counts + ordered items) in explain JSON.
+- Added memory injection audit events with bounded trace summaries (export-friendly).
+- Added `gismo memory preview --memory-profile ...` (policy-aware, read-only).
+- Updated policies, tests, and docs to cover memory.read and trace visibility.
+
+Next steps:
+- Validate policy-denied namespace behavior on Windows with real profiles.
+- Consider extending preview to prompt-based injection if operators need parity.
 
 Tests run:
 - python scripts/verify.py
+- pytest -q
 
 -------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Memory management (policy-gated; confirmation required for high-risk namespaces)
     --policy policy/dev-safe.json --yes --non-interactive
   gismo memory explain --plan PLAN_EVENT_ID
   gismo memory explain --run RUN_ID --json
+  gismo memory preview --memory-profile operator --json
   gismo memory doctor check --db .gismo/state.db --policy policy/dev-safe.json
   gismo memory doctor check --db .gismo/state.db --policy policy/dev-safe.json --json
   gismo memory doctor repair --rebuild-indexes --policy /path/to/policy.json --yes
@@ -177,6 +178,8 @@ Notes:
   memory.profile.retire plus explicit confirmation.
 - Retention enforcement is policy/confirmation-gated via memory.retention.enforce and runs only on writes.
 - Memory explain is observational only; it reads selection traces captured during ask/agent runs.
+- Memory injection trace is bounded and deterministic; it appears in explain JSON and
+  gismo memory preview for live inspection.
 - Memory doctor repairs are operator-controlled, policy-gated, and require explicit flags (no automatic fixes).
 - Snapshot item_hash values are computed from a canonical JSON payload that includes
   created_at/updated_at timestamps; snapshot_hash is the sha256 of ordered item_hashes.

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -227,6 +227,15 @@ Memory in ask/agent (read-only injection):
   gismo ask "plan with memory context" --dry-run --memory
   gismo ask "plan with operator profile" --dry-run --memory-profile operator
 
+Memory injection trace (bounded, deterministic):
+
+  gismo memory explain --plan PLAN_EVENT_ID --json
+  gismo memory preview --memory-profile operator --json
+
+Notes:
+- Ordering is deterministic (updated_at desc, namespace, key).
+- The trace includes eligibility counts, selected items, dropped counts, and an injection_hash.
+
 Memory suggestions:
 - The LLM may emit memory_suggestions.
 - Suggestions are advisory by default (no auto-write).

--- a/gismo/cli/agent_session.py
+++ b/gismo/cli/agent_session.py
@@ -25,6 +25,7 @@ class AgentSessionDependencies:
     request_llm_plan: Callable[..., tuple[dict, object, object, object, StateStore, dict[str, object]]]
     build_memory_injection: Callable[..., object]
     record_memory_profile_use: Callable[..., None]
+    record_memory_injection_trace: Callable[..., None]
     confirm_plan_gate: Callable[..., object]
     enqueue_plan_actions: Callable[..., tuple[list[str], list[str]]]
     drain_queue_items: Callable[..., list[QueueStatus]]
@@ -176,10 +177,18 @@ def run_agent_session_resume(args: argparse.Namespace, deps: AgentSessionDepende
     plan_event_id = str(uuid4())
     memory_injection = None
     if session.profile_id or session.profile_name:
+        source = f"role:{session.role_name}" if session.role_name else "--memory-profile"
         memory_injection = deps.build_memory_injection(
             args.db_path,
+            source=source,
             profile_selector=session.profile_id or session.profile_name,
             plan_id=plan_event_id,
+        )
+        deps.record_memory_injection_trace(
+            db_path=args.db_path,
+            memory_injection=memory_injection,
+            actor="agent_session",
+            related_event_id=plan_event_id,
         )
     role_context = None
     if session.role_id and session.role_name:

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -17,6 +17,7 @@ from uuid import UUID, uuid4
 from gismo.cli import memory_doctor as memory_doctor_cli
 from gismo.cli import memory_explain as memory_explain_cli
 from gismo.cli import memory_profile as memory_profile_cli
+from gismo.cli import memory_preview as memory_preview_cli
 from gismo.cli import memory_snapshot as memory_snapshot_cli
 from gismo.cli import agent_role as agent_role_cli
 from gismo.cli import agent_session as agent_session_cli
@@ -52,6 +53,17 @@ from gismo.core.toolpacks.fs_tools import FileSystemConfig, ListDirTool, ReadFil
 from gismo.core.toolpacks.shell_tool import ShellConfig, ShellTool
 from gismo.llm.ollama import OllamaError, ollama_chat, resolve_ollama_config
 from gismo.llm.prompts import build_system_prompt, build_user_prompt
+from gismo.memory.injection import (
+    MEMORY_INJECTION_BYTE_CAP,
+    MEMORY_INJECTION_ITEM_CAP,
+    MEMORY_INJECTION_TRACE_AUDIT_LIMIT,
+    MemoryInjectionTrace,
+    build_memory_injection_trace,
+    prompt_selection_filters,
+    profile_filters_payload,
+    profile_selection_filters,
+    select_injection_items,
+)
 from gismo.memory.store import (
     MemoryItem,
     MemoryNamespaceDetail,
@@ -628,6 +640,15 @@ def _print_plan_explain(explain: PlanExplain, *, verbose: bool) -> None:
         print(f"- shell allowlist: {explain.shell_allowlist_summary}")
         write_tools = ", ".join(explain.write_permissions) if explain.write_permissions else "none"
         print(f"- write permissions: {write_tools}")
+        trace = explain.memory_injection_trace
+        if isinstance(trace, dict):
+            eligibility = trace.get("eligibility")
+            selected_count = None
+            if isinstance(eligibility, dict):
+                selected_count = eligibility.get("selected_items")
+            print(f"- memory injection hash: {trace.get('injection_hash')}")
+            if selected_count is not None:
+                print(f"- memory selected count: {selected_count}")
 
 
 def _print_plan_json(
@@ -3083,6 +3104,7 @@ class MemoryInjection:
     keys: list[dict[str, str]]
     cap_items: int
     cap_bytes: int
+    trace: MemoryInjectionTrace
     profile: dict[str, object] | None = None
 
 
@@ -3091,31 +3113,6 @@ class AgentRoleContext:
     role_id: str
     role_name: str
     memory_profile_id: str | None
-
-
-MEMORY_INJECTION_ITEM_CAP = 20
-MEMORY_INJECTION_BYTE_CAP = 8192
-
-
-def _serialize_memory_value(value: object) -> str:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-
-
-def _memory_entries_for_prompt(items: list[MemoryItem]) -> list[dict[str, str]]:
-    entries: list[dict[str, str]] = []
-    for item in items:
-        entries.append(
-            {
-                "namespace": item.namespace,
-                "key": item.key,
-                "kind": item.kind,
-                "confidence": item.confidence,
-                "source": item.source,
-                "updated_at": item.updated_at,
-                "value_json": _serialize_memory_value(item.value),
-            }
-        )
-    return entries
 
 
 def _resolve_memory_profile(db_path: str, selector: str) -> MemoryProfile:
@@ -3129,27 +3126,17 @@ def _resolve_memory_profile(db_path: str, selector: str) -> MemoryProfile:
     return profile
 
 
-def _profile_filters(profile: MemoryProfile, effective_limit: int | None) -> dict[str, object]:
-    return {
-        "profile_id": profile.profile_id,
-        "name": profile.name,
-        "include_namespaces": profile.include_namespaces,
-        "exclude_namespaces": profile.exclude_namespaces,
-        "include_kinds": profile.include_kinds,
-        "exclude_kinds": profile.exclude_kinds,
-        "max_items": profile.max_items,
-        "effective_limit": effective_limit,
-    }
-
-
 def _build_memory_injection(
     db_path: str,
     *,
+    source: str,
     profile_selector: str | None = None,
     plan_id: str | None = None,
     run_id: str | None = None,
 ) -> MemoryInjection:
     profile_filters = None
+    selection_filters = None
+    trace_profile = None
     if profile_selector:
         profile = _resolve_memory_profile(db_path, profile_selector)
         items = memory_list_profile_items(
@@ -3161,7 +3148,9 @@ def _build_memory_injection(
             MEMORY_INJECTION_ITEM_CAP,
             profile.max_items if profile.max_items is not None else MEMORY_INJECTION_ITEM_CAP,
         )
-        profile_filters = _profile_filters(profile, effective_limit)
+        profile_filters = profile_filters_payload(profile, effective_limit)
+        trace_profile = profile_filters
+        selection_filters = profile_selection_filters(profile)
         memory_record_profile_selection_trace(
             db_path,
             profile=profile,
@@ -3171,27 +3160,23 @@ def _build_memory_injection(
         )
     else:
         items = memory_list_prompt_items(db_path, limit=MEMORY_INJECTION_ITEM_CAP)
+        selection_filters = prompt_selection_filters()
         memory_record_prompt_selection_trace(
             db_path,
             selected_items=items,
             run_id=run_id,
             plan_id=plan_id,
         )
-    entries = _memory_entries_for_prompt(items)
-    capped_entries: list[dict[str, str]] = []
-    total_bytes = 0
-    excluded_due_to_cap: list[MemoryItem] = []
-    for index, entry in enumerate(entries):
-        serialized = json.dumps(entry, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-        entry_bytes = len(serialized.encode("utf-8"))
-        if len(capped_entries) >= MEMORY_INJECTION_ITEM_CAP:
-            excluded_due_to_cap.extend(items[index:])
-            break
-        if total_bytes + entry_bytes > MEMORY_INJECTION_BYTE_CAP:
-            excluded_due_to_cap.extend(items[index:])
-            break
-        capped_entries.append(entry)
-        total_bytes += entry_bytes
+    if selection_filters is None:
+        raise RuntimeError("Memory selection filters were not resolved.")
+    selection = select_injection_items(
+        items,
+        cap_items=MEMORY_INJECTION_ITEM_CAP,
+        cap_bytes=MEMORY_INJECTION_BYTE_CAP,
+    )
+    capped_entries = selection.entries
+    total_bytes = selection.total_bytes
+    excluded_due_to_cap = selection.excluded_items
     if excluded_due_to_cap and (plan_id or run_id):
         include_reason = "include.profile" if profile_selector else "include.default"
         for item in excluded_due_to_cap:
@@ -3223,6 +3208,15 @@ def _build_memory_injection(
         keys=keys,
         cap_items=MEMORY_INJECTION_ITEM_CAP,
         cap_bytes=MEMORY_INJECTION_BYTE_CAP,
+        trace=build_memory_injection_trace(
+            db_path,
+            selected_items=selection.items,
+            source=source,
+            filters=selection_filters,
+            cap_items=MEMORY_INJECTION_ITEM_CAP,
+            cap_bytes=MEMORY_INJECTION_BYTE_CAP,
+            profile=trace_profile,
+        ),
         profile=profile_filters,
     )
 
@@ -3328,6 +3322,33 @@ def _record_memory_profile_use(
         policy_hash=policy_hash_for_path(None),
         request=request,
         result_meta=result_meta,
+        related_ask_event_id=related_event_id,
+    )
+
+
+def _record_memory_injection_trace(
+    *,
+    db_path: str,
+    memory_injection: MemoryInjection | None,
+    actor: str,
+    related_event_id: str | None,
+) -> None:
+    if memory_injection is None:
+        return
+    trace_payload = memory_injection.trace.to_dict(
+        max_selected_items=MEMORY_INJECTION_TRACE_AUDIT_LIMIT
+    )
+    request = {
+        "source": memory_injection.trace.source,
+        "profile": memory_injection.trace.profile,
+    }
+    memory_record_event(
+        db_path,
+        operation="memory.inject",
+        actor=actor,
+        policy_hash=policy_hash_for_path(None),
+        request=request,
+        result_meta=trace_payload,
         related_ask_event_id=related_event_id,
     )
 
@@ -3494,11 +3515,13 @@ def _request_llm_plan(
             )
             raise
         risk = classify_plan_risk(plan.get("actions", []))
+        trace_payload = memory_injection.trace.to_dict() if memory_injection else None
         explain_payload = build_plan_explain(
             plan=plan,
             risk=risk,
             policy_summary=policy_summary,
             memory_injection=_memory_injection_status(memory_injection),
+            memory_injection_trace=trace_payload,
             memory_suggestions_count=len(plan.get("memory_suggestions") or []),
         )
         if not json_output:
@@ -3583,10 +3606,18 @@ def run_ask(
     plan_event_id = str(uuid4())
     memory_injection = None
     if use_memory or memory_profile:
+        source = "--memory-profile" if memory_profile else "--memory"
         memory_injection = _build_memory_injection(
             db_path,
+            source=source,
             profile_selector=memory_profile,
             plan_id=plan_event_id,
+        )
+        _record_memory_injection_trace(
+            db_path=db_path,
+            memory_injection=memory_injection,
+            actor="ask",
+            related_event_id=plan_event_id,
         )
     plan, risk, explain_payload, policy_summary, state_store, payload = _request_llm_plan(
         db_path,
@@ -3883,10 +3914,23 @@ def run_agent(
         plan_event_id = str(uuid4())
         memory_injection = None
         if use_memory or memory_profile or role_profile_selector:
+            if role_profile_selector and role_context:
+                source = f"role:{role_context.role_name}"
+            elif memory_profile:
+                source = "--memory-profile"
+            else:
+                source = "--memory"
             memory_injection = _build_memory_injection(
                 db_path,
+                source=source,
                 profile_selector=role_profile_selector or memory_profile,
                 plan_id=plan_event_id,
+            )
+            _record_memory_injection_trace(
+                db_path=db_path,
+                memory_injection=memory_injection,
+                actor="agent",
+                related_event_id=plan_event_id,
             )
         plan, risk, explain_payload, policy_summary, state_store, _payload = _request_llm_plan(
             db_path,
@@ -4304,6 +4348,7 @@ def _agent_session_dependencies() -> agent_session_cli.AgentSessionDependencies:
         request_llm_plan=_request_llm_plan,
         build_memory_injection=_build_memory_injection,
         record_memory_profile_use=_record_memory_profile_use,
+        record_memory_injection_trace=_record_memory_injection_trace,
         confirm_plan_gate=_confirm_plan_gate,
         enqueue_plan_actions=_enqueue_plan_actions,
         drain_queue_items=_drain_queue_items,
@@ -4370,6 +4415,10 @@ def _handle_memory_search(args: argparse.Namespace) -> None:
 
 def _handle_memory_delete(args: argparse.Namespace) -> None:
     run_memory_delete(args)
+
+
+def _handle_memory_preview(args: argparse.Namespace) -> None:
+    memory_preview_cli.run_memory_preview(args)
 
 
 def _handle_memory_doctor_check(args: argparse.Namespace) -> None:
@@ -5517,6 +5566,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="Optional policy file path for audit hashing",
     )
     memory_search_parser.set_defaults(handler=_handle_memory_search)
+
+    memory_preview_parser = memory_subparsers.add_parser(
+        "preview",
+        help="Preview memory injection for a profile",
+        parents=[db_parent_optional],
+    )
+    memory_preview_parser.add_argument(
+        "--memory-profile",
+        required=True,
+        help="Memory profile name or ID",
+    )
+    memory_preview_parser.add_argument(
+        "--namespace",
+        action="append",
+        help="Restrict preview to namespace(s); supports * prefix matching",
+    )
+    memory_preview_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output JSON",
+    )
+    memory_preview_parser.add_argument(
+        "--policy",
+        default=None,
+        help="Optional policy file path",
+    )
+    memory_preview_parser.set_defaults(handler=_handle_memory_preview)
 
     memory_delete_parser = memory_subparsers.add_parser(
         "delete",

--- a/gismo/cli/memory_preview.py
+++ b/gismo/cli/memory_preview.py
@@ -1,0 +1,163 @@
+"""Memory preview CLI handlers."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from gismo.core.permissions import PermissionPolicy, load_policy
+from gismo.memory.injection import (
+    MEMORY_INJECTION_BYTE_CAP,
+    MEMORY_INJECTION_ITEM_CAP,
+    build_memory_injection_trace,
+    profile_filters_payload,
+    profile_selection_filters,
+    select_injection_items,
+)
+from gismo.memory.store import MemoryProfile, get_profile_by_selector, list_profile_items
+
+READ_ACTION = "memory.read"
+
+
+def run_memory_preview(args: argparse.Namespace) -> None:
+    profile = _resolve_profile(args.db_path, args.memory_profile)
+    namespace_filters = _normalize_list(args.namespace)
+    policy, _ = _load_memory_policy(args.policy)
+    tool_allowed = _check_tool_allowed(policy)
+
+    def policy_checker(namespace: str) -> bool:
+        if not tool_allowed:
+            return False
+        return policy.memory.is_allowed(READ_ACTION, namespace)
+
+    items = list_profile_items(
+        args.db_path,
+        profile=profile,
+        limit=MEMORY_INJECTION_ITEM_CAP,
+    )
+    selection_filters = profile_selection_filters(
+        profile,
+        namespace_filters=namespace_filters,
+    )
+    scoped_items = [
+        item for item in items if selection_filters.matches_namespace(item.namespace)
+    ]
+    allowed_items = [item for item in scoped_items if policy_checker(item.namespace)]
+    selection = select_injection_items(
+        allowed_items,
+        cap_items=MEMORY_INJECTION_ITEM_CAP,
+        cap_bytes=MEMORY_INJECTION_BYTE_CAP,
+    )
+    effective_limit = min(
+        MEMORY_INJECTION_ITEM_CAP,
+        profile.max_items if profile.max_items is not None else MEMORY_INJECTION_ITEM_CAP,
+    )
+    trace = build_memory_injection_trace(
+        args.db_path,
+        selected_items=selection.items,
+        source="--memory-profile",
+        filters=selection_filters,
+        cap_items=MEMORY_INJECTION_ITEM_CAP,
+        cap_bytes=MEMORY_INJECTION_BYTE_CAP,
+        profile=profile_filters_payload(profile, effective_limit),
+        policy_checker=policy_checker,
+    )
+    if args.json:
+        print(json.dumps(trace.to_dict(), ensure_ascii=False, sort_keys=True, indent=2))
+        return
+    _print_preview(trace)
+
+
+def _print_preview(trace) -> None:
+    print("Memory preview (profile)")
+    print(f"Source: {trace.source}")
+    eligibility = trace.counts.to_dict()
+    print(
+        "Selected: "
+        f"{eligibility.get('selected_items')}/"
+        f"{eligibility.get('filtered_items')} "
+        f"(cap_items={eligibility.get('cap_items')} cap_bytes={eligibility.get('cap_bytes')})"
+    )
+    print(f"Injection hash: {trace.injection_hash}")
+    if trace.denied_namespaces:
+        denied = ", ".join(
+            f"{entry['namespace']}={entry['count']}" for entry in trace.denied_namespaces
+        )
+        print(f"Denied namespaces: {denied}")
+    print("Selected items:")
+    if not trace.selected_items:
+        print("  - none")
+        return
+    for item in trace.selected_items:
+        print(
+            "  - "
+            f"{item.namespace}/{item.key} kind={item.kind} "
+            f"confidence={item.confidence} updated_at={item.updated_at} "
+            f"hash={item.item_hash}"
+        )
+
+
+def _resolve_profile(db_path: str, selector: str) -> MemoryProfile:
+    profile = get_profile_by_selector(db_path, selector)
+    if profile is None:
+        print(f"Memory profile not found: {selector}", file=sys.stderr)
+        raise SystemExit(2)
+    if profile.retired_at:
+        print(f"Memory profile is retired: {profile.name}", file=sys.stderr)
+        raise SystemExit(2)
+    return profile
+
+
+def _normalize_list(values: list[str] | None) -> list[str] | None:
+    if not values:
+        return None
+    normalized: list[str] = []
+    for item in values:
+        if not item:
+            continue
+        normalized.extend(part.strip() for part in item.split(",") if part.strip())
+    if not normalized:
+        return None
+    return sorted(set(normalized))
+
+
+def _resolve_default_policy_path(
+    policy_path: str | None,
+    repo_root: Path,
+) -> tuple[str | None, bool]:
+    if policy_path:
+        return policy_path, False
+    readonly_path = repo_root / "policy" / "readonly.json"
+    if readonly_path.exists():
+        return str(readonly_path), False
+    return None, True
+
+
+def _warn_missing_default_policy() -> None:
+    print(
+        "Warning: no policy provided and no policy/readonly.json found; "
+        "continuing with existing default tool allowances.",
+        file=sys.stderr,
+    )
+
+
+def _load_memory_policy(policy_path: str | None) -> tuple[PermissionPolicy, str | None]:
+    repo_root = Path(__file__).resolve().parents[2]
+    resolved_path, warn = _resolve_default_policy_path(policy_path, repo_root)
+    if warn:
+        _warn_missing_default_policy()
+    try:
+        policy = load_policy(resolved_path, repo_root=repo_root)
+    except (OSError, ValueError, PermissionError) as exc:
+        print(f"Policy file not valid: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    return policy, resolved_path
+
+
+def _check_tool_allowed(policy: PermissionPolicy) -> bool:
+    try:
+        policy.check_tool_allowed(READ_ACTION)
+    except PermissionError:
+        return False
+    return True

--- a/gismo/core/explain.py
+++ b/gismo/core/explain.py
@@ -22,6 +22,7 @@ class PlanExplain:
     shell_allowlist_summary: str
     write_permissions: list[str]
     memory_injection: MemoryInjectionStatus
+    memory_injection_trace: dict[str, object] | None
     memory_suggestions: dict[str, object]
 
     def to_dict(self) -> dict[str, object]:
@@ -35,6 +36,7 @@ class PlanExplain:
             "shell_allowlist_summary": self.shell_allowlist_summary,
             "write_permissions": list(self.write_permissions),
             "memory_injection": self.memory_injection,
+            "memory_injection_trace": self.memory_injection_trace,
             "memory_suggestions": dict(self.memory_suggestions),
         }
 
@@ -45,6 +47,7 @@ def build_plan_explain(
     risk: PlanRisk,
     policy_summary: PolicySummary,
     memory_injection: MemoryInjectionStatus,
+    memory_injection_trace: dict[str, object] | None,
     memory_suggestions_count: int,
 ) -> PlanExplain:
     summary = _plan_summary(plan)
@@ -63,6 +66,7 @@ def build_plan_explain(
         shell_allowlist_summary=policy_summary.shell_allowlist_summary,
         write_permissions=policy_summary.write_tools,
         memory_injection=memory_injection,
+        memory_injection_trace=memory_injection_trace,
         memory_suggestions=suggestions_payload,
     )
 

--- a/gismo/memory/injection.py
+++ b/gismo/memory/injection.py
@@ -1,0 +1,400 @@
+"""Deterministic memory injection selection and tracing."""
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Iterable, Sequence
+
+from gismo.memory.snapshot import memory_item_hash
+from gismo.memory.store import (
+    MemoryItem,
+    MemoryProfile,
+    PROMPT_ALLOWED_CONFIDENCES,
+    PROMPT_ALLOWED_KINDS,
+)
+
+MEMORY_INJECTION_ITEM_CAP = 20
+MEMORY_INJECTION_BYTE_CAP = 8192
+MEMORY_INJECTION_TRACE_AUDIT_LIMIT = 10
+MEMORY_INJECTION_TRACE_SCHEMA_VERSION = 1
+MEMORY_INJECTION_TRACE_ORDERING = "updated_at_desc,namespace,key,id"
+
+
+@dataclass(frozen=True)
+class NamespaceFilter:
+    exact: tuple[str, ...]
+    prefixes: tuple[str, ...]
+    allow_all: bool = False
+
+    @classmethod
+    def from_patterns(cls, patterns: Iterable[str]) -> "NamespaceFilter":
+        exact: list[str] = []
+        prefixes: list[str] = []
+        allow_all = False
+        for pattern in patterns:
+            pattern = pattern.strip()
+            if not pattern:
+                continue
+            if pattern == "*":
+                allow_all = True
+                continue
+            if pattern.endswith("*"):
+                prefixes.append(pattern[:-1])
+            else:
+                exact.append(pattern)
+        return cls(exact=tuple(sorted(set(exact))), prefixes=tuple(sorted(set(prefixes))), allow_all=allow_all)
+
+    def matches(self, namespace: str) -> bool:
+        if self.allow_all:
+            return True
+        if namespace in self.exact:
+            return True
+        return any(namespace.startswith(prefix) for prefix in self.prefixes)
+
+    def sql_clause(self) -> tuple[str | None, list[object]]:
+        if self.allow_all:
+            return None, []
+        parts: list[str] = []
+        params: list[object] = []
+        if self.exact:
+            placeholders = ",".join("?" for _ in self.exact)
+            parts.append(f"namespace IN ({placeholders})")
+            params.extend(self.exact)
+        for prefix in self.prefixes:
+            parts.append("namespace LIKE ?")
+            params.append(f"{prefix}%")
+        if not parts:
+            return None, []
+        return f"({' OR '.join(parts)})", params
+
+
+@dataclass(frozen=True)
+class MemorySelectionFilters:
+    include_groups: tuple[NamespaceFilter, ...]
+    exclude_namespaces: tuple[str, ...]
+    include_kinds: tuple[str, ...]
+    exclude_kinds: tuple[str, ...]
+    include_confidences: tuple[str, ...]
+
+    def namespace_only(self) -> "MemorySelectionFilters":
+        return MemorySelectionFilters(
+            include_groups=self.include_groups,
+            exclude_namespaces=self.exclude_namespaces,
+            include_kinds=(),
+            exclude_kinds=(),
+            include_confidences=(),
+        )
+
+    def matches_namespace(self, namespace: str) -> bool:
+        for group in self.include_groups:
+            if not group.matches(namespace):
+                return False
+        if self.exclude_namespaces and namespace in self.exclude_namespaces:
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class MemoryInjectionSelection:
+    items: list[MemoryItem]
+    entries: list[dict[str, str]]
+    total_bytes: int
+    excluded_items: list[MemoryItem]
+
+
+@dataclass(frozen=True)
+class MemoryInjectionTraceItem:
+    namespace: str
+    key: str
+    kind: str
+    confidence: str
+    updated_at: str
+    item_hash: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "namespace": self.namespace,
+            "key": self.key,
+            "kind": self.kind,
+            "confidence": self.confidence,
+            "updated_at": self.updated_at,
+            "item_hash": self.item_hash,
+        }
+
+
+@dataclass(frozen=True)
+class MemoryInjectionTraceCounts:
+    total_items: int
+    filtered_items: int
+    selected_items: int
+    dropped_items: int
+    cap_items: int
+    cap_bytes: int
+    denied_items: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "total_items": self.total_items,
+            "filtered_items": self.filtered_items,
+            "selected_items": self.selected_items,
+            "dropped_items": self.dropped_items,
+            "cap_items": self.cap_items,
+            "cap_bytes": self.cap_bytes,
+        }
+        if self.denied_items is not None:
+            payload["denied_items"] = self.denied_items
+        return payload
+
+
+@dataclass(frozen=True)
+class MemoryInjectionTrace:
+    enabled: bool
+    source: str
+    ordering: str
+    profile: dict[str, object] | None
+    counts: MemoryInjectionTraceCounts
+    selected_items: list[MemoryInjectionTraceItem]
+    injection_hash: str
+    denied_namespaces: list[dict[str, object]] | None = None
+
+    def to_dict(self, *, max_selected_items: int | None = None) -> dict[str, object]:
+        selected = self.selected_items
+        truncated = False
+        remaining = 0
+        if max_selected_items is not None and len(selected) > max_selected_items:
+            truncated = True
+            remaining = len(selected) - max_selected_items
+            selected = selected[:max_selected_items]
+        payload: dict[str, object] = {
+            "schema_version": MEMORY_INJECTION_TRACE_SCHEMA_VERSION,
+            "enabled": self.enabled,
+            "source": self.source,
+            "ordering": self.ordering,
+            "profile": self.profile,
+            "eligibility": self.counts.to_dict(),
+            "selected": [item.to_dict() for item in selected],
+            "selected_truncated": truncated,
+            "selected_remaining": remaining,
+            "injection_hash": self.injection_hash,
+        }
+        if self.denied_namespaces:
+            payload["denied_namespaces"] = list(self.denied_namespaces)
+        return payload
+
+
+def prompt_selection_filters(*, namespace_filters: Iterable[str] | None = None) -> MemorySelectionFilters:
+    include_groups = [NamespaceFilter.from_patterns(["global", "project:*"])]
+    if namespace_filters:
+        include_groups.append(NamespaceFilter.from_patterns(namespace_filters))
+    return MemorySelectionFilters(
+        include_groups=tuple(include_groups),
+        exclude_namespaces=(),
+        include_kinds=tuple(sorted(PROMPT_ALLOWED_KINDS)),
+        exclude_kinds=(),
+        include_confidences=tuple(sorted(PROMPT_ALLOWED_CONFIDENCES)),
+    )
+
+
+def profile_selection_filters(
+    profile: MemoryProfile,
+    *,
+    namespace_filters: Iterable[str] | None = None,
+) -> MemorySelectionFilters:
+    include_groups: list[NamespaceFilter] = []
+    if profile.include_namespaces:
+        include_groups.append(NamespaceFilter.from_patterns(profile.include_namespaces))
+    if namespace_filters:
+        include_groups.append(NamespaceFilter.from_patterns(namespace_filters))
+    return MemorySelectionFilters(
+        include_groups=tuple(include_groups),
+        exclude_namespaces=tuple(sorted(set(profile.exclude_namespaces))),
+        include_kinds=tuple(sorted(set(profile.include_kinds))),
+        exclude_kinds=tuple(sorted(set(profile.exclude_kinds))),
+        include_confidences=(),
+    )
+
+
+def profile_filters_payload(profile: MemoryProfile, effective_limit: int | None) -> dict[str, object]:
+    return {
+        "profile_id": profile.profile_id,
+        "name": profile.name,
+        "include_namespaces": profile.include_namespaces,
+        "exclude_namespaces": profile.exclude_namespaces,
+        "include_kinds": profile.include_kinds,
+        "exclude_kinds": profile.exclude_kinds,
+        "max_items": profile.max_items,
+        "effective_limit": effective_limit,
+    }
+
+
+def order_memory_items(items: Sequence[MemoryItem]) -> list[MemoryItem]:
+    return sorted(items, key=_memory_sort_key)
+
+
+def select_injection_items(
+    items: Sequence[MemoryItem],
+    *,
+    cap_items: int,
+    cap_bytes: int,
+) -> MemoryInjectionSelection:
+    ordered_items = order_memory_items(items)
+    entries = memory_entries_for_prompt(ordered_items)
+    capped_entries: list[dict[str, str]] = []
+    selected_items: list[MemoryItem] = []
+    excluded_items: list[MemoryItem] = []
+    total_bytes = 0
+    for index, entry in enumerate(entries):
+        serialized = json.dumps(entry, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        entry_bytes = len(serialized.encode("utf-8"))
+        if len(capped_entries) >= cap_items or total_bytes + entry_bytes > cap_bytes:
+            excluded_items.extend(ordered_items[index:])
+            break
+        capped_entries.append(entry)
+        selected_items.append(ordered_items[index])
+        total_bytes += entry_bytes
+    return MemoryInjectionSelection(
+        items=selected_items,
+        entries=capped_entries,
+        total_bytes=total_bytes,
+        excluded_items=excluded_items,
+    )
+
+
+def memory_entries_for_prompt(items: Sequence[MemoryItem]) -> list[dict[str, str]]:
+    entries: list[dict[str, str]] = []
+    for item in items:
+        entries.append(
+            {
+                "namespace": item.namespace,
+                "key": item.key,
+                "kind": item.kind,
+                "confidence": item.confidence,
+                "source": item.source,
+                "updated_at": item.updated_at,
+                "value_json": serialize_memory_value(item.value),
+            }
+        )
+    return entries
+
+
+def serialize_memory_value(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def injection_hash_for_items(items: Sequence[MemoryItem]) -> str:
+    ordered = order_memory_items(items)
+    item_hashes = [memory_item_hash(item) for item in ordered]
+    return _injection_hash(item_hashes)
+
+
+def build_memory_injection_trace(
+    db_path: str,
+    *,
+    selected_items: Sequence[MemoryItem],
+    source: str,
+    filters: MemorySelectionFilters,
+    cap_items: int,
+    cap_bytes: int,
+    profile: dict[str, object] | None = None,
+    policy_checker: Callable[[str], bool] | None = None,
+) -> MemoryInjectionTrace:
+    ordered_selected = order_memory_items(selected_items)
+    trace_items = [
+        MemoryInjectionTraceItem(
+            namespace=item.namespace,
+            key=item.key,
+            kind=item.kind,
+            confidence=item.confidence,
+            updated_at=item.updated_at,
+            item_hash=memory_item_hash(item),
+        )
+        for item in ordered_selected
+    ]
+    injection_hash = _injection_hash([item.item_hash for item in trace_items])
+    total_by_namespace = _count_items_by_namespace(db_path, filters.namespace_only())
+    filtered_by_namespace = _count_items_by_namespace(db_path, filters)
+    total_count = sum(total_by_namespace.values())
+    filtered_count = sum(filtered_by_namespace.values())
+    denied_namespaces: list[dict[str, object]] = []
+    denied_items = 0
+    if policy_checker is not None:
+        for namespace, count in filtered_by_namespace.items():
+            if not policy_checker(namespace):
+                denied_namespaces.append({"namespace": namespace, "count": count})
+                denied_items += count
+        denied_namespaces.sort(key=lambda entry: entry["namespace"])
+    allowed_filtered = filtered_count - denied_items
+    dropped_count = max(0, allowed_filtered - len(ordered_selected))
+    counts = MemoryInjectionTraceCounts(
+        total_items=total_count,
+        filtered_items=filtered_count,
+        selected_items=len(ordered_selected),
+        dropped_items=dropped_count,
+        cap_items=cap_items,
+        cap_bytes=cap_bytes,
+        denied_items=denied_items if denied_namespaces else None,
+    )
+    return MemoryInjectionTrace(
+        enabled=True,
+        source=source,
+        ordering=MEMORY_INJECTION_TRACE_ORDERING,
+        profile=profile,
+        counts=counts,
+        selected_items=trace_items,
+        injection_hash=injection_hash,
+        denied_namespaces=denied_namespaces or None,
+    )
+
+
+def _memory_sort_key(item: MemoryItem) -> tuple[float, str, str, str]:
+    parsed = datetime.fromisoformat(item.updated_at)
+    return (-parsed.timestamp(), item.namespace, item.key, item.id)
+
+
+def _count_items_by_namespace(
+    db_path: str,
+    filters: MemorySelectionFilters,
+) -> dict[str, int]:
+    clauses: list[str] = ["is_tombstoned = 0"]
+    params: list[object] = []
+    for group in filters.include_groups:
+        clause, group_params = group.sql_clause()
+        if clause:
+            clauses.append(clause)
+            params.extend(group_params)
+    if filters.exclude_namespaces:
+        placeholders = ",".join("?" for _ in filters.exclude_namespaces)
+        clauses.append(f"namespace NOT IN ({placeholders})")
+        params.extend(filters.exclude_namespaces)
+    if filters.include_kinds:
+        placeholders = ",".join("?" for _ in filters.include_kinds)
+        clauses.append(f"kind IN ({placeholders})")
+        params.extend(filters.include_kinds)
+    if filters.exclude_kinds:
+        placeholders = ",".join("?" for _ in filters.exclude_kinds)
+        clauses.append(f"kind NOT IN ({placeholders})")
+        params.extend(filters.exclude_kinds)
+    if filters.include_confidences:
+        placeholders = ",".join("?" for _ in filters.include_confidences)
+        clauses.append(f"confidence IN ({placeholders})")
+        params.extend(filters.include_confidences)
+    where_clause = " AND ".join(clauses)
+    sql = (
+        "SELECT namespace, COUNT(*) AS count "
+        "FROM memory_items "
+        f"WHERE {where_clause} "
+        "GROUP BY namespace "
+        "ORDER BY namespace ASC"
+    )
+    with sqlite3.connect(db_path) as connection:
+        connection.row_factory = sqlite3.Row
+        rows = connection.execute(sql, params).fetchall()
+    return {row["namespace"]: int(row["count"]) for row in rows}
+
+
+def _injection_hash(item_hashes: Sequence[str]) -> str:
+    joined = "".join(item_hashes)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()

--- a/gismo/memory/store.py
+++ b/gismo/memory/store.py
@@ -1193,7 +1193,7 @@ class MemoryStore:
             "AND (namespace = ? OR namespace LIKE ?) "
             f"AND kind IN ({kind_placeholders}) "
             f"AND confidence IN ({confidence_placeholders}) "
-            "ORDER BY updated_at DESC, key ASC "
+            "ORDER BY updated_at DESC, namespace ASC, key ASC, id ASC "
             "LIMIT ?"
         )
         params: list[Any] = [

--- a/policy/dev-safe.json
+++ b/policy/dev-safe.json
@@ -6,13 +6,15 @@
     "write_note",
     "run_shell",
     "memory.put",
-    "memory.delete"
+    "memory.delete",
+    "memory.read"
   ],
   "fs": { "base_dir": "." },
   "memory": {
     "allow": {
       "memory.put": ["run:*", "project:*", "global"],
-      "memory.delete": ["run:*", "project:*", "global"]
+      "memory.delete": ["run:*", "project:*", "global"],
+      "memory.read": ["run:*", "project:*", "global"]
     },
     "require_confirmation": {
       "memory.put": ["project:*", "global"],

--- a/policy/dev.json
+++ b/policy/dev.json
@@ -7,7 +7,8 @@
     "list_dir",
     "run_shell",
     "memory.put",
-    "memory.delete"
+    "memory.delete",
+    "memory.read"
   ],
   "fs": {
     "base_dir": "."
@@ -15,7 +16,8 @@
   "memory": {
     "allow": {
       "memory.put": ["run:*", "project:*", "global"],
-      "memory.delete": ["run:*"]
+      "memory.delete": ["run:*"],
+      "memory.read": ["run:*", "project:*", "global"]
     },
     "require_confirmation": {
       "memory.put": ["project:*", "global"]

--- a/policy/readonly.json
+++ b/policy/readonly.json
@@ -1,4 +1,9 @@
 {
-  "allowed_tools": ["echo", "read_file", "list_dir"],
-  "fs": { "base_dir": "." }
+  "allowed_tools": ["echo", "read_file", "list_dir", "memory.read"],
+  "fs": { "base_dir": "." },
+  "memory": {
+    "allow": {
+      "memory.read": ["*"]
+    }
+  }
 }

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -13,12 +13,14 @@ from unittest import mock
 
 from gismo.cli import main as cli_main
 from gismo.cli import memory_explain as memory_explain_cli
-from gismo.core.models import QueueStatus
+from gismo.core.export import export_run_jsonl
+from gismo.core.models import EVENT_TYPE_LLM_PLAN, QueueStatus
 from gismo.core.state import StateStore
 from gismo.memory.store import (
     create_profile as memory_create_profile,
     policy_hash_for_path as memory_policy_hash_for_path,
     retire_namespace as memory_retire_namespace,
+    put_item as memory_put_item,
     upsert_item_with_timestamps as memory_upsert_item_with_timestamps,
 )
 
@@ -131,6 +133,84 @@ class AgentCliTest(unittest.TestCase):
             items = state_store.list_queue_items(limit=10)
             self.assertEqual(len(items), 1)
             self.assertEqual(items[0].status, QueueStatus.SUCCEEDED)
+
+    def test_agent_memory_injection_trace_is_exported(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "queue",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "echo: queued",
+                        "timeout_seconds": 15,
+                        "retries": 0,
+                        "why": "record",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+
+        def _fake_run_daemon_once(db_path: str, policy_path: str | None) -> None:
+            state_store = StateStore(db_path)
+            for item in state_store.list_queue_items(limit=10):
+                if item.status == QueueStatus.QUEUED:
+                    state_store.mark_queue_item_succeeded(item.id)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            memory_put_item(
+                db_path,
+                namespace="global",
+                key="default_model",
+                kind="preference",
+                value="phi3:mini",
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="operator",
+                policy_hash=memory_policy_hash_for_path(None),
+            )
+            with mock.patch.dict(os.environ, self._mock_env(), clear=False):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    with mock.patch.object(cli_main, "_run_daemon_once", _fake_run_daemon_once):
+                        cli_main.run_agent(
+                            db_path,
+                            "enqueue a note",
+                            policy_path=None,
+                            once=True,
+                            max_cycles=1,
+                            yes=True,
+                            dry_run=False,
+                            use_memory=True,
+                        )
+            state_store = StateStore(db_path)
+            plan_event = next(
+                event for event in state_store.list_events() if event.event_type == EVENT_TYPE_LLM_PLAN
+            )
+            payload = plan_event.json_payload
+            assert payload is not None
+            trace = payload["explain"]["memory_injection_trace"]
+            self.assertIn("injection_hash", trace)
+            self.assertEqual(trace["eligibility"]["selected_items"], 1)
+
+            run = state_store.get_latest_run()
+            assert run is not None
+            output_path = export_run_jsonl(state_store, run.id, base_dir=Path(tmpdir))
+            records = [
+                json.loads(line)
+                for line in output_path.read_text(encoding="utf-8").strip().splitlines()
+            ]
+            memory_event = next(
+                record
+                for record in records
+                if record["record_type"] == "memory_event"
+                and record["operation"] == "memory.inject"
+            )
+            self.assertIn("injection_hash", memory_event["result_meta"])
 
     def test_agent_requires_confirmation_for_shell(self) -> None:
         response = json.dumps(

--- a/tests/test_memory_injection_trace.py
+++ b/tests/test_memory_injection_trace.py
@@ -1,0 +1,75 @@
+import unittest
+
+from gismo.memory.injection import injection_hash_for_items, order_memory_items
+from gismo.memory.store import MemoryItem
+
+
+def _memory_item(
+    item_id: str,
+    *,
+    namespace: str,
+    key: str,
+    updated_at: str,
+) -> MemoryItem:
+    return MemoryItem(
+        id=item_id,
+        namespace=namespace,
+        key=key,
+        kind="fact",
+        value={"value": key},
+        tags=[],
+        confidence="high",
+        source="operator",
+        ttl_seconds=None,
+        is_tombstoned=False,
+        created_at=updated_at,
+        updated_at=updated_at,
+    )
+
+
+class MemoryInjectionTraceTest(unittest.TestCase):
+    def test_ordering_is_deterministic(self) -> None:
+        item_old = _memory_item(
+            "item-old",
+            namespace="global",
+            key="beta",
+            updated_at="2024-01-02T00:00:00+00:00",
+        )
+        item_new_global = _memory_item(
+            "item-new-global",
+            namespace="global",
+            key="alpha",
+            updated_at="2024-01-03T00:00:00+00:00",
+        )
+        item_new_project = _memory_item(
+            "item-new-project",
+            namespace="project:alpha",
+            key="alpha",
+            updated_at="2024-01-03T00:00:00+00:00",
+        )
+        ordered = order_memory_items([item_old, item_new_project, item_new_global])
+        self.assertEqual(
+            [item.id for item in ordered],
+            ["item-new-global", "item-new-project", "item-old"],
+        )
+
+    def test_injection_hash_is_stable(self) -> None:
+        item_a = _memory_item(
+            "item-a",
+            namespace="global",
+            key="alpha",
+            updated_at="2024-01-04T00:00:00+00:00",
+        )
+        item_b = _memory_item(
+            "item-b",
+            namespace="project:alpha",
+            key="beta",
+            updated_at="2024-01-03T00:00:00+00:00",
+        )
+        first_hash = injection_hash_for_items([item_a, item_b])
+        second_hash = injection_hash_for_items([item_b, item_a])
+        self.assertEqual(first_hash, second_hash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_preview_cli.py
+++ b/tests/test_memory_preview_cli.py
@@ -1,0 +1,81 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.memory.store import (
+    create_profile as memory_create_profile,
+    policy_hash_for_path as memory_policy_hash_for_path,
+    put_item as memory_put_item,
+)
+
+
+def _run_cli(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+class MemoryPreviewCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.db_path = Path(self.temp_dir.name) / "state.db"
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_memory_preview_includes_hash_and_counts(self) -> None:
+        memory_create_profile(
+            str(self.db_path),
+            name="operator",
+            description="Operator profile",
+            include_namespaces=["global"],
+            exclude_namespaces=[],
+            include_kinds=["preference"],
+            exclude_kinds=[],
+            max_items=None,
+        )
+        memory_put_item(
+            str(self.db_path),
+            namespace="global",
+            key="default_model",
+            kind="preference",
+            value="phi3:mini",
+            tags=None,
+            confidence="high",
+            source="operator",
+            ttl_seconds=None,
+            actor="operator",
+            policy_hash=memory_policy_hash_for_path(None),
+        )
+        policy_path = self.repo_root / "policy" / "readonly.json"
+        preview = _run_cli(
+            [
+                "memory",
+                "preview",
+                "--db",
+                str(self.db_path),
+                "--memory-profile",
+                "operator",
+                "--policy",
+                str(policy_path),
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(preview.returncode, 0, preview.stderr)
+        payload = json.loads(preview.stdout)
+        self.assertIn("injection_hash", payload)
+        eligibility = payload.get("eligibility", {})
+        self.assertEqual(eligibility.get("selected_items"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Kick off Phase 3 to add transparent, deterministic memory injection tracing for ask/agent runs while keeping injection observational and non-autonomous.  
- Provide operators a read-only preview command so they can inspect exactly what would be injected under profile rules and policy gating.  
- Ensure traces are audit-friendly and export-safe by bounding detailed lists and publishing a stable `injection_hash` to verify content deterministically.  
- Preserve existing behavior and policy/confirmation guardrails while improving observability of memory selection.

### Description

- Added a new deterministic selection & trace module `gismo/memory/injection.py` that orders selected items, computes stable `item_hash` values and an `injection_hash`, and produces a structured `MemoryInjectionTrace`.  
- Threaded the trace into the planner flow by attaching `trace` to `MemoryInjection`, exposing it in plan explain JSON as `memory_injection_trace`, and recording bounded audit events (`operation="memory.inject"`) for exports.  
- Implemented a new CLI handler `gismo memory preview --memory-profile <name> [--namespace ...] [--json]` in `gismo/cli/memory_preview.py` which performs a policy-aware, read-only preview and emits the same trace structure including `injection_hash`.  
- Updated CLI wiring, explain builder, policies (`policy/*.json`), docs (`README.md`, `docs/OPERATOR.md`, `Handoff.md`), and added unit/CLI/integration tests covering deterministic ordering, hash stability, preview output, and explain/audit inclusion.

### Testing

- Ran the required verification: `python scripts/verify.py` completed successfully.  
- Ran the full test suite: `pytest -q` completed successfully with all tests passing (226 passed, 4 skipped).  
- Smoke checks: `gismo memory preview --memory-profile operator --json` returns a JSON payload containing `injection_hash` and `eligibility.selected_items`, and `gismo ask "Plan with memory context" --dry-run --memory` includes `memory_injection_trace` in the explain payload.  
- Risks / limitations: preview is read-only and respects policy; if `memory.read` is denied the trace will show denied counts, and detailed selected lists are bounded in audit events (first N items + `injection_hash`) to avoid export bloat.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d47651e9883309358e05268d10442)