### PR TITLE
Add Windows operator smoke scripts and daemon --once regression test

### DIFF
--- a/Handoff.md
+++ b/Handoff.md
@@ -156,12 +156,13 @@ INTENTIONAL LIMITATIONS (NOT BUGS)
 
 RECENT NOTABLE CHANGE (LATEST WORK)
 
-SQLite handle guardrails (Windows):
-- Converted CLI tests to use context-managed StateStore/MemoryStore access where they read back state.
-- Added a Windows-only subprocess guardrail test for memory explain handle release.
-- Reinforced expectations that DB handles are closed deterministically after CLI paths.
+Operator smoke scripts + handle guardrail:
+- Added Windows-friendly operator smoke scripts (operator + end-to-end enqueue→daemon→export).
+- Added a CLI subprocess regression test that runs daemon --once and asserts DB handles are released.
+- Documented smoke scripts as the recommended operator regression check.
 
 Next steps:
+- Run operator_smoke.ps1 and e2e_smoke.ps1 on Windows after CLI changes.
 - Validate ask/agent subprocess flows on Windows for handle hygiene at higher concurrency.
 - Monitor for any new audit/export paths that retain SQLite handles across CLI exits.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Install (from repo root):
 
 -------------------------------------------------------------------------------
 
+SMOKE SCRIPTS (WINDOWS)
+
+Windows-friendly operator smoke checks (no Ollama required):
+
+  powershell -ExecutionPolicy Bypass -File scripts/operator_smoke.ps1
+  powershell -ExecutionPolicy Bypass -File scripts/e2e_smoke.ps1
+
+Notes:
+- Scripts create a temp DB under %TEMP% and clean it up afterward.
+- `e2e_smoke.ps1` validates enqueue → daemon --once → export for the core operator loop.
+- `e2e_smoke.ps1 -EnableMemoryPreview` records and checks a memory injection trace event (no Ollama).
+
+-------------------------------------------------------------------------------
+
 CANONICAL INVOCATION
 
 Prefer:

--- a/docs/OPERATOR.md
+++ b/docs/OPERATOR.md
@@ -30,6 +30,23 @@ If installed in editable mode:
 
 -------------------------------------------------------------------------------
 
+OPERATOR SMOKE SCRIPTS (WINDOWS)
+
+Quick smoke checks (no Ollama required):
+
+  powershell -ExecutionPolicy Bypass -File scripts/operator_smoke.ps1
+  powershell -ExecutionPolicy Bypass -File scripts/e2e_smoke.ps1
+
+What they prove:
+- operator_smoke.ps1: basic operator run + export on a temp DB.
+- e2e_smoke.ps1: enqueue → daemon --once → export on a temp DB.
+
+Notes:
+- Scripts create temp state DBs under %TEMP% and clean them up on exit.
+- Use -EnableMemoryPreview on e2e_smoke.ps1 to record and verify a memory injection trace event.
+
+-------------------------------------------------------------------------------
+
 STATE & FILE LOCATIONS
 
 Default state database:

--- a/scripts/e2e_smoke.ps1
+++ b/scripts/e2e_smoke.ps1
@@ -1,0 +1,190 @@
+param(
+    [switch]$EnableMemoryPreview
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-GismoCli {
+    param(
+        [string[]]$Arguments
+    )
+
+    $output = & python -m gismo.cli.main @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $joined = ($output -join "`n")
+        throw "Command failed (exit=$exitCode): python -m gismo.cli.main $($Arguments -join ' ')`n$joined"
+    }
+    return $output
+}
+
+function Write-Ok {
+    param([string]$Message)
+    Write-Host "OK: $Message"
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$policyPath = Join-Path $repoRoot "policy" "dev-safe.json"
+$operatorPolicyPath = Join-Path $repoRoot "policy" "dev-operator.json"
+
+& python -c "import gismo" | Out-Null
+
+$tmp = Join-Path $env:TEMP ("gismo-e2e-" + [guid]::NewGuid().ToString())
+$db = Join-Path $tmp "state.db"
+
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+Write-Host "Using temp DB: $db"
+
+try {
+    Invoke-GismoCli @("--db", $db, "enqueue", "echo:smoke-e2e-ok") | Out-Null
+    Write-Ok "enqueue ok"
+
+    Invoke-GismoCli @("--db", $db, "daemon", "--policy", $policyPath, "--once") | Out-Null
+    Write-Ok "daemon once ok"
+
+    $statsOutput = Invoke-GismoCli @("--db", $db, "queue", "stats", "--json")
+    $statsJson = ($statsOutput -join "`n") | ConvertFrom-Json
+    $byStatus = $statsJson.by_status
+    if ($byStatus.QUEUED -ne 0 -or $byStatus.IN_PROGRESS -ne 0 -or $byStatus.FAILED -ne 0) {
+        throw "Queue not empty: QUEUED=$($byStatus.QUEUED) IN_PROGRESS=$($byStatus.IN_PROGRESS) FAILED=$($byStatus.FAILED)"
+    }
+    if ($byStatus.SUCCEEDED -lt 1) {
+        throw "Queue item did not succeed (SUCCEEDED=$($byStatus.SUCCEEDED))"
+    }
+    Write-Ok "queue stats ok"
+
+    $runsOutput = Invoke-GismoCli @("--db", $db, "runs", "list", "--limit", "1")
+    $runsLine = $runsOutput | Where-Object { $_ -match "^Runs:" }
+    if (-not $runsLine) {
+        throw "Runs list did not include summary line"
+    }
+    if ($runsLine -notmatch "Runs:\s+(\d+)") {
+        throw "Runs list summary parse failed: $runsLine"
+    }
+    $runsCount = [int]$Matches[1]
+    if ($runsCount -lt 1) {
+        throw "No runs recorded"
+    }
+    Write-Ok "runs list ok"
+
+    if ($EnableMemoryPreview) {
+        if (-not (Test-Path $operatorPolicyPath)) {
+            throw "Operator policy not found: $operatorPolicyPath"
+        }
+        Invoke-GismoCli @(
+            "--db",
+            $db,
+            "memory",
+            "profile",
+            "create",
+            "--name",
+            "smoke-e2e",
+            "--description",
+            "Smoke e2e profile",
+            "--include-namespace",
+            "run:*",
+            "--include-kind",
+            "note",
+            "--max-items",
+            "5",
+            "--policy",
+            $operatorPolicyPath,
+            "--yes"
+        ) | Out-Null
+        Invoke-GismoCli @(
+            "--db",
+            $db,
+            "memory",
+            "put",
+            "--namespace",
+            "run:smoke",
+            "--key",
+            "seed",
+            "--kind",
+            "note",
+            "--value-text",
+            "smoke",
+            "--confidence",
+            "high",
+            "--source",
+            "operator",
+            "--policy",
+            $policyPath,
+            "--yes"
+        ) | Out-Null
+        $previewOutput = Invoke-GismoCli @(
+            "--db",
+            $db,
+            "memory",
+            "preview",
+            "--memory-profile",
+            "smoke-e2e",
+            "--policy",
+            $operatorPolicyPath,
+            "--json"
+        )
+        $previewPath = Join-Path $tmp "memory_preview.json"
+        ($previewOutput -join "`n") | Set-Content -Path $previewPath -Encoding utf8
+
+        $runId = & python -c "from gismo.core.state import StateStore; s=StateStore(r'$db'); run=s.get_latest_run(); print(run.id if run else ''); s.close()"
+        if (-not $runId) {
+            throw "Unable to resolve latest run id for memory preview"
+        }
+        $recordScript = @'
+import json
+import sys
+from gismo.memory.store import record_event, policy_hash_for_path
+
+preview_path = sys.argv[1]
+run_id = sys.argv[2]
+db_path = sys.argv[3]
+policy_path = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] else None
+
+with open(preview_path, "r", encoding="utf-8") as handle:
+    preview = json.load(handle)
+
+record_event(
+    db_path,
+    operation="memory.inject",
+    actor="operator_smoke",
+    policy_hash=policy_hash_for_path(policy_path),
+    request={"source": preview.get("source"), "profile": preview.get("profile")},
+    result_meta=preview,
+    related_run_id=run_id,
+)
+print(run_id)
+'@
+        & python -c $recordScript $previewPath $runId $db $operatorPolicyPath | Out-Null
+        Write-Ok "memory preview trace recorded"
+    }
+
+    $exportOutput = Invoke-GismoCli @("--db", $db, "export", "--latest", "--policy", $policyPath)
+    $exportLine = $exportOutput | Where-Object { $_ -match "^Exported run audit to" }
+    if (-not $exportLine) {
+        throw "Export output missing path"
+    }
+    if ($exportLine -notmatch "Exported run audit to\s+(.+)$") {
+        throw "Export path parse failed: $exportLine"
+    }
+    $exportPath = $Matches[1].Trim()
+    if (-not (Test-Path $exportPath)) {
+        throw "Export file not found: $exportPath"
+    }
+    Write-Host "Export path: $exportPath"
+    if ($EnableMemoryPreview) {
+        $memoryEvent = Get-Content $exportPath | Where-Object { $_ -match '"record_type"\s*:\s*"memory_event"' -and $_ -match '"operation"\s*:\s*"memory.inject"' }
+        if (-not $memoryEvent) {
+            throw "Export did not include memory.inject event"
+        }
+        Write-Ok "memory inject event present"
+    }
+
+    Write-Ok "e2e smoke passed"
+} finally {
+    try {
+        Remove-Item -Path $tmp -Recurse -Force -ErrorAction Stop
+    } catch {
+        throw "Failed to clean up temp directory (possible locked DB): $tmp - $($_.Exception.Message)"
+    }
+}

--- a/scripts/operator_smoke.ps1
+++ b/scripts/operator_smoke.ps1
@@ -1,0 +1,59 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Invoke-GismoCli {
+    param(
+        [string[]]$Arguments
+    )
+
+    $output = & python -m gismo.cli.main @Arguments 2>&1
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        $joined = ($output -join "`n")
+        throw "Command failed (exit=$exitCode): python -m gismo.cli.main $($Arguments -join ' ')`n$joined"
+    }
+    return $output
+}
+
+function Write-Ok {
+    param([string]$Message)
+    Write-Host "OK: $Message"
+}
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$policyPath = Join-Path $repoRoot "policy" "dev-safe.json"
+
+& python -c "import gismo" | Out-Null
+
+$tmp = Join-Path $env:TEMP ("gismo-operator-" + [guid]::NewGuid().ToString())
+$db = Join-Path $tmp "state.db"
+
+New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+Write-Host "Using temp DB: $db"
+
+try {
+    Invoke-GismoCli @("--db", $db, "run", "echo:operator-smoke-ok", "--policy", $policyPath) | Out-Null
+    Write-Ok "run ok"
+
+    $exportOutput = Invoke-GismoCli @("--db", $db, "export", "--latest", "--policy", $policyPath)
+    $exportLine = $exportOutput | Where-Object { $_ -match "^Exported run audit to" }
+    if (-not $exportLine) {
+        throw "Export output missing path"
+    }
+    if ($exportLine -notmatch "Exported run audit to\s+(.+)$") {
+        throw "Export path parse failed: $exportLine"
+    }
+    $exportPath = $Matches[1].Trim()
+    if (-not (Test-Path $exportPath)) {
+        throw "Export file not found: $exportPath"
+    }
+    Write-Host "Export path: $exportPath"
+
+    Write-Ok "operator smoke passed"
+} finally {
+    try {
+        Remove-Item -Path $tmp -Recurse -Force -ErrorAction Stop
+    } catch {
+        throw "Failed to clean up temp directory (possible locked DB): $tmp - $($_.Exception.Message)"
+    }
+}

--- a/tests/test_e2e_smoke_cli.py
+++ b/tests/test_e2e_smoke_cli.py
@@ -1,0 +1,58 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from gismo.core.models import QueueStatus
+from gismo.core.state import StateStore
+
+
+class E2ESmokeCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.policy_path = self.repo_root / "policy" / "dev-safe.json"
+
+    def _run_cli(self, args: list[str]) -> None:
+        cmd = [sys.executable, "-m", "gismo.cli.main", *args]
+        result = subprocess.run(
+            cmd,
+            cwd=str(self.repo_root),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            message = (
+                "CLI command failed: "
+                f"{' '.join(cmd)}\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+            )
+            self.fail(message)
+
+    def test_daemon_once_releases_db_handle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "state.db"
+            self._run_cli(["--db", str(db_path), "enqueue", "echo:smoke-e2e-ok"])
+            self._run_cli(
+                [
+                    "--db",
+                    str(db_path),
+                    "daemon",
+                    "--policy",
+                    str(self.policy_path),
+                    "--once",
+                ]
+            )
+            with StateStore(str(db_path)) as state_store:
+                queued = state_store.list_queue_items_by_status(QueueStatus.QUEUED)
+                in_progress = state_store.list_queue_items_by_status(QueueStatus.IN_PROGRESS)
+                failed = state_store.list_queue_items_by_status(QueueStatus.FAILED)
+                self.assertFalse(queued)
+                self.assertFalse(in_progress)
+                self.assertFalse(failed)
+                self.assertIsNotNone(state_store.get_latest_run())
+            try:
+                os.remove(db_path)
+            except OSError as exc:
+                self.fail(f"Expected DB path to be deletable, got error: {exc}")
+            self.assertFalse(db_path.exists())


### PR DESCRIPTION
### Motivation

- Provide a fast, deterministic Windows-first smoke check that validates the core operator loop (enqueue → daemon → export) on a fresh temp DB.
- Detect and prevent SQLite handle leaks on CLI paths by ensuring the daemon can run once and exit cleanly so DB files can be deleted.
- Make an operator-friendly regression check available and document how to run it for maintainers and operators.

### Description

- Added `scripts/e2e_smoke.ps1`, a PowerShell end-to-end smoke script that enqueues an `echo:` command, runs `gismo daemon --once`, exports the latest run, optionally records a memory injection trace with `-EnableMemoryPreview`, and cleans up the temp DB.
- Added `scripts/operator_smoke.ps1`, a PowerShell smoke script that runs a simple operator `run` followed by `export --latest` against a temp DB and then cleans up.
- Added `tests/test_e2e_smoke_cli.py`, a unittest that enqueues an item, invokes `daemon --once`, asserts the queue is empty and a run exists, and verifies the SQLite DB file is deletable (guard against leaked handles).
- Updated `README.md`, `docs/OPERATOR.md`, and `Handoff.md` to document the new smoke scripts and recommended operator checks.

### Testing

- Ran `python scripts/verify.py`, which executes the full test suite, and it completed successfully (Ran 224 tests, OK).
- The newly added `tests/test_e2e_smoke_cli.py` passed as part of the verification run.
- Recommended manual checks are `powershell -ExecutionPolicy Bypass -File scripts/operator_smoke.ps1` and `powershell -ExecutionPolicy Bypass -File scripts/e2e_smoke.ps1`, and `e2e_smoke.ps1 -EnableMemoryPreview` to verify memory injection traces.
- No automated tests failed in the verification run; all added and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db11447ec83309e91752547ba3854)