### PR TITLE
Enforce non-enqueue inquire plans

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -156,18 +156,17 @@ INTENTIONAL LIMITATIONS (NOT BUGS)
 
 RECENT NOTABLE CHANGE (LATEST WORK)
 
-Ask planner inquire enforcement + risk alignment:
-- Enforced read-only normalization for intent=inquire and added safe echo fallback behavior.
-- Normalized per-action risk to align with plan-level risk flags on writes.
-- Updated prompts/docs/tests to reflect read-only inquiry defaults and failure modes.
+Ask planner inquire non-enqueue enforcement:
+- Tightened inquire prompt guidance to forbid enqueue actions and prefer echo-only answers.
+- Enforced inquire normalization to strip enqueue prefixes, coerce to echo-only actions, or fail closed.
+- Updated ask execution to bypass enqueue path for inquire and refreshed docs/tests for the new behavior.
 
 Next steps:
-- Validate inquire behavior against operator workflows and policy combinations.
-- Expand operator guidance for inquiry vs write intent if support tickets show confusion.
+- Validate inquire output formatting in operator workflows (dry-run + JSON).
+- Monitor for any policy combinations that suppress echo and ensure fail-closed messaging is clear.
 
 Tests run:
 - python scripts/verify.py
-- pytest -q
 
 -------------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ Planner (local LLM via Ollama):
   gismo ask "Remember the default model" --apply-memory-suggestions \
     --policy policy/dev-safe.json --yes
   Notes:
-  - Inquiries are read-only by default; explicit write intent or flags
-    (for example, --enqueue or --apply-memory-suggestions) are required to log/remember.
+  - Inquire intent is echo-only and never enqueues work; ask acts as read-only answer mode.
+  - Explicit write intent or flags (for example, --enqueue or --apply-memory-suggestions)
+    are required to log/remember.
 
 Agent loop (leashed autonomy):
 

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -153,14 +153,15 @@ EXECUTE PLAN:
   gismo ask "do X safely" --enqueue
 
 Planner rules:
-- Produces enqueue-only plans
+- Produces enqueue-only plans except for intent=inquire (echo-only, non-enqueue)
 - Action count is bounded
 - Output is normalized (schema enforcement; malformed model output fails closed)
 - Uses Ollama JSON mode with keep_alive to reduce reload latency
 - Policy is still enforced at execution time
 - Planner cannot execute directly
-- Inquiries are read-only by default; explicit write intent or flags
-  (for example, --enqueue or --apply-memory-suggestions) are required to log/remember.
+- Inquire intent is echo-only and never enqueues work; ask behaves as read-only answer mode.
+- Explicit write intent or flags (for example, --enqueue or --apply-memory-suggestions)
+  are required to log/remember.
 - Deterministic risk assessment (LOW/MEDIUM/HIGH), flags, and rationale printed with every plan
 - MEDIUM/HIGH risk plans require confirmation before enqueueing unless --yes is used
 - Non-interactive mode fails closed if confirmation would be required

--- a/gismo/cli/main.py
+++ b/gismo/cli/main.py
@@ -314,32 +314,6 @@ def _action_tools_allowed(command_text: str, policy_summary: PolicySummary) -> b
     return all(tool in policy_summary.allowed_tools for tool in tool_names)
 
 
-def _select_inquire_action(
-    actions: list[dict[str, object]],
-    *,
-    policy_summary: PolicySummary,
-) -> dict[str, object] | None:
-    for action in actions:
-        command_text = action.get("command") or ""
-        if not command_is_readonly(command_text):
-            continue
-        if _action_tools_allowed(command_text, policy_summary):
-            return action
-    if "echo" in policy_summary.allowed_tools:
-        return {
-            "type": "enqueue",
-            "command": (
-                "echo: No action required; inquiries are read-only. "
-                "Use `gismo memory get ...` if you need to inspect stored state."
-            ),
-            "timeout_seconds": 30,
-            "retries": 0,
-            "why": "inquiry response without side effects",
-            "risk": "low",
-        }
-    return None
-
-
 def _enforce_inquire_readonly(
     plan: dict,
     *,
@@ -353,31 +327,61 @@ def _enforce_inquire_readonly(
     actions = list(plan.get("actions") or [])
     if not actions:
         return plan
-    if not any(command_implies_write(action.get("command") or "") for action in actions):
-        return plan
-    fallback = _select_inquire_action(actions, policy_summary=policy_summary)
-    if fallback is None:
-        message = (
-            "Inquire intent included write actions, but no read-only fallback is allowed by policy."
+    normalized: list[dict[str, object]] = []
+    invalid_actions: list[str] = []
+    modified = False
+    for action in actions:
+        command_text = action.get("command") or ""
+        command_str = command_text if isinstance(command_text, str) else str(command_text)
+        command_str = command_str.strip()
+        lowered = command_str.lower()
+        if lowered.startswith("enqueue:"):
+            command_str = command_str.split(":", 1)[1].strip()
+            modified = True
+        if not command_str:
+            invalid_actions.append("empty action")
+            continue
+        if not command_str.lower().startswith("echo:"):
+            invalid_actions.append(command_str)
+            continue
+        if not _action_tools_allowed(command_str, policy_summary):
+            invalid_actions.append(command_str)
+            continue
+        if action.get("type") != "echo":
+            modified = True
+        normalized.append(
+            {
+                "type": "echo",
+                "command": command_str,
+                "timeout_seconds": 0,
+                "retries": 0,
+                "why": action.get("why") or "answer inquiry without enqueue",
+                "risk": infer_action_risk(command_str).lower(),
+            }
         )
+    if invalid_actions:
+        message = "Inquire intent must be echo-only and cannot enqueue actions."
         if non_interactive:
             print(f"ERROR: {message}", file=sys.stderr)
             raise SystemExit(2)
         notes = _coerce_str_list(plan.get("notes"))
         notes.append(message)
-        plan["actions"] = []
+        plan["actions"] = normalized
         plan["notes"] = notes
         return plan
-    fallback = dict(fallback)
-    fallback["risk"] = _merge_action_risk(
-        str(fallback.get("risk") or "medium"),
-        infer_action_risk(str(fallback.get("command") or "")).lower(),
-    )
-    plan["actions"] = [fallback]
-    notes = _coerce_str_list(plan.get("notes"))
-    notes.append("Normalized inquire intent to read-only action; removed write actions.")
-    plan["notes"] = notes
+    if modified:
+        notes = _coerce_str_list(plan.get("notes"))
+        notes.append("Normalized inquire intent to non-enqueue echo actions.")
+        plan["notes"] = notes
+    plan["actions"] = normalized
     return plan
+
+
+def _is_inquire_intent(plan: dict) -> bool:
+    intent = plan.get("intent")
+    if not isinstance(intent, str):
+        return False
+    return intent.strip().lower() == "inquire"
 
 
 def _first_non_option_token(argv: list[str]) -> str | None:
@@ -543,6 +547,7 @@ def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
     notes = _coerce_str_list(plan.get("notes"))
     raw_actions = plan.get("actions")
     actions: list[dict[str, object]] = []
+    allowed_action_types = {"enqueue", "echo"}
     if isinstance(raw_actions, list):
         for action in raw_actions:
             if not isinstance(action, dict):
@@ -586,7 +591,7 @@ def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
             risk_text = risk.strip().lower() if isinstance(risk, str) else ""
             if risk_text not in {"low", "medium", "high"}:
                 risk_text = "medium"
-            if action_type_text != "enqueue":
+            if action_type_text not in allowed_action_types:
                 coerced_command = _coerce_action_type_to_command(action_type_text)
                 if coerced_command:
                     action_type_text = "enqueue"
@@ -620,7 +625,13 @@ def _normalize_llm_plan(plan: dict, max_actions: int) -> dict:
             f"Truncated actions from {original_action_count} to {max_actions} based on --max-actions."
         )
         actions = actions[:max_actions]
-    unknown_types = sorted({a["type"] for a in actions if a["type"] and a["type"] != "enqueue"})
+    unknown_types = sorted(
+        {
+            a["type"]
+            for a in actions
+            if a["type"] and a["type"] not in allowed_action_types
+        }
+    )
     if unknown_types:
         notes.append(f"Ignored unsupported action types: {', '.join(unknown_types)}.")
     memory_suggestions = _normalize_memory_suggestions(plan.get("memory_suggestions"), notes)
@@ -3856,6 +3867,15 @@ def run_ask(
                 json_payload=payload,
                 event_id=plan_event_id,
             )
+        if _is_inquire_intent(plan):
+            if json_output:
+                _print_plan_json(
+                    plan=plan,
+                    explain_payload=explain_payload,
+                    enqueue=False,
+                    dry_run=dry_run,
+                )
+            return
         if json_output and not enqueue:
             _print_plan_json(
                 plan=plan,

--- a/gismo/llm/prompts.py
+++ b/gismo/llm/prompts.py
@@ -13,10 +13,11 @@ def build_system_prompt(
     constraints = "\n".join(
         [
             "Planner constraints:",
-            "- enqueue-only (never execute directly)",
+            "- enqueue-only (never execute directly) unless intent is inquire",
             f"- max_actions: {max_actions}",
             "- prefer readonly tools when possible",
-            "- if intent is inquire, do not propose writes; answer with echo or other read-only tools",
+            "- if intent is inquire, do not enqueue; answer with echo actions only or no actions",
+            "- if intent is inquire, use action.type=\"echo\" with command \"echo: ...\"",
         ]
     )
     return (
@@ -57,8 +58,8 @@ def build_system_prompt(
         "    }\n"
         "  ]\n"
         "}\n"
-        "Rules: action.type MUST be exactly \"enqueue\" (string). "
-        "Do not emit any other action types. "
+        "Rules: action.type MUST be either \"enqueue\" or \"echo\" (string). "
+        "Use \"echo\" only for intent=inquire. "
         "command must be a GISMO operator command string (echo:, note:, shell:, or graph:), "
         "for example \"echo: hello\". "
         "Keep actions small and sequenced. "
@@ -68,6 +69,7 @@ def build_system_prompt(
         "that describes the batch instead of listing each item. "
         "If the user request is unsafe or unsupported, return actions as an empty array "
         "and explain why in notes. "
+        "If intent is inquire, do not include any enqueue actions; use echo actions or none. "
         "Examples:\n"
         "{\"intent\":\"greet\",\"assumptions\":[],\"actions\":[{\"type\":\"enqueue\","
         "\"command\":\"echo: hello\",\"timeout_seconds\":30,\"retries\":0,"
@@ -75,6 +77,10 @@ def build_system_prompt(
         "{\"intent\":\"record\",\"assumptions\":[\"Operator requested a note\"],"
         "\"actions\":[{\"type\":\"enqueue\",\"command\":\"note: logged\","
         "\"timeout_seconds\":30,\"retries\":0,\"why\":\"record a note\","
+        "\"risk\":\"low\"}],\"notes\":[]}\n"
+        "{\"intent\":\"inquire\",\"assumptions\":[],"
+        "\"actions\":[{\"type\":\"echo\",\"command\":\"echo: model is phi3:mini\","
+        "\"timeout_seconds\":0,\"retries\":0,\"why\":\"answer inquiry\","
         "\"risk\":\"low\"}],\"notes\":[]}\n"
         "{\"intent\":\"unsupported\",\"assumptions\":[],\"actions\":[],"
         "\"notes\":[\"Request requires unsupported tooling.\"]}"

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -1182,9 +1182,157 @@ class AskCliTest(unittest.TestCase):
             assert payload is not None
             plan = payload["plan"]
             actions = plan["actions"]
+            self.assertEqual(len(actions), 0)
+            self.assertIn(
+                "Inquire intent must be echo-only and cannot enqueue actions.",
+                plan["notes"],
+            )
+
+    def test_ask_inquire_with_memory_profile_is_echo_only(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "inquire",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "echo: Default model is phi3:mini",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "answer from memory",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            policy_hash = memory_policy_hash_for_path(None)
+            memory_put_item(
+                db_path,
+                namespace="global",
+                key="default_model",
+                kind="preference",
+                value="phi3:mini",
+                tags=None,
+                confidence="high",
+                source="operator",
+                ttl_seconds=None,
+                actor="test",
+                policy_hash=policy_hash,
+            )
+            profile = memory_create_profile(
+                db_path,
+                name="operator",
+                description="Operator defaults",
+                include_namespaces=["global"],
+                exclude_namespaces=None,
+                include_kinds=["preference"],
+                exclude_kinds=None,
+                max_items=5,
+            )
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    buffer = io.StringIO()
+                    with contextlib.redirect_stdout(buffer):
+                        cli_main.run_ask(
+                            db_path,
+                            "What is my default model preference?",
+                            model=None,
+                            host=None,
+                            timeout_s=None,
+                            enqueue=False,
+                            dry_run=True,
+                            max_actions=5,
+                            yes=False,
+                            explain=False,
+                            memory_profile=profile.name,
+                        )
+            output = buffer.getvalue()
+            self.assertIn("phi3:mini", output)
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            plan = payload["plan"]
+            self.assertEqual(plan["intent"].lower(), "inquire")
+            actions = plan["actions"]
+            self.assertTrue(all(action["type"] != "enqueue" for action in actions))
+            self.assertTrue(
+                all(
+                    not str(action["command"]).strip().lower().startswith("enqueue:")
+                    for action in actions
+                )
+            )
+            explain = payload["explain"]
+            self.assertEqual(explain["risk_level"], "LOW")
+            self.assertEqual(explain["risk_flags"], [])
+
+    def test_ask_inquire_strips_enqueue_prefix_for_echo(self) -> None:
+        response = json.dumps(
+            {
+                "intent": "inquire",
+                "assumptions": [],
+                "actions": [
+                    {
+                        "type": "enqueue",
+                        "command": "enqueue: echo: hello from GISMO",
+                        "timeout_seconds": 30,
+                        "retries": 0,
+                        "why": "answer",
+                        "risk": "low",
+                    }
+                ],
+                "notes": [],
+            }
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = str(Path(tmpdir) / "state.db")
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GISMO_OLLAMA_MODEL": "",
+                    "GISMO_OLLAMA_TIMEOUT_S": "",
+                    "GISMO_OLLAMA_URL": "",
+                    "GISMO_LLM_MODEL": "",
+                    "OLLAMA_HOST": "",
+                },
+                clear=False,
+            ):
+                with mock.patch.object(cli_main, "ollama_chat", return_value=response):
+                    cli_main.run_ask(
+                        db_path,
+                        "What is my default model preference?",
+                        model=None,
+                        host=None,
+                        timeout_s=None,
+                        enqueue=False,
+                        dry_run=True,
+                        max_actions=5,
+                        yes=False,
+                        explain=False,
+                    )
+            state_store = StateStore(db_path)
+            event = state_store.list_events()[0]
+            payload = event.json_payload
+            assert payload is not None
+            plan = payload["plan"]
+            actions = plan["actions"]
             self.assertEqual(len(actions), 1)
+            self.assertEqual(actions[0]["type"], "echo")
             self.assertTrue(actions[0]["command"].startswith("echo:"))
-            self.assertNotIn("note:", actions[0]["command"])
+            self.assertFalse(actions[0]["command"].lower().startswith("enqueue:"))
 
     def test_ask_write_action_risk_is_high_and_matches_plan(self) -> None:
         response = json.dumps(


### PR DESCRIPTION
### Motivation
- Inquire intent should be strictly read-only and must not schedule work via the queue execution model. 
- Models were producing `enqueue:` wrappers for inquiries which is mechanically incorrect and can bypass read-only semantics. 
- The planner prompt and normalization must steer and enforce `echo`-style answers and fail-closed when unsafe. 
- Risk/explain artifacts must reflect that inquire answers are LOW risk with no enqueue flags.

### Description
- Tightened the Ollama system prompt in `gismo/llm/prompts.py` to forbid enqueue actions for `intent=inquire` and introduce `echo` as a permitted action type for inquiries. 
- Enforced fail-closed / coercion logic in `gismo/cli/main.py` by updating `_normalize_llm_plan` and replacing the old fallback with `_enforce_inquire_readonly` that strips `enqueue:` prefixes, coerces to `echo` actions, or fails closed in non-interactive mode, and added `_is_inquire_intent` to bypass enqueue execution. 
- Adjusted ask execution in `run_ask` to bypass the enqueue path for `inquire` plans so `--dry-run` and normal inquiry flows print answers directly and never enqueue. 
- Updated docs (`README.md`, `docs/OPERATOR.md`, `Handoff.md`) and extended tests in `tests/test_ask_cli.py` to cover memory-profile inquiries, enqueue-prefix regression, and non-interactive failure behavior.

### Testing
- Ran the repository gate: `python scripts/verify.py` which executes the full test suite and it completed successfully (tests OK). 
- New and updated tests in `tests/test_ask_cli.py` were executed as part of verification and passed, including the enqueue-prefix regression and memory-profile inquire cases. 
- Existing unit and integration tests were exercised by the verification script and showed no regressions. 
- Local manual repro using `gismo ask ... --dry-run --memory-profile` was validated via the updated tests to ensure outputs include injected memory and contain no `enqueue:` actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9e8b2b4483308a113c53d4103ca7)