### PR TITLE
Ensure SQLite handles are closed in CLI tests (Windows guardrail)

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -156,14 +156,14 @@ INTENTIONAL LIMITATIONS (NOT BUGS)
 
 RECENT NOTABLE CHANGE (LATEST WORK)
 
-Ask planner inquire non-enqueue enforcement:
-- Tightened inquire prompt guidance to forbid enqueue actions and prefer echo-only answers.
-- Enforced inquire normalization to strip enqueue prefixes, coerce to echo-only actions, or fail closed.
-- Updated ask execution to bypass enqueue path for inquire and refreshed docs/tests for the new behavior.
+SQLite handle guardrails (Windows):
+- Converted CLI tests to use context-managed StateStore/MemoryStore access where they read back state.
+- Added a Windows-only subprocess guardrail test for memory explain handle release.
+- Reinforced expectations that DB handles are closed deterministically after CLI paths.
 
 Next steps:
-- Validate inquire output formatting in operator workflows (dry-run + JSON).
-- Monitor for any policy combinations that suppress echo and ensure fail-closed messaging is clear.
+- Validate ask/agent subprocess flows on Windows for handle hygiene at higher concurrency.
+- Monitor for any new audit/export paths that retain SQLite handles across CLI exits.
 
 Tests run:
 - python scripts/verify.py

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -77,13 +77,13 @@ class AgentCliTest(unittest.TestCase):
             self.assertIn("=== Agent Summary ===", output)
             self.assertIn("Final status: dry-run", output)
 
-            state_store = StateStore(db_path)
-            self.assertEqual(state_store.list_queue_items(limit=10), [])
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            self.assertIn("explain", payload)
-            self.assertEqual(payload["explain"]["risk_level"], "LOW")
+            with StateStore(db_path) as state_store:
+                self.assertEqual(state_store.list_queue_items(limit=10), [])
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                self.assertIn("explain", payload)
+                self.assertEqual(payload["explain"]["risk_level"], "LOW")
 
     def test_agent_once_enqueues_and_executes(self) -> None:
         response = json.dumps(
@@ -105,10 +105,10 @@ class AgentCliTest(unittest.TestCase):
         )
 
         def _fake_run_daemon_once(db_path: str, policy_path: str | None) -> None:
-            state_store = StateStore(db_path)
-            for item in state_store.list_queue_items(limit=10):
-                if item.status == QueueStatus.QUEUED:
-                    state_store.mark_queue_item_succeeded(item.id)
+            with StateStore(db_path) as state_store:
+                for item in state_store.list_queue_items(limit=10):
+                    if item.status == QueueStatus.QUEUED:
+                        state_store.mark_queue_item_succeeded(item.id)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")
@@ -129,10 +129,10 @@ class AgentCliTest(unittest.TestCase):
             output = buffer.getvalue()
             self.assertIn("Final status: succeeded", output)
 
-            state_store = StateStore(db_path)
-            items = state_store.list_queue_items(limit=10)
-            self.assertEqual(len(items), 1)
-            self.assertEqual(items[0].status, QueueStatus.SUCCEEDED)
+            with StateStore(db_path) as state_store:
+                items = state_store.list_queue_items(limit=10)
+                self.assertEqual(len(items), 1)
+                self.assertEqual(items[0].status, QueueStatus.SUCCEEDED)
 
     def test_agent_memory_injection_trace_is_exported(self) -> None:
         response = json.dumps(
@@ -154,10 +154,10 @@ class AgentCliTest(unittest.TestCase):
         )
 
         def _fake_run_daemon_once(db_path: str, policy_path: str | None) -> None:
-            state_store = StateStore(db_path)
-            for item in state_store.list_queue_items(limit=10):
-                if item.status == QueueStatus.QUEUED:
-                    state_store.mark_queue_item_succeeded(item.id)
+            with StateStore(db_path) as state_store:
+                for item in state_store.list_queue_items(limit=10):
+                    if item.status == QueueStatus.QUEUED:
+                        state_store.mark_queue_item_succeeded(item.id)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")
@@ -187,30 +187,32 @@ class AgentCliTest(unittest.TestCase):
                             dry_run=False,
                             use_memory=True,
                         )
-            state_store = StateStore(db_path)
-            plan_event = next(
-                event for event in state_store.list_events() if event.event_type == EVENT_TYPE_LLM_PLAN
-            )
-            payload = plan_event.json_payload
-            assert payload is not None
-            trace = payload["explain"]["memory_injection_trace"]
-            self.assertIn("injection_hash", trace)
-            self.assertEqual(trace["eligibility"]["selected_items"], 1)
+            with StateStore(db_path) as state_store:
+                plan_event = next(
+                    event
+                    for event in state_store.list_events()
+                    if event.event_type == EVENT_TYPE_LLM_PLAN
+                )
+                payload = plan_event.json_payload
+                assert payload is not None
+                trace = payload["explain"]["memory_injection_trace"]
+                self.assertIn("injection_hash", trace)
+                self.assertEqual(trace["eligibility"]["selected_items"], 1)
 
-            run = state_store.get_latest_run()
-            assert run is not None
-            output_path = export_run_jsonl(state_store, run.id, base_dir=Path(tmpdir))
-            records = [
-                json.loads(line)
-                for line in output_path.read_text(encoding="utf-8").strip().splitlines()
-            ]
-            memory_event = next(
-                record
-                for record in records
-                if record["record_type"] == "memory_event"
-                and record["operation"] == "memory.inject"
-            )
-            self.assertIn("injection_hash", memory_event["result_meta"])
+                run = state_store.get_latest_run()
+                assert run is not None
+                output_path = export_run_jsonl(state_store, run.id, base_dir=Path(tmpdir))
+                records = [
+                    json.loads(line)
+                    for line in output_path.read_text(encoding="utf-8").strip().splitlines()
+                ]
+                memory_event = next(
+                    record
+                    for record in records
+                    if record["record_type"] == "memory_event"
+                    and record["operation"] == "memory.inject"
+                )
+                self.assertIn("injection_hash", memory_event["result_meta"])
 
     def test_agent_requires_confirmation_for_shell(self) -> None:
         response = json.dumps(
@@ -246,8 +248,8 @@ class AgentCliTest(unittest.TestCase):
                                 dry_run=False,
                             )
             self.assertEqual(exc.exception.code, 2)
-            state_store = StateStore(db_path)
-            self.assertEqual(state_store.list_queue_items(limit=10), [])
+            with StateStore(db_path) as state_store:
+                self.assertEqual(state_store.list_queue_items(limit=10), [])
 
     def test_agent_memory_suggestions_are_advisory_by_default(self) -> None:
         response = json.dumps(
@@ -362,14 +364,14 @@ class AgentCliTest(unittest.TestCase):
                         dry_run=True,
                         memory_profile=profile.name,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            injected_keys = payload.get("memory_injected_keys")
-            self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
-            profile_payload = payload.get("memory_profile") or {}
-            self.assertEqual(profile_payload.get("profile_id"), profile.profile_id)
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                injected_keys = payload.get("memory_injected_keys")
+                self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
+                profile_payload = payload.get("memory_profile") or {}
+                self.assertEqual(profile_payload.get("profile_id"), profile.profile_id)
             with contextlib.closing(sqlite3.connect(db_path)) as connection:
                 row = connection.execute(
                     "SELECT request_json FROM memory_events "
@@ -440,13 +442,12 @@ class AgentCliTest(unittest.TestCase):
                 exclude_kinds=None,
                 max_items=1,
             )
-            state_store = StateStore(db_path)
-            role = state_store.create_agent_role(
-                name="planner",
-                description="Planner role",
-                memory_profile_id=profile.profile_id,
-            )
-            state_store.close()
+            with StateStore(db_path) as state_store:
+                role = state_store.create_agent_role(
+                    name="planner",
+                    description="Planner role",
+                    memory_profile_id=profile.profile_id,
+                )
             with mock.patch.dict(os.environ, self._mock_env(), clear=False):
                 with mock.patch.object(cli_main, "ollama_chat", return_value=response):
                     cli_main.run_agent(
@@ -459,29 +460,29 @@ class AgentCliTest(unittest.TestCase):
                         dry_run=False,
                         role=role.name,
                     )
-            state_store = StateStore(db_path)
-            event = next(
-                (item for item in state_store.list_events() if item.json_payload),
-                None,
-            )
-            self.assertIsNotNone(event)
-            payload = event.json_payload or {}
-            injected_keys = payload.get("memory_injected_keys")
-            self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
-            role_payload = payload.get("agent_role") or {}
-            self.assertEqual(role_payload.get("role_id"), role.role_id)
-            self.assertEqual(role_payload.get("role_name"), role.name)
-            self.assertEqual(role_payload.get("memory_profile_id"), profile.profile_id)
-            runs = list(state_store.list_runs(limit=5))
-            self.assertEqual(len(runs), 1)
-            run_role = runs[0].metadata_json.get("agent_role", {})
-            self.assertEqual(run_role.get("role_id"), role.role_id)
-            state_store.close()
+            with StateStore(db_path) as state_store:
+                event = next(
+                    (item for item in state_store.list_events() if item.json_payload),
+                    None,
+                )
+                self.assertIsNotNone(event)
+                payload = event.json_payload or {}
+                injected_keys = payload.get("memory_injected_keys")
+                self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
+                role_payload = payload.get("agent_role") or {}
+                self.assertEqual(role_payload.get("role_id"), role.role_id)
+                self.assertEqual(role_payload.get("role_name"), role.name)
+                self.assertEqual(role_payload.get("memory_profile_id"), profile.profile_id)
+                runs = list(state_store.list_runs(limit=5))
+                self.assertEqual(len(runs), 1)
+                run_role = runs[0].metadata_json.get("agent_role", {})
+                self.assertEqual(run_role.get("role_id"), role.role_id)
+                event_id = event.id
 
             args = argparse.Namespace(
                 db_path=db_path,
                 run=None,
-                plan=event.id,
+                plan=event_id,
                 limit=memory_explain_cli.DEFAULT_EXPLAIN_LIMIT,
                 json=True,
             )
@@ -551,9 +552,9 @@ class AgentCliTest(unittest.TestCase):
             self.assertIsNotNone(event_row)
             related_event_id = event_row[0]
             self.assertIsNotNone(related_event_id)
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            self.assertEqual(event.id, related_event_id)
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                self.assertEqual(event.id, related_event_id)
 
     def test_agent_role_dry_run_releases_db_handle(self) -> None:
         response = json.dumps(
@@ -566,13 +567,12 @@ class AgentCliTest(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = Path(tmpdir) / "state.db"
-            state_store = StateStore(str(db_path))
-            role = state_store.create_agent_role(
-                name="planner",
-                description=None,
-                memory_profile_id=None,
-            )
-            state_store.close()
+            with StateStore(str(db_path)) as state_store:
+                role = state_store.create_agent_role(
+                    name="planner",
+                    description=None,
+                    memory_profile_id=None,
+                )
             with warnings.catch_warnings():
                 warnings.simplefilter("error", ResourceWarning)
                 with mock.patch.dict(os.environ, self._mock_env(), clear=False):

--- a/tests/test_ask_cli.py
+++ b/tests/test_ask_cli.py
@@ -80,17 +80,17 @@ class AskCliTest(unittest.TestCase):
             self.assertIn("=== GISMO LLM Plan ===", output)
             self.assertIn("Intent: greet", output)
 
-            state_store = StateStore(db_path)
-            events = state_store.list_events()
-            self.assertTrue(events)
-            event = events[0]
-            self.assertEqual(event.event_type, EVENT_TYPE_LLM_PLAN)
-            payload = event.json_payload
-            assert payload is not None
-            self.assertTrue(payload["dry_run"])
-            self.assertFalse(payload["enqueue"])
-            self.assertIn("explain", payload)
-            self.assertEqual(payload["explain"]["risk_level"], "LOW")
+            with StateStore(db_path) as state_store:
+                events = state_store.list_events()
+                self.assertTrue(events)
+                event = events[0]
+                self.assertEqual(event.event_type, EVENT_TYPE_LLM_PLAN)
+                payload = event.json_payload
+                assert payload is not None
+                self.assertTrue(payload["dry_run"])
+                self.assertFalse(payload["enqueue"])
+                self.assertIn("explain", payload)
+                self.assertEqual(payload["explain"]["risk_level"], "LOW")
 
     def test_ask_enqueue_enqueues_items_and_writes_event(self) -> None:
         response = json.dumps(
@@ -141,16 +141,16 @@ class AskCliTest(unittest.TestCase):
             output = buffer.getvalue()
             self.assertIn("Enqueued items:", output)
 
-            state_store = StateStore(db_path)
-            items = state_store.list_queue_items(limit=10)
-            self.assertEqual(len(items), 1)
-            self.assertEqual(items[0].command_text, "echo: queued")
-            self.assertEqual(items[0].max_retries, 1)
-            self.assertEqual(items[0].timeout_seconds, 15)
+            with StateStore(db_path) as state_store:
+                items = state_store.list_queue_items(limit=10)
+                self.assertEqual(len(items), 1)
+                self.assertEqual(items[0].command_text, "echo: queued")
+                self.assertEqual(items[0].max_retries, 1)
+                self.assertEqual(items[0].timeout_seconds, 15)
 
-            events = state_store.list_events()
-            self.assertTrue(events)
-            self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
+                events = state_store.list_events()
+                self.assertTrue(events)
+                self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
 
     def test_ask_includes_memory_suggestions_in_plan(self) -> None:
         response = json.dumps(
@@ -203,14 +203,14 @@ class AskCliTest(unittest.TestCase):
             self.assertIn("Suggested memory updates (advisory only):", output)
             self.assertIn("gismo memory put", output)
 
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            suggestions = plan.get("memory_suggestions")
-            self.assertEqual(len(suggestions), 1)
-            self.assertEqual(suggestions[0]["key"], "default_model")
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                suggestions = plan.get("memory_suggestions")
+                self.assertEqual(len(suggestions), 1)
+                self.assertEqual(suggestions[0]["key"], "default_model")
 
     def test_ask_high_risk_requires_confirmation_in_non_interactive(self) -> None:
         response = json.dumps(
@@ -344,14 +344,14 @@ class AskCliTest(unittest.TestCase):
                         explain=False,
                         memory_profile=profile.name,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            injected_keys = payload.get("memory_injected_keys")
-            self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
-            profile_payload = payload.get("memory_profile") or {}
-            self.assertEqual(profile_payload.get("profile_id"), profile.profile_id)
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                injected_keys = payload.get("memory_injected_keys")
+                self.assertEqual(injected_keys, [{"namespace": "global", "key": "alpha"}])
+                profile_payload = payload.get("memory_profile") or {}
+                self.assertEqual(profile_payload.get("profile_id"), profile.profile_id)
             with contextlib.closing(sqlite3.connect(db_path)) as connection:
                 row = connection.execute(
                     "SELECT request_json FROM memory_events "
@@ -507,16 +507,16 @@ class AskCliTest(unittest.TestCase):
                         yes=False,
                         explain=False,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            suggestions = plan.get("memory_suggestions")
-            self.assertEqual(len(suggestions), 5)
-            notes = plan["notes"]
-            self.assertIn("Ignored 1 invalid memory_suggestion(s).", notes)
-            self.assertIn("Truncated memory_suggestions to 5 item(s).", notes)
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                suggestions = plan.get("memory_suggestions")
+                self.assertEqual(len(suggestions), 5)
+                notes = plan["notes"]
+                self.assertIn("Ignored 1 invalid memory_suggestion(s).", notes)
+                self.assertIn("Truncated memory_suggestions to 5 item(s).", notes)
 
     def test_ask_does_not_write_memory_items(self) -> None:
         response = json.dumps(
@@ -539,7 +539,8 @@ class AskCliTest(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as tmpdir:
             db_path = str(Path(tmpdir) / "state.db")
-            StateStore(db_path)
+            with StateStore(db_path):
+                pass
             with contextlib.closing(sqlite3.connect(db_path)) as connection:
                 initial_count = connection.execute(
                     "SELECT COUNT(*) FROM memory_items"
@@ -641,17 +642,17 @@ class AskCliTest(unittest.TestCase):
             self.assertIsNotNone(related_ask_event_id)
             result_meta = json.loads(result_meta_json)
             self.assertEqual(result_meta["policy_action"], "memory.put")
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            self.assertEqual(event.id, related_ask_event_id)
-            payload = event.json_payload
-            assert payload is not None
-            self.assertTrue(payload["apply_memory_suggestions_requested"])
-            self.assertEqual(payload["apply_memory_suggestions_result"]["applied"], 1)
-            self.assertEqual(
-                payload["apply_memory_suggestions_applied"],
-                [{"namespace": "global", "key": "default_model"}],
-            )
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                self.assertEqual(event.id, related_ask_event_id)
+                payload = event.json_payload
+                assert payload is not None
+                self.assertTrue(payload["apply_memory_suggestions_requested"])
+                self.assertEqual(payload["apply_memory_suggestions_result"]["applied"], 1)
+                self.assertEqual(
+                    payload["apply_memory_suggestions_applied"],
+                    [{"namespace": "global", "key": "default_model"}],
+                )
 
     def test_ask_apply_memory_suggestions_requires_confirmation_interactive(self) -> None:
         response = json.dumps(
@@ -894,10 +895,10 @@ class AskCliTest(unittest.TestCase):
             self.assertIn("LLM response was not valid JSON", str(exc.exception))
             self.assertIn("Model violated JSON-only contract", str(exc.exception))
 
-            state_store = StateStore(db_path)
-            events = state_store.list_events()
-            self.assertTrue(events)
-            self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
+            with StateStore(db_path) as state_store:
+                events = state_store.list_events()
+                self.assertTrue(events)
+                self.assertEqual(events[0].event_type, EVENT_TYPE_LLM_PLAN)
     
     def test_ask_best_effort_json_extraction_succeeds(self) -> None:
         response = (
@@ -936,13 +937,13 @@ class AskCliTest(unittest.TestCase):
                         yes=False,
                         explain=False,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            self.assertEqual(plan["intent"], "queue")
-            self.assertEqual(plan["actions"][0]["command"], "echo: hello")
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                self.assertEqual(plan["intent"], "queue")
+                self.assertEqual(plan["actions"][0]["command"], "echo: hello")
 
     def test_ask_best_effort_json_extraction_fails_on_comments(self) -> None:
         response = (
@@ -1132,16 +1133,18 @@ class AskCliTest(unittest.TestCase):
                         yes=False,
                         explain=False,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            actions = plan["actions"]
-            self.assertEqual(actions[0]["type"], "enqueue")
-            self.assertEqual(actions[0]["command"], "echo: hello from GISMO")
-            notes = plan["notes"]
-            self.assertFalse(any("Ignored unsupported action types" in note for note in notes))
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                actions = plan["actions"]
+                self.assertEqual(actions[0]["type"], "enqueue")
+                self.assertEqual(actions[0]["command"], "echo: hello from GISMO")
+                notes = plan["notes"]
+                self.assertFalse(
+                    any("Ignored unsupported action types" in note for note in notes)
+                )
 
     def test_ask_inquire_normalizes_write_actions_to_echo(self) -> None:
         response = json.dumps(
@@ -1176,17 +1179,17 @@ class AskCliTest(unittest.TestCase):
                     yes=False,
                     explain=False,
                 )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            actions = plan["actions"]
-            self.assertEqual(len(actions), 0)
-            self.assertIn(
-                "Inquire intent must be echo-only and cannot enqueue actions.",
-                plan["notes"],
-            )
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                actions = plan["actions"]
+                self.assertEqual(len(actions), 0)
+                self.assertIn(
+                    "Inquire intent must be echo-only and cannot enqueue actions.",
+                    plan["notes"],
+                )
 
     def test_ask_inquire_with_memory_profile_is_echo_only(self) -> None:
         response = json.dumps(
@@ -1261,23 +1264,23 @@ class AskCliTest(unittest.TestCase):
                         )
             output = buffer.getvalue()
             self.assertIn("phi3:mini", output)
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            self.assertEqual(plan["intent"].lower(), "inquire")
-            actions = plan["actions"]
-            self.assertTrue(all(action["type"] != "enqueue" for action in actions))
-            self.assertTrue(
-                all(
-                    not str(action["command"]).strip().lower().startswith("enqueue:")
-                    for action in actions
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                self.assertEqual(plan["intent"].lower(), "inquire")
+                actions = plan["actions"]
+                self.assertTrue(all(action["type"] != "enqueue" for action in actions))
+                self.assertTrue(
+                    all(
+                        not str(action["command"]).strip().lower().startswith("enqueue:")
+                        for action in actions
+                    )
                 )
-            )
-            explain = payload["explain"]
-            self.assertEqual(explain["risk_level"], "LOW")
-            self.assertEqual(explain["risk_flags"], [])
+                explain = payload["explain"]
+                self.assertEqual(explain["risk_level"], "LOW")
+                self.assertEqual(explain["risk_flags"], [])
 
     def test_ask_inquire_strips_enqueue_prefix_for_echo(self) -> None:
         response = json.dumps(
@@ -1323,16 +1326,16 @@ class AskCliTest(unittest.TestCase):
                         yes=False,
                         explain=False,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            actions = plan["actions"]
-            self.assertEqual(len(actions), 1)
-            self.assertEqual(actions[0]["type"], "echo")
-            self.assertTrue(actions[0]["command"].startswith("echo:"))
-            self.assertFalse(actions[0]["command"].lower().startswith("enqueue:"))
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                actions = plan["actions"]
+                self.assertEqual(len(actions), 1)
+                self.assertEqual(actions[0]["type"], "echo")
+                self.assertTrue(actions[0]["command"].startswith("echo:"))
+                self.assertFalse(actions[0]["command"].lower().startswith("enqueue:"))
 
     def test_ask_write_action_risk_is_high_and_matches_plan(self) -> None:
         response = json.dumps(
@@ -1367,15 +1370,15 @@ class AskCliTest(unittest.TestCase):
                     yes=False,
                     explain=False,
                 )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            actions = plan["actions"]
-            self.assertEqual(actions[0]["risk"], "high")
-            explain = payload["explain"]
-            self.assertEqual(explain["risk_level"], "HIGH")
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                actions = plan["actions"]
+                self.assertEqual(actions[0]["risk"], "high")
+                explain = payload["explain"]
+                self.assertEqual(explain["risk_level"], "HIGH")
 
     def test_ask_inquire_non_interactive_fails_without_readonly_tool(self) -> None:
         response = json.dumps(
@@ -1463,15 +1466,15 @@ class AskCliTest(unittest.TestCase):
                         yes=False,
                         explain=False,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            plan = payload["plan"]
-            self.assertIn(
-                "Ignored unsupported action types: delete_files.",
-                plan["notes"],
-            )
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                plan = payload["plan"]
+                self.assertIn(
+                    "Ignored unsupported action types: delete_files.",
+                    plan["notes"],
+                )
 
     def test_ask_failure_writes_failed_event(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1519,10 +1522,10 @@ class AskCliTest(unittest.TestCase):
                     self.assertIn("ERROR: Ollama request failed", stderr_output)
                     self.assertNotIn("Traceback", stderr_output)
                     self.assertNotIn("Traceback", stdout_buffer.getvalue())
-            state_store = StateStore(db_path)
-            events = state_store.list_events()
-            self.assertTrue(events)
-            self.assertEqual(events[0].event_type, EVENT_TYPE_ASK_FAILED)
+            with StateStore(db_path) as state_store:
+                events = state_store.list_events()
+                self.assertTrue(events)
+                self.assertEqual(events[0].event_type, EVENT_TYPE_ASK_FAILED)
 
     def test_normalize_plan_drops_ungrounded_assumptions(self) -> None:
         plan = {
@@ -1613,9 +1616,9 @@ class AskCliTest(unittest.TestCase):
                                 explain=False,
                             )
                         self.assertEqual(exc.exception.code, 2)
-            state_store = StateStore(db_path)
-            items = state_store.list_queue_items(limit=20)
-            self.assertEqual(len(items), 0)
+            with StateStore(db_path) as state_store:
+                items = state_store.list_queue_items(limit=20)
+                self.assertEqual(len(items), 0)
 
     def test_ask_enqueue_requires_confirmation_interactive_accept(self) -> None:
         actions = [
@@ -1661,9 +1664,9 @@ class AskCliTest(unittest.TestCase):
                             yes=False,
                             explain=False,
                         )
-            state_store = StateStore(db_path)
-            items = state_store.list_queue_items(limit=20)
-            self.assertEqual(len(items), 13)
+            with StateStore(db_path) as state_store:
+                items = state_store.list_queue_items(limit=20)
+                self.assertEqual(len(items), 13)
 
     def test_ask_enqueue_requires_confirmation_non_interactive(self) -> None:
         actions = [
@@ -1714,9 +1717,9 @@ class AskCliTest(unittest.TestCase):
                                 )
                             self.assertEqual(exc.exception.code, 2)
                     self.assertIn("--yes", buffer.getvalue())
-            state_store = StateStore(db_path)
-            items = state_store.list_queue_items(limit=20)
-            self.assertEqual(len(items), 0)
+            with StateStore(db_path) as state_store:
+                items = state_store.list_queue_items(limit=20)
+                self.assertEqual(len(items), 0)
 
     def test_ask_enqueue_requires_confirmation_yes_override(self) -> None:
         actions = [
@@ -1762,9 +1765,9 @@ class AskCliTest(unittest.TestCase):
                             yes=True,
                             explain=False,
                         )
-            state_store = StateStore(db_path)
-            items = state_store.list_queue_items(limit=20)
-            self.assertEqual(len(items), 13)
+            with StateStore(db_path) as state_store:
+                items = state_store.list_queue_items(limit=20)
+                self.assertEqual(len(items), 13)
 
     def test_ask_without_memory_has_no_audit_metadata(self) -> None:
         response = json.dumps({"intent": "noop", "assumptions": [], "actions": [], "notes": []})
@@ -1794,12 +1797,12 @@ class AskCliTest(unittest.TestCase):
                         yes=False,
                         explain=False,
                     )
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            self.assertNotIn("memory_injection_enabled", payload)
-            self.assertNotIn("memory_injected_count", payload)
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                self.assertNotIn("memory_injection_enabled", payload)
+                self.assertNotIn("memory_injected_count", payload)
 
     def test_ask_memory_injection_filters_and_orders(self) -> None:
         response = json.dumps({"intent": "noop", "assumptions": [], "actions": [], "notes": []})
@@ -1936,17 +1939,20 @@ class AskCliTest(unittest.TestCase):
             self.assertEqual([entry["key"] for entry in entries], ["beta", "alpha"])
             self.assertEqual(entries[0]["namespace"], "project:alpha")
             self.assertEqual(entries[1]["namespace"], "global")
-            state_store = StateStore(db_path)
-            event = state_store.list_events()[0]
-            payload = event.json_payload
-            assert payload is not None
-            self.assertTrue(payload["memory_injection_enabled"])
-            self.assertEqual(payload["memory_injected_count"], 2)
-            self.assertEqual(
-                payload["memory_injected_keys"],
-                [{"namespace": "project:alpha", "key": "beta"}, {"namespace": "global", "key": "alpha"}],
-            )
-            self.assertLessEqual(payload["memory_injected_bytes"], 8192)
+            with StateStore(db_path) as state_store:
+                event = state_store.list_events()[0]
+                payload = event.json_payload
+                assert payload is not None
+                self.assertTrue(payload["memory_injection_enabled"])
+                self.assertEqual(payload["memory_injected_count"], 2)
+                self.assertEqual(
+                    payload["memory_injected_keys"],
+                    [
+                        {"namespace": "project:alpha", "key": "beta"},
+                        {"namespace": "global", "key": "alpha"},
+                    ],
+                )
+                self.assertLessEqual(payload["memory_injected_bytes"], 8192)
             os.remove(db_path)
 
     def test_ask_memory_enforces_item_and_byte_caps(self) -> None:
@@ -2009,11 +2015,11 @@ class AskCliTest(unittest.TestCase):
             keys = [entry["key"] for entry in entries]
             self.assertLessEqual(len(entries), 20)
             self.assertEqual(keys, sorted(keys))
-            state_store = StateStore(db_path)
-            payload = state_store.list_events()[0].json_payload
-            assert payload is not None
-            self.assertLessEqual(payload["memory_injected_bytes"], 8192)
-            self.assertEqual(payload["memory_injected_count"], len(entries))
+            with StateStore(db_path) as state_store:
+                payload = state_store.list_events()[0].json_payload
+                assert payload is not None
+                self.assertLessEqual(payload["memory_injected_bytes"], 8192)
+                self.assertEqual(payload["memory_injected_count"], len(entries))
 
 
 if __name__ == "__main__":

--- a/tests/test_db_handle_guardrails.py
+++ b/tests/test_db_handle_guardrails.py
@@ -3,6 +3,7 @@ import gc
 import io
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -33,6 +34,15 @@ class DbHandleGuardrailsTest(unittest.TestCase):
             with contextlib.redirect_stdout(io.StringIO()):
                 with contextlib.redirect_stderr(io.StringIO()):
                     cli_main.main()
+
+    def _run_subprocess_cli(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+        return subprocess.run(
+            cmd,
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+        )
 
     def _run_ask(self, db_path: Path, args: list[str], response: str) -> None:
         env = {
@@ -176,6 +186,27 @@ class DbHandleGuardrailsTest(unittest.TestCase):
                     "--json",
                 ]
             )
+            gc.collect()
+            self._assert_db_deletable(db_path)
+
+    @unittest.skipUnless(sys.platform == "win32", "Windows-only handle release check")
+    def test_windows_memory_explain_subprocess_releases_db_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            with StateStore(str(db_path)) as state_store:
+                run = state_store.create_run(label="guardrail", metadata={})
+            result = self._run_subprocess_cli(
+                [
+                    "--db",
+                    str(db_path),
+                    "memory",
+                    "explain",
+                    "--run",
+                    run.id,
+                    "--json",
+                ]
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
             gc.collect()
             self._assert_db_deletable(db_path)
 

--- a/tests/test_memory_retention.py
+++ b/tests/test_memory_retention.py
@@ -48,24 +48,24 @@ class MemoryRetentionCliTest(unittest.TestCase):
         return row[0], json.loads(row[1])
 
     def _insert_item(self, namespace: str, key: str, created_at: str) -> None:
-        store = MemoryStore(str(self.db_path))
-        store.upsert_item_with_timestamps(
-            namespace=namespace,
-            key=key,
-            kind="note",
-            value=key,
-            tags=None,
-            confidence="low",
-            source="operator",
-            ttl_seconds=None,
-            is_tombstoned=False,
-            created_at=created_at,
-            updated_at=created_at,
-            update_created_at=True,
-            actor="operator",
-            policy_hash=policy_hash_for_path(None),
-            operation="put",
-        )
+        with MemoryStore(str(self.db_path)) as store:
+            store.upsert_item_with_timestamps(
+                namespace=namespace,
+                key=key,
+                kind="note",
+                value=key,
+                tags=None,
+                confidence="low",
+                source="operator",
+                ttl_seconds=None,
+                is_tombstoned=False,
+                created_at=created_at,
+                updated_at=created_at,
+                update_created_at=True,
+                actor="operator",
+                policy_hash=policy_hash_for_path(None),
+                operation="put",
+            )
 
     def test_retention_set_list_show_clear(self) -> None:
         policy_path = self._write_policy(
@@ -190,13 +190,13 @@ class MemoryRetentionCliTest(unittest.TestCase):
                 },
             }
         )
-        store = MemoryStore(str(self.db_path))
-        store.set_retention_rule(
-            namespace="global",
-            max_items=2,
-            ttl_seconds=None,
-            policy_source="operator",
-        )
+        with MemoryStore(str(self.db_path)) as store:
+            store.set_retention_rule(
+                namespace="global",
+                max_items=2,
+                ttl_seconds=None,
+                policy_source="operator",
+            )
         base = datetime(2024, 1, 1, tzinfo=timezone.utc)
         self._insert_item("global", "alpha", (base - timedelta(hours=2)).isoformat())
         self._insert_item("global", "beta", (base - timedelta(hours=1)).isoformat())
@@ -270,13 +270,13 @@ class MemoryRetentionCliTest(unittest.TestCase):
                 },
             }
         )
-        store = MemoryStore(str(self.db_path))
-        store.set_retention_rule(
-            namespace="global",
-            max_items=None,
-            ttl_seconds=3600,
-            policy_source="operator",
-        )
+        with MemoryStore(str(self.db_path)) as store:
+            store.set_retention_rule(
+                namespace="global",
+                max_items=None,
+                ttl_seconds=3600,
+                policy_source="operator",
+            )
         now = datetime.now(timezone.utc)
         self._insert_item("global", "oldest", (now - timedelta(hours=3)).isoformat())
         self._insert_item("global", "older", (now - timedelta(hours=2)).isoformat())
@@ -331,13 +331,13 @@ class MemoryRetentionCliTest(unittest.TestCase):
                 },
             }
         )
-        store = MemoryStore(str(self.db_path))
-        store.set_retention_rule(
-            namespace="global",
-            max_items=1,
-            ttl_seconds=None,
-            policy_source="operator",
-        )
+        with MemoryStore(str(self.db_path)) as store:
+            store.set_retention_rule(
+                namespace="global",
+                max_items=1,
+                ttl_seconds=None,
+                policy_source="operator",
+            )
         self._insert_item(
             "global",
             "seed",
@@ -398,13 +398,13 @@ class MemoryRetentionCliTest(unittest.TestCase):
                 },
             }
         )
-        store = MemoryStore(str(self.db_path))
-        store.set_retention_rule(
-            namespace="global",
-            max_items=1,
-            ttl_seconds=None,
-            policy_source="operator",
-        )
+        with MemoryStore(str(self.db_path)) as store:
+            store.set_retention_rule(
+                namespace="global",
+                max_items=1,
+                ttl_seconds=None,
+                policy_source="operator",
+            )
         self._insert_item(
             "global",
             "seed",


### PR DESCRIPTION
### Motivation

- Windows CI was failing when TemporaryDirectory cleanup tried to remove `state.db` due to lingering SQLite handles.  
- Tests that spawn the CLI or inspect DB files were leaving connections open or using non-deterministic cleanup.  
- The intent is to ensure every CLI path deterministically releases SQLite file handles so subprocess-based CLI tests can delete temp DB files on Windows.  
- Add a regression guardrail to catch regressions that would reintroduce handle leaks.

### Description

- Rewrote key test reads to use context-managed stores so connections are closed deterministically by replacing `StateStore(...)`/`MemoryStore(...)` uses with `with StateStore(...) as state_store:` or `with MemoryStore(...) as store:` in tests (`tests/test_ask_cli.py`, `tests/test_agent_cli.py`, `tests/test_memory_retention.py`).
- Added a subprocess helper and a Windows-only guardrail test `test_windows_memory_explain_subprocess_releases_db_handle` in `tests/test_db_handle_guardrails.py` that runs `memory explain` as a subprocess and asserts the DB file can be deleted after the CLI exits. 
- Added `with`-scoped changes to helper code in tests (e.g., seeding memory/retention rules) so no connections remain open after a test step. 
- Updated `Handoff.md` to document the SQLite handle guardrails and next steps for Windows verification.

### Testing

- Ran the repository verification script `python scripts/verify.py` which executed the full test suite and returned: Ran 223 tests in ~50s — OK (skipped=5).  
- The new Windows-only subprocess guardrail is gated with `@unittest.skipUnless(sys.platform == "win32")` so it runs only on Windows and is skipped elsewhere.  
- No automated tests failed in the verification run; the suite completed successfully.  
- To reproduce locally run `python scripts/verify.py` (or `pytest -q` / `python -m unittest discover -s tests -p "test*.py" -v`) and confirm no `PermissionError` occurs during tempdir cleanup on Windows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da59ebd3883308abdd031cec3326c)