### PR TITLE
Add operator policy for memory profile lifecycle

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -107,6 +107,7 @@ gismo/
 
 policy/
   dev-safe.json
+  dev-operator.json
   readonly.json
 
 docs/
@@ -155,15 +156,14 @@ INTENTIONAL LIMITATIONS (NOT BUGS)
 
 RECENT NOTABLE CHANGE (LATEST WORK)
 
-Phase 3 kickoff (memory injection trace + preview):
-- Added deterministic memory injection trace artifacts (hash + counts + ordered items) in explain JSON.
-- Added memory injection audit events with bounded trace summaries (export-friendly).
-- Added `gismo memory preview --memory-profile ...` (policy-aware, read-only).
-- Updated policies, tests, and docs to cover memory.read and trace visibility.
+Memory profile policy separation:
+- Added an operator policy for memory profile lifecycle (memory.profile.create/retire).
+- Kept dev-safe/readonly policies readonly for profile governance.
+- Updated docs and tests to reflect profile lifecycle gating and preview usage.
 
 Next steps:
-- Validate policy-denied namespace behavior on Windows with real profiles.
-- Consider extending preview to prompt-based injection if operators need parity.
+- Validate operator profile workflows against real Windows operator runs.
+- Consider shipping default profile templates once governance workflows stabilize.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Memory management (policy-gated; confirmation required for high-risk namespaces)
   gismo memory profile show operator --policy policy/dev-safe.json
   gismo memory profile create --name operator --description "Operator defaults" \
     --include-namespace global --include-kind preference --include-kind fact \
-    --max-items 20 --policy /path/to/policy.json --yes
-  gismo memory profile retire operator --policy /path/to/policy.json --yes
+    --max-items 20 --policy policy/dev-operator.json --yes
+  gismo memory profile retire operator --policy policy/dev-operator.json --yes
   gismo memory retention list --policy policy/dev-safe.json
   gismo memory retention show global --policy policy/dev-safe.json
   gismo memory retention set global --max-items 500 --ttl-seconds 86400 \
@@ -162,7 +162,7 @@ Memory management (policy-gated; confirmation required for high-risk namespaces)
     --policy policy/dev-safe.json --yes --non-interactive
   gismo memory explain --plan PLAN_EVENT_ID
   gismo memory explain --run RUN_ID --json
-  gismo memory preview --memory-profile operator --json
+  gismo memory preview --memory-profile operator --policy policy/dev-operator.json --json
   gismo memory doctor check --db .gismo/state.db --policy policy/dev-safe.json
   gismo memory doctor check --db .gismo/state.db --policy policy/dev-safe.json --json
   gismo memory doctor repair --rebuild-indexes --policy /path/to/policy.json --yes
@@ -175,7 +175,7 @@ Notes:
 - Namespace retirement requires a policy that allows memory.namespace.retire for the target namespace.
 - Memory profiles control read-only visibility only; they never write memory.
 - Memory profile create/retire requires policy allowance for memory.profile.create and
-  memory.profile.retire plus explicit confirmation.
+  memory.profile.retire plus explicit confirmation (use policy/dev-operator.json).
 - Retention enforcement is policy/confirmation-gated via memory.retention.enforce and runs only on writes.
 - Memory explain is observational only; it reads selection traces captured during ask/agent runs.
 - Memory injection trace is bounded and deterministic; it appears in explain JSON and

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -230,11 +230,20 @@ Memory in ask/agent (read-only injection):
 Memory injection trace (bounded, deterministic):
 
   gismo memory explain --plan PLAN_EVENT_ID --json
-  gismo memory preview --memory-profile operator --json
+  gismo memory preview --memory-profile operator --policy policy/dev-operator.json --json
 
 Notes:
 - Ordering is deterministic (updated_at desc, namespace, key).
 - The trace includes eligibility counts, selected items, dropped counts, and an injection_hash.
+
+Memory profiles are governance objects:
+- Profile lifecycle (create/retire) is policy-gated and requires explicit confirmation.
+- Use an operator policy that allows memory.profile.create/retire.
+
+  gismo memory profile create --name operator --description "Operator defaults" \
+    --include-namespace global --include-kind preference --include-kind fact \
+    --max-items 20 --policy policy/dev-operator.json --yes
+  gismo memory profile retire operator --policy policy/dev-operator.json --yes
 
 Memory suggestions:
 - The LLM may emit memory_suggestions.

--- a/policy/dev-operator.json
+++ b/policy/dev-operator.json
@@ -1,0 +1,37 @@
+{
+  "allowed_tools": [
+    "echo",
+    "read_file",
+    "list_dir",
+    "write_note",
+    "run_shell",
+    "memory.put",
+    "memory.delete",
+    "memory.read"
+  ],
+  "fs": { "base_dir": "." },
+  "memory": {
+    "allow": {
+      "memory.put": ["run:*", "project:*", "global"],
+      "memory.delete": ["run:*", "project:*", "global"],
+      "memory.read": ["run:*", "project:*", "global"],
+      "memory.profile.create": ["*"],
+      "memory.profile.retire": ["*"]
+    },
+    "require_confirmation": {
+      "memory.put": ["project:*", "global"],
+      "memory.delete": ["project:*", "global"],
+      "memory.profile.create": ["*"],
+      "memory.profile.retire": ["*"]
+    }
+  },
+  "shell": {
+    "base_dir": ".",
+    "allowlist": [
+      ["git", "status"],
+      ["python", "-m", "unittest"],
+      ["make", "test"],
+      ["echo", "hello"]
+    ]
+  }
+}

--- a/tests/test_memory_preview_cli.py
+++ b/tests/test_memory_preview_cli.py
@@ -76,6 +76,80 @@ class MemoryPreviewCliTest(unittest.TestCase):
         eligibility = payload.get("eligibility", {})
         self.assertEqual(eligibility.get("selected_items"), 1)
 
+    def test_memory_preview_requires_profile_then_succeeds(self) -> None:
+        policy_path = self.repo_root / "policy" / "dev-operator.json"
+        missing = _run_cli(
+            [
+                "memory",
+                "preview",
+                "--db",
+                str(self.db_path),
+                "--memory-profile",
+                "operator",
+                "--policy",
+                str(policy_path),
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(missing.returncode, 0)
+        self.assertIn("Memory profile not found", missing.stderr)
+
+        create = _run_cli(
+            [
+                "memory",
+                "profile",
+                "create",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--name",
+                "operator",
+                "--description",
+                "Operator profile",
+                "--include-namespace",
+                "global",
+                "--include-kind",
+                "preference",
+                "--yes",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+
+        memory_put_item(
+            str(self.db_path),
+            namespace="global",
+            key="default_model",
+            kind="preference",
+            value="phi3:mini",
+            tags=None,
+            confidence="high",
+            source="operator",
+            ttl_seconds=None,
+            actor="operator",
+            policy_hash=memory_policy_hash_for_path(str(policy_path)),
+        )
+
+        preview = _run_cli(
+            [
+                "memory",
+                "preview",
+                "--db",
+                str(self.db_path),
+                "--memory-profile",
+                "operator",
+                "--policy",
+                str(policy_path),
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(preview.returncode, 0, preview.stderr)
+        payload = json.loads(preview.stdout)
+        eligibility = payload.get("eligibility", {})
+        self.assertEqual(eligibility.get("selected_items"), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_profile_cli.py
+++ b/tests/test_memory_profile_cli.py
@@ -207,3 +207,72 @@ class MemoryProfileCliTest(unittest.TestCase):
         self.assertEqual(show.returncode, 0, show.stderr)
         payload = json.loads(show.stdout)
         self.assertTrue(payload["warnings"])
+
+    def test_memory_profile_create_blocked_by_dev_safe_policy(self) -> None:
+        policy_path = self.repo_root / "policy" / "dev-safe.json"
+        create = _run_cli(
+            [
+                "memory",
+                "profile",
+                "create",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--name",
+                "operator",
+                "--include-namespace",
+                "global",
+                "--non-interactive",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertNotEqual(create.returncode, 0)
+        self.assertIn("blocked by policy", create.stderr)
+
+    def test_memory_profile_create_and_retire_with_operator_policy(self) -> None:
+        policy_path = self.repo_root / "policy" / "dev-operator.json"
+        create = _run_cli(
+            [
+                "memory",
+                "profile",
+                "create",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--name",
+                "operator",
+                "--description",
+                "Operator profile",
+                "--include-namespace",
+                "global",
+                "--include-kind",
+                "fact",
+                "--yes",
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(create.returncode, 0, create.stderr)
+        created = json.loads(create.stdout)
+        self.assertEqual(created["name"], "operator")
+
+        retire = _run_cli(
+            [
+                "memory",
+                "profile",
+                "retire",
+                "operator",
+                "--db",
+                str(self.db_path),
+                "--policy",
+                str(policy_path),
+                "--yes",
+                "--json",
+            ],
+            cwd=self.repo_root,
+        )
+        self.assertEqual(retire.returncode, 0, retire.stderr)
+        retired = json.loads(retire.stdout)
+        self.assertIsNotNone(retired["retired_at"])


### PR DESCRIPTION
### Motivation

- The CLI was blocking `gismo memory profile create`/`retire` because existing policies did not include the exact capability keys the code checks.
- Memory profiles are governance objects and profile lifecycle should require an explicit, elevated operator policy rather than relaxing `dev-safe` or `readonly`.
- Provide a minimal, auditable operator workflow that works on Windows and preserves deny-by-default safety.
- Keep changes small and focused: add a new policy file, update docs, and add tests to cover the gating behavior.

### Description

- Added `policy/dev-operator.json` that grants `memory.profile.create` and `memory.profile.retire` allowances and marks them confirmation-required. 
- Updated docs to point operators to the new policy: `README.md`, `docs/OPERATOR.md`, and `Handoff.md` now reference `policy/dev-operator.json` for profile lifecycle and preview usage. 
- Added CLI tests verifying that profile create is blocked under `policy/dev-safe.json`, succeeds under `policy/dev-operator.json`, and that `gismo memory preview` fails when the profile is missing and succeeds after creation. 
- The CLI checks the capability strings `memory.profile.create` and `memory.profile.retire`; operator commands to reproduce are: `gismo memory profile create --name operator --description "Operator defaults" --include-namespace global --include-kind preference --include-kind fact --max-items 20 --policy policy/dev-operator.json --yes` and `gismo memory preview --memory-profile operator --policy policy/dev-operator.json --json`.

### Testing

- Ran `python scripts/verify.py` which completed successfully. 
- Ran `pytest -q` and the test suite passed (all tests green; several Windows-specific tests skipped where applicable). 
- Added unit/CLI tests in `tests/test_memory_profile_cli.py` and `tests/test_memory_preview_cli.py` that exercise denial under `dev-safe`, success under `dev-operator`, and preview-before/after-create behavior. 
- No production behavior was weakened: `dev-safe.json` and `readonly.json` remain unchanged and continue to deny profile lifecycle actions by default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d5d2f693483309c0d2274c0dfa04a)