### PR TITLE
Enforce read-only inquire plans and align risk labeling

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -156,14 +156,14 @@ INTENTIONAL LIMITATIONS (NOT BUGS)
 
 RECENT NOTABLE CHANGE (LATEST WORK)
 
-Memory profile policy separation:
-- Added an operator policy for memory profile lifecycle (memory.profile.create/retire).
-- Kept dev-safe/readonly policies readonly for profile governance.
-- Updated docs and tests to reflect profile lifecycle gating and preview usage.
+Ask planner inquire enforcement + risk alignment:
+- Enforced read-only normalization for intent=inquire and added safe echo fallback behavior.
+- Normalized per-action risk to align with plan-level risk flags on writes.
+- Updated prompts/docs/tests to reflect read-only inquiry defaults and failure modes.
 
 Next steps:
-- Validate operator profile workflows against real Windows operator runs.
-- Consider shipping default profile templates once governance workflows stabilize.
+- Validate inquire behavior against operator workflows and policy combinations.
+- Expand operator guidance for inquiry vs write intent if support tickets show confusion.
 
 Tests run:
 - python scripts/verify.py

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ Planner (local LLM via Ollama):
   gismo ask "Plan with operator memory profile" --dry-run --memory-profile operator
   gismo ask "Remember the default model" --apply-memory-suggestions \
     --policy policy/dev-safe.json --yes
+  Notes:
+  - Inquiries are read-only by default; explicit write intent or flags
+    (for example, --enqueue or --apply-memory-suggestions) are required to log/remember.
 
 Agent loop (leashed autonomy):
 

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -159,6 +159,8 @@ Planner rules:
 - Uses Ollama JSON mode with keep_alive to reduce reload latency
 - Policy is still enforced at execution time
 - Planner cannot execute directly
+- Inquiries are read-only by default; explicit write intent or flags
+  (for example, --enqueue or --apply-memory-suggestions) are required to log/remember.
 - Deterministic risk assessment (LOW/MEDIUM/HIGH), flags, and rationale printed with every plan
 - MEDIUM/HIGH risk plans require confirmation before enqueueing unless --yes is used
 - Non-interactive mode fails closed if confirmation would be required

--- a/gismo/cli/agent_session.py
+++ b/gismo/cli/agent_session.py
@@ -210,6 +210,7 @@ def run_agent_session_resume(args: argparse.Namespace, deps: AgentSessionDepende
         explain=False,
         debug=False,
         actor="agent_session",
+        non_interactive=args.non_interactive,
         memory_injection=memory_injection,
         role_context=role_context,
         policy_path=args.policy,

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -45,7 +45,14 @@ from gismo.core.permissions import PermissionPolicy, load_policy
 from gismo.core.explain import PlanExplain, build_plan_explain
 from gismo.core.gating import ConfirmationDecision, confirm_plan_gate
 from gismo.core.policy_summary import PolicySummary, summarize_policy
-from gismo.core.risk import PlanRisk, classify_plan_risk
+from gismo.core.risk import (
+    PlanRisk,
+    classify_plan_risk,
+    command_implies_write,
+    command_is_readonly,
+    infer_action_risk,
+    infer_tools_from_command,
+)
 from gismo.core.state import StateStore
 from gismo.core.tools import EchoTool, ToolRegistry, WriteNoteTool
 from gismo.core.tool_receipts import ToolReceiptReplayReport, replay_tool_receipts
@@ -289,6 +296,90 @@ def _coerce_action_type_to_command(action_type_text: str) -> str | None:
     return candidate
 
 
+_RISK_ORDER = {"low": 0, "medium": 1, "high": 2}
+
+
+def _merge_action_risk(action_risk: str, inferred: str) -> str:
+    if action_risk not in _RISK_ORDER:
+        return inferred
+    if inferred not in _RISK_ORDER:
+        return action_risk
+    return action_risk if _RISK_ORDER[action_risk] >= _RISK_ORDER[inferred] else inferred
+
+
+def _action_tools_allowed(command_text: str, policy_summary: PolicySummary) -> bool:
+    tool_names = infer_tools_from_command(command_text)
+    if not tool_names:
+        return False
+    return all(tool in policy_summary.allowed_tools for tool in tool_names)
+
+
+def _select_inquire_action(
+    actions: list[dict[str, object]],
+    *,
+    policy_summary: PolicySummary,
+) -> dict[str, object] | None:
+    for action in actions:
+        command_text = action.get("command") or ""
+        if not command_is_readonly(command_text):
+            continue
+        if _action_tools_allowed(command_text, policy_summary):
+            return action
+    if "echo" in policy_summary.allowed_tools:
+        return {
+            "type": "enqueue",
+            "command": (
+                "echo: No action required; inquiries are read-only. "
+                "Use `gismo memory get ...` if you need to inspect stored state."
+            ),
+            "timeout_seconds": 30,
+            "retries": 0,
+            "why": "inquiry response without side effects",
+            "risk": "low",
+        }
+    return None
+
+
+def _enforce_inquire_readonly(
+    plan: dict,
+    *,
+    policy_summary: PolicySummary,
+    non_interactive: bool,
+) -> dict:
+    intent = plan.get("intent")
+    intent_text = intent.strip().lower() if isinstance(intent, str) else ""
+    if intent_text != "inquire":
+        return plan
+    actions = list(plan.get("actions") or [])
+    if not actions:
+        return plan
+    if not any(command_implies_write(action.get("command") or "") for action in actions):
+        return plan
+    fallback = _select_inquire_action(actions, policy_summary=policy_summary)
+    if fallback is None:
+        message = (
+            "Inquire intent included write actions, but no read-only fallback is allowed by policy."
+        )
+        if non_interactive:
+            print(f"ERROR: {message}", file=sys.stderr)
+            raise SystemExit(2)
+        notes = _coerce_str_list(plan.get("notes"))
+        notes.append(message)
+        plan["actions"] = []
+        plan["notes"] = notes
+        return plan
+    fallback = dict(fallback)
+    fallback["risk"] = _merge_action_risk(
+        str(fallback.get("risk") or "medium"),
+        infer_action_risk(str(fallback.get("command") or "")).lower(),
+    )
+    plan["actions"] = [fallback]
+    notes = _coerce_str_list(plan.get("notes"))
+    notes.append("Normalized inquire intent to read-only action; removed write actions.")
+    plan["notes"] = notes
+    return plan
+
+
 def _first_non_option_token(argv: list[str]) -> str | None:
     skip_next = False
     force_positional = False
@@ -503,6 +594,8 @@ def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
                     timeout_seconds = 30
                     retries = 0
                     risk_text = "medium"
+            inferred_risk = infer_action_risk(command_text).lower() if command_text else "low"
+            risk_text = _merge_action_risk(risk_text, inferred_risk)
             actions.append(
                 {
                     "type": action_type_text,
@@ -3366,6 +3459,7 @@ def _request_llm_plan(
     explain: bool,
     debug: bool,
     actor: str,
+    non_interactive: bool,
     memory_injection: MemoryInjection | None = None,
     role_context: AgentRoleContext | None = None,
     policy_path: str | None = None,
@@ -3514,6 +3608,11 @@ def _request_llm_plan(
                 json_payload=payload,
             )
             raise
+        plan = _enforce_inquire_readonly(
+            plan,
+            policy_summary=policy_summary,
+            non_interactive=non_interactive,
+        )
         risk = classify_plan_risk(plan.get("actions", []))
         trace_payload = memory_injection.trace.to_dict() if memory_injection else None
         explain_payload = build_plan_explain(
@@ -3631,6 +3730,7 @@ def run_ask(
         explain=explain,
         debug=debug,
         actor="ask",
+        non_interactive=non_interactive,
         memory_injection=memory_injection,
         policy_path=policy_path,
         json_output=json_output,
@@ -3944,6 +4044,7 @@ def run_agent(
             explain=False,
             debug=False,
             actor="agent",
+            non_interactive=non_interactive,
             policy_path=policy_path,
             json_output=json_output,
             memory_injection=memory_injection,

--- a/gismo/core/risk.py
+++ b/gismo/core/risk.py
@@ -162,3 +162,34 @@ def _matches_memory_mutation(command_lower: str) -> bool:
 
 def _matches_supervisor_lifecycle(command_lower: str) -> bool:
     return any(re.search(pattern, command_lower) for pattern in _SUPERVISOR_PATTERNS)
+
+
+def infer_tools_from_command(command: str) -> list[str]:
+    return _infer_tools_from_command(command)
+
+
+def infer_action_risk(command: str) -> RiskLevel:
+    if not isinstance(command, str):
+        return "LOW"
+    return classify_plan_risk([{"type": "enqueue", "command": command}]).risk_level
+
+
+def command_implies_write(command: str) -> bool:
+    if not isinstance(command, str):
+        return False
+    command_lower = command.strip().lower()
+    tool_names = _infer_tools_from_command(command)
+    if "run_shell" in tool_names or command_lower.startswith("shell:"):
+        return True
+    if _contains_write_tool(tool_names):
+        return True
+    if _matches_memory_mutation(command_lower):
+        return True
+    return False
+
+
+def command_is_readonly(command: str) -> bool:
+    tool_names = _infer_tools_from_command(command)
+    if not tool_names:
+        return False
+    return all(tool == "echo" for tool in tool_names)

--- a/gismo/llm/prompts.py
+++ b/gismo/llm/prompts.py
@@ -16,6 +16,7 @@ def build_system_prompt(
             "- enqueue-only (never execute directly)",
             f"- max_actions: {max_actions}",
             "- prefer readonly tools when possible",
+            "- if intent is inquire, do not propose writes; answer with echo or other read-only tools",
         ]
     )
     return (

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -1143,6 +1143,134 @@ class AskCliTest(unittest.TestCase):
             notes = plan["notes"]
             self.assertFalse(any("Ignored unsupported action types" in note for note in notes))
 
+    def test_ask_inquire_normalizes_write_actions_to_echo(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "inquire",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "note: remember this",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "store a note",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                cli_main.run_ask(
+                    db_path,
+                    "What is my default model preference?",
+                    model=None,
+                    host=None,
+                    timeout_s=None,
+                    enqueue=False,
+                    dry_run=True,
+                    max_actions=5,
+                    yes=False,
+                    explain=False,
+                )
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            plan = payload["plan"]
+            actions = plan["actions"]
+            self.assertEqual(len(actions), 1)
+            self.assertTrue(actions[0]["command"].startswith("echo:"))
+            self.assertNotIn("note:", actions[0]["command"])
+
+    def test_ask_write_action_risk_is_high_and_matches_plan(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "record",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "note: record a preference",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "save a note",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                cli_main.run_ask(
+                    db_path,
+                    "Remember that I prefer the default model.",
+                    model=None,
+                    host=None,
+                    timeout_s=None,
+                    enqueue=False,
+                    dry_run=True,
+                    max_actions=5,
+                    yes=False,
+                    explain=False,
+                )
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            plan = payload["plan"]
+            actions = plan["actions"]
+            self.assertEqual(actions[0]["risk"], "high")
+            explain = payload["explain"]
+            self.assertEqual(explain["risk_level"], "HIGH")
+
+    def test_ask_inquire_non_interactive_fails_without_readonly_tool(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "inquire",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "note: store this",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "write a note",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_path = self._write_policy(
+                tmpdir,
+                {"allowed_tools": [], "fs": {"base_dir": "."}, "memory": {"allow": {}}},
+            )
+            with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                with self.assertRaises(SystemExit) as context:
+                    cli_main.run_ask(
+                        db_path,
+                        "What is my default model preference?",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=5,
+                        yes=False,
+                        explain=False,
+                        non_interactive=True,
+                        policy_path=policy_path,
+                    )
+            self.assertEqual(context.exception.code, 2)
+
     def test_ask_unsupported_action_still_reported(self) -> None:
         response = json.dumps(
             {


### PR DESCRIPTION
### Motivation
- Ensure `gismo ask` treats `intent=inquire` as read-only by default and prevents accidental planner-produced writes.
- Eliminate inconsistencies where the plan explain flags (e.g., `writes`) disagree with per-action `risk` labels.
- Make planner prompts policy-aware so LLMs are explicitly instructed not to propose writes for inquiries.
- Fail closed in non-interactive contexts when an inquire plan cannot be safely normalized.

### Description
- Added helpers in `gismo/core/risk.py` (`command_implies_write`, `command_is_readonly`, `infer_action_risk`, `infer_tools_from_command`) to detect write-implying commands and infer action risk.
- Enforced inquire normalization in `gismo/cli/main.py` via `_enforce_inquire_readonly`, which replaces write actions with a policy-allowed read-only `echo:` fallback or clears actions and fails closed in non-interactive mode, and merged inferred risk into action `risk` using `_merge_action_risk`.
- Propagated `non_interactive` into `_request_llm_plan` and agent session call sites and tightened the system prompt in `gismo/llm/prompts.py` to instruct: "if intent is inquire, do not propose writes; answer with echo or other read-only tools".
- Updated docs (`README.md`, `docs/OPERATOR.md`, `Handoff.md`) and added/extended tests in `tests/test_ask_cli.py` covering inquire normalization, per-action risk alignment, and non-interactive fail-closed behavior.

### Testing
- Ran `python scripts/verify.py` and it completed successfully.
- Ran `pytest -q` and the full test suite passed (`232 passed, 4 skipped`).
- New unit tests added include `test_ask_inquire_normalizes_write_actions_to_echo`, `test_ask_write_action_risk_is_high_and_matches_plan`, and `test_ask_inquire_non_interactive_fails_without_readonly_tool`, and they passed under the test run.
- Quick reproduction: run `gismo ask "What is my default model preference?" --dry-run --memory-profile operator` and verify the plan contains no write/enqueue actions and risk labels are consistent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d77f1e7b88330ac85742ba526c7b0)